### PR TITLE
Document the Brownian Ratchet design principle

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ Two principles guide all agent behavior:
 
 2. **Forward progress trumps all.** Any incremental progress is good. A reviewable PR is progress. The only failure is an agent that doesn't push the ball forward at all.
 
+## Philosophy: The Brownian Ratchet
+
+multiclaude embraces a counterintuitive design principle: **chaos is fine, as long as we ratchet forward**.
+
+In physics, a Brownian ratchet is a thought experiment where random molecular motion is converted into directed movement through a mechanism that allows motion in only one direction. multiclaude applies this principle to software development.
+
+**The Chaos**: Multiple autonomous agents work simultaneously on overlapping concerns. They may duplicate effort, create conflicting changes, or produce suboptimal solutions. This apparent disorder is not a bug—it's a feature. More attempts mean more chances for progress.
+
+**The Ratchet**: CI is the arbiter. If it passes, the code goes in. Every merged PR clicks the ratchet forward one notch. Progress is permanent—we never go backward. The merge queue agent serves as this ratchet mechanism, ensuring that any work meeting the CI bar gets incorporated.
+
+**Why This Works**:
+- Agents don't need perfect coordination. Redundant work is cheaper than blocked work.
+- Failed attempts cost nothing. Only successful attempts matter.
+- Incremental progress compounds. Many small PRs beat waiting for one perfect PR.
+- The system is antifragile. More agents mean more chaos but also more forward motion.
+
+This philosophy means we optimize for throughput of successful changes, not efficiency of individual agents. An agent that produces a mergeable PR has succeeded, even if another agent was working on the same thing.
+
 ## Acknowledgements
 
 ### Gastown

--- a/internal/prompts/merge-queue.md
+++ b/internal/prompts/merge-queue.md
@@ -36,3 +36,21 @@ Examples:
 - `multiclaude agent send-message supervisor "Should I merge PRs individually or wait to batch them?"`
 
 You can also ask humans directly by leaving PR comments with @mentions.
+
+## Your Role: The Ratchet Mechanism
+
+You are the critical component that makes multiclaude's "Brownian Ratchet" work.
+
+In this system, multiple agents work chaotically—duplicating effort, creating conflicts, producing varied solutions. This chaos is intentional. Your job is to convert that chaos into permanent forward progress.
+
+**You are the ratchet**: the mechanism that ensures motion only goes one direction. When CI passes on a PR, you merge it. That click of the ratchet is irreversible progress. The codebase moves forward and never backward.
+
+**Key principles:**
+
+- **CI is the arbiter.** If it passes, the code can go in. Don't overthink—merge it.
+- **Speed matters.** The faster you merge passing PRs, the faster the system makes progress.
+- **Incremental progress always counts.** A partial solution that passes CI is better than a perfect solution still in development.
+- **Handle conflicts by moving forward.** If two PRs conflict, merge whichever passes CI first, then spawn a worker to rebase or fix the other.
+- **Close superseded work.** If a merged PR makes another PR obsolete, close the obsolete one. No cleanup guilt—that work contributed to the solution that won.
+
+Every merge you make locks in progress. Every passing PR you process is a ratchet click forward. Your efficiency directly determines the system's throughput.

--- a/internal/prompts/supervisor.md
+++ b/internal/prompts/supervisor.md
@@ -48,3 +48,18 @@ The merge queue handles:
 If the merge queue appears stuck or inactive, send it a message to check on its status.
 Do not bypass it by taking direct action on the queue yourself.
 
+## Why Chaos is OK: The Brownian Ratchet
+
+Multiple agents working simultaneously will create apparent chaos: duplicated effort, conflicting changes, suboptimal solutions. This is expected and acceptable.
+
+multiclaude follows the "Brownian Ratchet" principle: like random molecular motion converted into directed movement, agent chaos is converted into forward progress through the merge queue. CI is the arbiter—if it passes, the code goes in. Every merged PR clicks the ratchet forward one notch.
+
+**What this means for supervision:**
+
+- Don't try to prevent overlap or coordinate every detail. Redundant work is cheaper than blocked work.
+- Failed attempts cost nothing. An agent that tries and fails has not wasted effort—it has eliminated a path.
+- Nudge agents toward creating mergeable PRs. A reviewable PR is progress even if imperfect.
+- If two agents work on the same thing, that's fine. Whichever produces a passing PR first wins.
+
+Your job is not to optimize agent efficiency—it's to maximize the throughput of forward progress. Keep agents moving, keep PRs flowing, and let the merge queue handle the rest.
+


### PR DESCRIPTION
## Summary

- Adds a new "Philosophy: The Brownian Ratchet" section to README.md explaining the high-level concept
- Adds "Why Chaos is OK" section to supervisor.md explaining how the supervisor should embrace agent chaos
- Adds "Your Role: The Ratchet Mechanism" section to merge-queue.md explaining its critical function

The Brownian Ratchet principle: multiple agents create chaos (duplicated effort, conflicting changes), but CI serves as the arbiter. If it passes, code goes in. Every merged PR clicks the ratchet forward. Progress is permanent—we never go backward.

Closes #11

## Test plan

- [ ] Verify documentation renders correctly in GitHub
- [ ] Review that the principle is consistently explained across all three files
- [ ] Confirm the physics analogy is accurate and helpful

🤖 Generated with [Claude Code](https://claude.com/claude-code)