### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Build
+        run: go build -v ./...
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Run unit tests
+        run: go test -v ./internal/... ./pkg/...
+
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Install tmux
+        run: sudo apt-get update && sudo apt-get install -y tmux
+
+      - name: Configure git
+        run: |
+          git config --global user.email "ci@github.com"
+          git config --global user.name "GitHub CI"
+
+      - name: Run e2e tests
+        run: go test -v ./test/...


### PR DESCRIPTION
## Summary
- Implements CI workflow as described in issue #1
- Creates `.github/workflows/ci.yml` with three parallel jobs:
  - **Build**: Compiles the Go project to verify it builds successfully
  - **Unit Tests**: Runs `go test -v ./internal/... ./pkg/...`
  - **E2E Tests**: Installs tmux, configures git, and runs `go test -v ./test/...`

## Implementation Details
- Uses latest GitHub Actions versions:
  - `actions/checkout@v4`
  - `actions/setup-go@v5`
- Go version: 1.25 (compatible with go.mod requirement of 1.25.1)
- Go module caching enabled via `cache: true` in setup-go
- Triggers on push to main and pull requests to main
- E2E tests install tmux and configure git globally for CI environment

## Test plan
- [x] Verified workflow YAML syntax is valid
- [x] Confirmed local build passes with `go build -v ./...`
- [x] Confirmed unit tests pass locally with `go test -v ./internal/... ./pkg/...`
- [ ] CI workflow will validate when PR is created

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)