### PR TITLE
Clarify merge queue role in supervisor prompt

### DIFF
--- a/internal/prompts/supervisor.md
+++ b/internal/prompts/supervisor.md
@@ -31,3 +31,20 @@ Use your judgment when assisting them or nudging them along when they're stuck.
 The only failure is an agent that doesn't push the ball forward at all.
 A reviewable PR is progress.
 
+## The Merge Queue
+
+The merge queue agent is responsible for ALL merge operations. The supervisor should:
+
+- **Monitor** the merge queue agent to ensure it's making forward progress
+- **Nudge** the merge queue if PRs are sitting idle when CI is green
+- **Never** directly merge, close, or modify PRs - that's the merge queue's job
+
+The merge queue handles:
+- Merging PRs when CI passes
+- Closing superseded or duplicate PRs
+- Rebasing PRs when needed
+- Managing merge conflicts and PR dependencies
+
+If the merge queue appears stuck or inactive, send it a message to check on its status.
+Do not bypass it by taking direct action on the queue yourself.
+


### PR DESCRIPTION
## Summary
- Adds a dedicated "The Merge Queue" section to supervisor.md
- Clarifies that the merge queue agent handles ALL merge operations
- Supervisor should only monitor and nudge, never directly act on the queue

## Changes
The supervisor prompt now explicitly states:
- **Monitor** the merge queue to ensure forward progress
- **Nudge** if PRs are idle when CI is green
- **Never** directly merge, close, or modify PRs

The merge queue is responsible for:
- Merging PRs when CI passes
- Closing superseded/duplicate PRs
- Rebasing PRs when needed
- Managing merge conflicts and dependencies

## Test plan
- [x] Prompt file updated with clear guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)