### PR TITLE
Add default workspace for each project

### DIFF
--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -14,6 +14,7 @@ const (
 	TypeSupervisor AgentType = "supervisor"
 	TypeWorker     AgentType = "worker"
 	TypeMergeQueue AgentType = "merge-queue"
+	TypeWorkspace  AgentType = "workspace"
 )
 
 // Embedded default prompts
@@ -26,6 +27,9 @@ var defaultWorkerPrompt string
 //go:embed merge-queue.md
 var defaultMergeQueuePrompt string
 
+//go:embed workspace.md
+var defaultWorkspacePrompt string
+
 // GetDefaultPrompt returns the default prompt for the given agent type
 func GetDefaultPrompt(agentType AgentType) string {
 	switch agentType {
@@ -35,6 +39,8 @@ func GetDefaultPrompt(agentType AgentType) string {
 		return defaultWorkerPrompt
 	case TypeMergeQueue:
 		return defaultMergeQueuePrompt
+	case TypeWorkspace:
+		return defaultWorkspacePrompt
 	default:
 		return ""
 	}
@@ -51,6 +57,8 @@ func LoadCustomPrompt(repoPath string, agentType AgentType) (string, error) {
 		filename = "WORKER.md"
 	case TypeMergeQueue:
 		filename = "REVIEWER.md"
+	case TypeWorkspace:
+		filename = "WORKSPACE.md"
 	default:
 		return "", fmt.Errorf("unknown agent type: %s", agentType)
 	}

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -16,6 +16,7 @@ func TestGetDefaultPrompt(t *testing.T) {
 		{"supervisor", TypeSupervisor, false},
 		{"worker", TypeWorker, false},
 		{"merge-queue", TypeMergeQueue, false},
+		{"workspace", TypeWorkspace, false},
 		{"unknown", AgentType("unknown"), true},
 	}
 
@@ -58,6 +59,15 @@ func TestGetDefaultPromptContent(t *testing.T) {
 	}
 	if !strings.Contains(mergePrompt, "CRITICAL CONSTRAINT") {
 		t.Error("merge queue prompt should have critical constraint about CI")
+	}
+
+	// Verify workspace prompt
+	workspacePrompt := GetDefaultPrompt(TypeWorkspace)
+	if !strings.Contains(workspacePrompt, "user workspace") {
+		t.Error("workspace prompt should mention 'user workspace'")
+	}
+	if !strings.Contains(workspacePrompt, "NOT receive messages from the supervisor") {
+		t.Error("workspace prompt should clarify that it doesn't receive supervisor messages")
 	}
 }
 
@@ -125,6 +135,22 @@ func TestLoadCustomPrompt(t *testing.T) {
 		}
 
 		prompt, err := LoadCustomPrompt(tmpDir, TypeMergeQueue)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if prompt != customContent {
+			t.Errorf("expected %q, got %q", customContent, prompt)
+		}
+	})
+
+	t.Run("with custom workspace prompt", func(t *testing.T) {
+		customContent := "Custom workspace instructions"
+		promptPath := filepath.Join(multiclaudeDir, "WORKSPACE.md")
+		if err := os.WriteFile(promptPath, []byte(customContent), 0644); err != nil {
+			t.Fatalf("failed to write custom prompt: %v", err)
+		}
+
+		prompt, err := LoadCustomPrompt(tmpDir, TypeWorkspace)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/internal/prompts/workspace.md
+++ b/internal/prompts/workspace.md
@@ -1,0 +1,34 @@
+You are a user workspace - a dedicated Claude Code session for the user to interact with directly.
+
+This workspace is your personal coding environment within the multiclaude system. Unlike worker agents who handle assigned tasks, you're here to help the user with whatever they need.
+
+## Your Role
+
+- Help the user with coding tasks, debugging, and exploration
+- You have your own worktree, so changes you make won't conflict with other agents
+- You can work on any branch the user chooses
+- You persist across sessions - your conversation history is preserved
+
+## What You Can Do
+
+- Explore and understand the codebase
+- Make changes and commit them
+- Create branches and PRs
+- Run tests and builds
+- Answer questions about the code
+
+## Important Notes
+
+- You do NOT receive messages from the supervisor or other agents
+- You are NOT part of the automated task assignment system
+- You work directly with the user on whatever they need
+
+## Git Workflow
+
+Your worktree starts on the main branch. You can:
+- Create new branches for your work
+- Switch branches as needed
+- Commit and push changes
+- Create PRs when ready
+
+This is your space to experiment and work freely with the user.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -15,6 +15,7 @@ const (
 	AgentTypeSupervisor AgentType = "supervisor"
 	AgentTypeWorker     AgentType = "worker"
 	AgentTypeMergeQueue AgentType = "merge-queue"
+	AgentTypeWorkspace  AgentType = "workspace"
 )
 
 // Agent represents an agent's state


### PR DESCRIPTION
## Summary
- Implements issue #3: Auto-create a dedicated user workspace after `multiclaude init`
- Workspace has its own worktree and tmux window running Claude Code
- Tracked in state.json alongside workers
- Users can attach with: `multiclaude attach workspace`

## Test plan
- [ ] Run `go test ./...` to verify all tests pass
- [ ] Run `multiclaude init <repo>` and verify workspace is created
- [ ] Verify `multiclaude work list` shows workspace
- [ ] Verify `multiclaude attach workspace` works
- [ ] Verify workspace doesn't receive supervisor messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)