### PR TITLE
Add debugging docs for ~/.multiclaude directory structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,31 @@ jobs:
 
       - name: Run e2e tests
         run: go test -v ./test/...
+
+  verify-generated-docs:
+    name: Verify Generated Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Regenerate docs
+        run: go generate ./pkg/config/...
+
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --quiet docs/DIRECTORY_STRUCTURE.md; then
+            echo "Error: docs/DIRECTORY_STRUCTURE.md is out of date!"
+            echo "Run 'go generate ./pkg/config/...' and commit the changes."
+            echo ""
+            echo "Diff:"
+            git diff docs/DIRECTORY_STRUCTURE.md
+            exit 1
+          fi
+          echo "Generated docs are up to date."

--- a/cmd/generate-docs/main.go
+++ b/cmd/generate-docs/main.go
@@ -1,0 +1,238 @@
+// Command generate-docs generates documentation from code constants.
+// This ensures documentation stays in sync with the actual implementation.
+//
+// Usage:
+//
+//	go run ./cmd/generate-docs
+//	go generate ./pkg/config/...
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dlorenc/multiclaude/pkg/config"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	content := generateDirectoryStructure()
+
+	// Determine output path
+	outPath := "docs/DIRECTORY_STRUCTURE.md"
+	if len(os.Args) > 1 {
+		outPath = os.Args[1]
+	}
+
+	// If path is relative, make it relative to the project root (where go.mod is)
+	if !filepath.IsAbs(outPath) {
+		root, err := findProjectRoot()
+		if err != nil {
+			return fmt.Errorf("failed to find project root: %w", err)
+		}
+		outPath = filepath.Join(root, outPath)
+	}
+
+	// Ensure directory exists
+	if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Write the file
+	if err := os.WriteFile(outPath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	fmt.Printf("Generated %s\n", outPath)
+	return nil
+}
+
+// findProjectRoot walks up the directory tree to find go.mod
+func findProjectRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found")
+		}
+		dir = parent
+	}
+}
+
+func generateDirectoryStructure() string {
+	var buf bytes.Buffer
+
+	// Header
+	buf.WriteString("# Multiclaude Directory Structure\n\n")
+	buf.WriteString("This document describes the directory structure used by multiclaude in `~/.multiclaude/`.\n")
+	buf.WriteString("It is intended to help with debugging and understanding how multiclaude organizes its data.\n\n")
+	buf.WriteString("> **Note**: This file is auto-generated from code constants in `pkg/config/doc.go`.\n")
+	buf.WriteString("> Do not edit manually. Run `go generate ./pkg/config/...` to regenerate.\n\n")
+
+	// Directory layout
+	buf.WriteString("## Directory Layout\n\n")
+	buf.WriteString("```\n")
+	buf.WriteString("~/.multiclaude/\n")
+	buf.WriteString("├── daemon.pid          # Daemon process ID\n")
+	buf.WriteString("├── daemon.sock         # Unix socket for CLI communication\n")
+	buf.WriteString("├── daemon.log          # Daemon activity log\n")
+	buf.WriteString("├── state.json          # Persistent daemon state\n")
+	buf.WriteString("│\n")
+	buf.WriteString("├── repos/              # Cloned repositories\n")
+	buf.WriteString("│   └── <repo-name>/    # Git clone of tracked repo\n")
+	buf.WriteString("│\n")
+	buf.WriteString("├── wts/                # Git worktrees\n")
+	buf.WriteString("│   └── <repo-name>/\n")
+	buf.WriteString("│       ├── supervisor/     # Supervisor's worktree\n")
+	buf.WriteString("│       ├── merge-queue/    # Merge queue's worktree\n")
+	buf.WriteString("│       └── <worker-name>/  # Worker worktrees\n")
+	buf.WriteString("│\n")
+	buf.WriteString("├── messages/           # Inter-agent messages\n")
+	buf.WriteString("│   └── <repo-name>/\n")
+	buf.WriteString("│       └── <agent-name>/\n")
+	buf.WriteString("│           └── msg-<uuid>.json\n")
+	buf.WriteString("│\n")
+	buf.WriteString("└── prompts/            # Generated agent prompts\n")
+	buf.WriteString("    └── <agent-name>.md\n")
+	buf.WriteString("```\n\n")
+
+	// Generate detailed descriptions
+	docs := config.DirectoryDocs()
+	buf.WriteString("## Path Descriptions\n\n")
+	for _, doc := range docs {
+		typeEmoji := "📄"
+		if doc.Type == "directory" {
+			typeEmoji = "📁"
+		}
+		buf.WriteString(fmt.Sprintf("### %s `%s`\n\n", typeEmoji, doc.Path))
+		buf.WriteString(fmt.Sprintf("**Type**: %s\n\n", doc.Type))
+		buf.WriteString(fmt.Sprintf("%s\n\n", doc.Description))
+		if doc.Notes != "" {
+			buf.WriteString(fmt.Sprintf("**Notes**: %s\n\n", doc.Notes))
+		}
+	}
+
+	// Generate state.json documentation
+	buf.WriteString("## state.json Format\n\n")
+	buf.WriteString("The `state.json` file contains the daemon's persistent state. It is written atomically\n")
+	buf.WriteString("(write to temp file, then rename) to prevent corruption.\n\n")
+	buf.WriteString("### Schema\n\n")
+	buf.WriteString("```json\n")
+	buf.WriteString(`{
+  "repos": {
+    "<repo-name>": {
+      "github_url": "https://github.com/owner/repo",
+      "tmux_session": "multiclaude-repo",
+      "agents": {
+        "<agent-name>": {
+          "type": "supervisor|worker|merge-queue|workspace",
+          "worktree_path": "/path/to/worktree",
+          "tmux_window": "window-name",
+          "session_id": "uuid",
+          "pid": 12345,
+          "task": "task description (workers only)",
+          "created_at": "2025-01-01T00:00:00Z",
+          "last_nudge": "2025-01-01T00:00:00Z",
+          "ready_for_cleanup": false
+        }
+      }
+    }
+  }
+}
+`)
+	buf.WriteString("```\n\n")
+
+	buf.WriteString("### Field Reference\n\n")
+	buf.WriteString("| Field | Type | Description |\n")
+	buf.WriteString("|-------|------|-------------|\n")
+	for _, doc := range config.StateDocs() {
+		buf.WriteString(fmt.Sprintf("| `%s` | `%s` | %s |\n", doc.Field, doc.Type, doc.Description))
+	}
+	buf.WriteString("\n")
+
+	// Generate message file documentation
+	buf.WriteString("## Message File Format\n\n")
+	buf.WriteString("Message files are stored in `messages/<repo>/<agent>/msg-<uuid>.json`.\n")
+	buf.WriteString("They are used for inter-agent communication.\n\n")
+	buf.WriteString("### Schema\n\n")
+	buf.WriteString("```json\n")
+	buf.WriteString(`{
+  "id": "msg-abc123def456",
+  "from": "supervisor",
+  "to": "happy-platypus",
+  "timestamp": "2025-01-01T00:00:00Z",
+  "body": "Please review PR #42",
+  "status": "pending",
+  "acked_at": null
+}
+`)
+	buf.WriteString("```\n\n")
+
+	buf.WriteString("### Field Reference\n\n")
+	buf.WriteString("| Field | Type | Description |\n")
+	buf.WriteString("|-------|------|-------------|\n")
+	for _, doc := range config.MessageDocs() {
+		buf.WriteString(fmt.Sprintf("| `%s` | `%s` | %s |\n", doc.Field, doc.Type, doc.Description))
+	}
+	buf.WriteString("\n")
+
+	// Add debugging tips section
+	buf.WriteString("## Debugging Tips\n\n")
+	buf.WriteString("### Check daemon status\n\n")
+	buf.WriteString("```bash\n")
+	buf.WriteString("# Is the daemon running?\n")
+	buf.WriteString("cat ~/.multiclaude/daemon.pid && ps -p $(cat ~/.multiclaude/daemon.pid)\n\n")
+	buf.WriteString("# View daemon logs\n")
+	buf.WriteString("tail -f ~/.multiclaude/daemon.log\n")
+	buf.WriteString("```\n\n")
+
+	buf.WriteString("### Inspect state\n\n")
+	buf.WriteString("```bash\n")
+	buf.WriteString("# Pretty-print current state\n")
+	buf.WriteString("cat ~/.multiclaude/state.json | jq .\n\n")
+	buf.WriteString("# List all agents for a repo\n")
+	buf.WriteString("cat ~/.multiclaude/state.json | jq '.repos[\"my-repo\"].agents | keys'\n")
+	buf.WriteString("```\n\n")
+
+	buf.WriteString("### Check agent worktrees\n\n")
+	buf.WriteString("```bash\n")
+	buf.WriteString("# List all worktrees for a repo\n")
+	buf.WriteString("ls ~/.multiclaude/wts/my-repo/\n\n")
+	buf.WriteString("# Check git status in an agent's worktree\n")
+	buf.WriteString("git -C ~/.multiclaude/wts/my-repo/supervisor status\n")
+	buf.WriteString("```\n\n")
+
+	buf.WriteString("### View messages\n\n")
+	buf.WriteString("```bash\n")
+	buf.WriteString("# List all messages for an agent\n")
+	buf.WriteString("ls ~/.multiclaude/messages/my-repo/supervisor/\n\n")
+	buf.WriteString("# Read a specific message\n")
+	buf.WriteString("cat ~/.multiclaude/messages/my-repo/supervisor/msg-*.json | jq .\n")
+	buf.WriteString("```\n\n")
+
+	buf.WriteString("### Clean up stale state\n\n")
+	buf.WriteString("```bash\n")
+	buf.WriteString("# Use the built-in repair command\n")
+	buf.WriteString("multiclaude repair\n\n")
+	buf.WriteString("# Or manually clean up orphaned resources\n")
+	buf.WriteString("multiclaude cleanup\n")
+	buf.WriteString("```\n")
+
+	return buf.String()
+}

--- a/docs/DIRECTORY_STRUCTURE.md
+++ b/docs/DIRECTORY_STRUCTURE.md
@@ -1,0 +1,272 @@
+# Multiclaude Directory Structure
+
+This document describes the directory structure used by multiclaude in `~/.multiclaude/`.
+It is intended to help with debugging and understanding how multiclaude organizes its data.
+
+> **Note**: This file is auto-generated from code constants in `pkg/config/doc.go`.
+> Do not edit manually. Run `go generate ./pkg/config/...` to regenerate.
+
+## Directory Layout
+
+```
+~/.multiclaude/
+├── daemon.pid          # Daemon process ID
+├── daemon.sock         # Unix socket for CLI communication
+├── daemon.log          # Daemon activity log
+├── state.json          # Persistent daemon state
+│
+├── repos/              # Cloned repositories
+│   └── <repo-name>/    # Git clone of tracked repo
+│
+├── wts/                # Git worktrees
+│   └── <repo-name>/
+│       ├── supervisor/     # Supervisor's worktree
+│       ├── merge-queue/    # Merge queue's worktree
+│       └── <worker-name>/  # Worker worktrees
+│
+├── messages/           # Inter-agent messages
+│   └── <repo-name>/
+│       └── <agent-name>/
+│           └── msg-<uuid>.json
+│
+└── prompts/            # Generated agent prompts
+    └── <agent-name>.md
+```
+
+## Path Descriptions
+
+### 📄 `daemon.pid`
+
+**Type**: file
+
+Contains the process ID of the running multiclaude daemon
+
+**Notes**: Text file with a single integer. Deleted on clean daemon shutdown.
+
+### 📄 `daemon.sock`
+
+**Type**: file
+
+Unix domain socket for CLI-to-daemon communication
+
+**Notes**: Created with mode 0600 for security. The CLI connects here to send commands.
+
+### 📄 `daemon.log`
+
+**Type**: file
+
+Append-only log of daemon activity
+
+**Notes**: Useful for debugging daemon issues. Check this when agents behave unexpectedly.
+
+### 📄 `state.json`
+
+**Type**: file
+
+Central state file containing all tracked repositories and agents
+
+**Notes**: Written atomically via temp file + rename. See StateDoc() for format details.
+
+### 📁 `repos/`
+
+**Type**: directory
+
+Contains cloned git repositories (bare or working)
+
+**Notes**: Each repository is stored in repos/<repo-name>/
+
+### 📁 `repos/<repo-name>/`
+
+**Type**: directory
+
+A cloned git repository
+
+**Notes**: Full git clone of the tracked repository.
+
+### 📁 `wts/`
+
+**Type**: directory
+
+Git worktrees for isolated agent working directories
+
+**Notes**: Each agent gets its own worktree to work independently.
+
+### 📁 `wts/<repo-name>/`
+
+**Type**: directory
+
+Worktrees directory for a specific repository
+
+**Notes**: Contains subdirectories for each agent working on this repo.
+
+### 📁 `wts/<repo-name>/<agent-name>/`
+
+**Type**: directory
+
+An agent's isolated git worktree
+
+**Notes**: Agent types: supervisor, merge-queue, or worker names like happy-platypus.
+
+### 📁 `messages/`
+
+**Type**: directory
+
+Inter-agent message files for coordination
+
+**Notes**: Agents communicate via JSON message files in this directory.
+
+### 📁 `messages/<repo-name>/`
+
+**Type**: directory
+
+Messages directory for a specific repository
+
+**Notes**: Contains subdirectories for each agent that can receive messages.
+
+### 📁 `messages/<repo-name>/<agent-name>/`
+
+**Type**: directory
+
+Inbox directory for a specific agent
+
+**Notes**: Contains msg-<uuid>.json files addressed to this agent.
+
+### 📁 `prompts/`
+
+**Type**: directory
+
+Generated prompt files for agents
+
+**Notes**: Created on-demand. Contains <agent-name>.md prompt files.
+
+## state.json Format
+
+The `state.json` file contains the daemon's persistent state. It is written atomically
+(write to temp file, then rename) to prevent corruption.
+
+### Schema
+
+```json
+{
+  "repos": {
+    "<repo-name>": {
+      "github_url": "https://github.com/owner/repo",
+      "tmux_session": "multiclaude-repo",
+      "agents": {
+        "<agent-name>": {
+          "type": "supervisor|worker|merge-queue|workspace",
+          "worktree_path": "/path/to/worktree",
+          "tmux_window": "window-name",
+          "session_id": "uuid",
+          "pid": 12345,
+          "task": "task description (workers only)",
+          "created_at": "2025-01-01T00:00:00Z",
+          "last_nudge": "2025-01-01T00:00:00Z",
+          "ready_for_cleanup": false
+        }
+      }
+    }
+  }
+}
+```
+
+### Field Reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repos` | `map[string]*Repository` | Map of repository name to repository state |
+| `repos.<name>.github_url` | `string` | GitHub URL of the repository |
+| `repos.<name>.tmux_session` | `string` | Name of the tmux session for this repo |
+| `repos.<name>.agents` | `map[string]Agent` | Map of agent name to agent state |
+| `repos.<name>.agents.<name>.type` | `string` | Agent type: supervisor, worker, merge-queue, or workspace |
+| `repos.<name>.agents.<name>.worktree_path` | `string` | Absolute path to the agent's git worktree |
+| `repos.<name>.agents.<name>.tmux_window` | `string` | Tmux window name for this agent |
+| `repos.<name>.agents.<name>.session_id` | `string` | UUID for Claude session context |
+| `repos.<name>.agents.<name>.pid` | `int` | Process ID of the Claude process |
+| `repos.<name>.agents.<name>.task` | `string` | Task description (workers only, omitempty) |
+| `repos.<name>.agents.<name>.created_at` | `time.Time` | When the agent was created |
+| `repos.<name>.agents.<name>.last_nudge` | `time.Time` | Last time agent was nudged (omitempty) |
+| `repos.<name>.agents.<name>.ready_for_cleanup` | `bool` | Whether worker is ready to be cleaned up (workers only, omitempty) |
+
+## Message File Format
+
+Message files are stored in `messages/<repo>/<agent>/msg-<uuid>.json`.
+They are used for inter-agent communication.
+
+### Schema
+
+```json
+{
+  "id": "msg-abc123def456",
+  "from": "supervisor",
+  "to": "happy-platypus",
+  "timestamp": "2025-01-01T00:00:00Z",
+  "body": "Please review PR #42",
+  "status": "pending",
+  "acked_at": null
+}
+```
+
+### Field Reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Message ID in format msg-<uuid> |
+| `from` | `string` | Sender agent name |
+| `to` | `string` | Recipient agent name |
+| `timestamp` | `time.Time` | When the message was sent |
+| `body` | `string` | Message content (markdown text) |
+| `status` | `string` | Message status: pending, delivered, read, or acked |
+| `acked_at` | `time.Time` | When the message was acknowledged (omitempty) |
+
+## Debugging Tips
+
+### Check daemon status
+
+```bash
+# Is the daemon running?
+cat ~/.multiclaude/daemon.pid && ps -p $(cat ~/.multiclaude/daemon.pid)
+
+# View daemon logs
+tail -f ~/.multiclaude/daemon.log
+```
+
+### Inspect state
+
+```bash
+# Pretty-print current state
+cat ~/.multiclaude/state.json | jq .
+
+# List all agents for a repo
+cat ~/.multiclaude/state.json | jq '.repos["my-repo"].agents | keys'
+```
+
+### Check agent worktrees
+
+```bash
+# List all worktrees for a repo
+ls ~/.multiclaude/wts/my-repo/
+
+# Check git status in an agent's worktree
+git -C ~/.multiclaude/wts/my-repo/supervisor status
+```
+
+### View messages
+
+```bash
+# List all messages for an agent
+ls ~/.multiclaude/messages/my-repo/supervisor/
+
+# Read a specific message
+cat ~/.multiclaude/messages/my-repo/supervisor/msg-*.json | jq .
+```
+
+### Clean up stale state
+
+```bash
+# Use the built-in repair command
+multiclaude repair
+
+# Or manually clean up orphaned resources
+multiclaude cleanup
+```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,3 +1,5 @@
+//go:generate go run ../../cmd/generate-docs
+
 package config
 
 import (

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -1,0 +1,145 @@
+package config
+
+// PathDoc describes a single path for documentation purposes
+type PathDoc struct {
+	Path        string // Relative path from ~/.multiclaude/
+	Description string // What this path is used for
+	Type        string // "file" or "directory"
+	Notes       string // Additional implementation notes
+}
+
+// DirectoryDocs returns documentation for all paths in ~/.multiclaude/
+// This is the single source of truth for directory structure documentation.
+func DirectoryDocs() []PathDoc {
+	return []PathDoc{
+		{
+			Path:        "daemon.pid",
+			Description: "Contains the process ID of the running multiclaude daemon",
+			Type:        "file",
+			Notes:       "Text file with a single integer. Deleted on clean daemon shutdown.",
+		},
+		{
+			Path:        "daemon.sock",
+			Description: "Unix domain socket for CLI-to-daemon communication",
+			Type:        "file",
+			Notes:       "Created with mode 0600 for security. The CLI connects here to send commands.",
+		},
+		{
+			Path:        "daemon.log",
+			Description: "Append-only log of daemon activity",
+			Type:        "file",
+			Notes:       "Useful for debugging daemon issues. Check this when agents behave unexpectedly.",
+		},
+		{
+			Path:        "state.json",
+			Description: "Central state file containing all tracked repositories and agents",
+			Type:        "file",
+			Notes:       "Written atomically via temp file + rename. See StateDoc() for format details.",
+		},
+		{
+			Path:        "repos/",
+			Description: "Contains cloned git repositories (bare or working)",
+			Type:        "directory",
+			Notes:       "Each repository is stored in repos/<repo-name>/",
+		},
+		{
+			Path:        "repos/<repo-name>/",
+			Description: "A cloned git repository",
+			Type:        "directory",
+			Notes:       "Full git clone of the tracked repository.",
+		},
+		{
+			Path:        "wts/",
+			Description: "Git worktrees for isolated agent working directories",
+			Type:        "directory",
+			Notes:       "Each agent gets its own worktree to work independently.",
+		},
+		{
+			Path:        "wts/<repo-name>/",
+			Description: "Worktrees directory for a specific repository",
+			Type:        "directory",
+			Notes:       "Contains subdirectories for each agent working on this repo.",
+		},
+		{
+			Path:        "wts/<repo-name>/<agent-name>/",
+			Description: "An agent's isolated git worktree",
+			Type:        "directory",
+			Notes:       "Agent types: supervisor, merge-queue, or worker names like happy-platypus.",
+		},
+		{
+			Path:        "messages/",
+			Description: "Inter-agent message files for coordination",
+			Type:        "directory",
+			Notes:       "Agents communicate via JSON message files in this directory.",
+		},
+		{
+			Path:        "messages/<repo-name>/",
+			Description: "Messages directory for a specific repository",
+			Type:        "directory",
+			Notes:       "Contains subdirectories for each agent that can receive messages.",
+		},
+		{
+			Path:        "messages/<repo-name>/<agent-name>/",
+			Description: "Inbox directory for a specific agent",
+			Type:        "directory",
+			Notes:       "Contains msg-<uuid>.json files addressed to this agent.",
+		},
+		{
+			Path:        "prompts/",
+			Description: "Generated prompt files for agents",
+			Type:        "directory",
+			Notes:       "Created on-demand. Contains <agent-name>.md prompt files.",
+		},
+	}
+}
+
+// StateDoc returns documentation for the state.json file format
+type StateFieldDoc struct {
+	Field       string // JSON field path
+	Type        string // Go type
+	Description string // What this field represents
+}
+
+// StateDocs returns documentation for state.json fields
+func StateDocs() []StateFieldDoc {
+	return []StateFieldDoc{
+		// Top level
+		{Field: "repos", Type: "map[string]*Repository", Description: "Map of repository name to repository state"},
+
+		// Repository fields
+		{Field: "repos.<name>.github_url", Type: "string", Description: "GitHub URL of the repository"},
+		{Field: "repos.<name>.tmux_session", Type: "string", Description: "Name of the tmux session for this repo"},
+		{Field: "repos.<name>.agents", Type: "map[string]Agent", Description: "Map of agent name to agent state"},
+
+		// Agent fields
+		{Field: "repos.<name>.agents.<name>.type", Type: "string", Description: "Agent type: supervisor, worker, merge-queue, or workspace"},
+		{Field: "repos.<name>.agents.<name>.worktree_path", Type: "string", Description: "Absolute path to the agent's git worktree"},
+		{Field: "repos.<name>.agents.<name>.tmux_window", Type: "string", Description: "Tmux window name for this agent"},
+		{Field: "repos.<name>.agents.<name>.session_id", Type: "string", Description: "UUID for Claude session context"},
+		{Field: "repos.<name>.agents.<name>.pid", Type: "int", Description: "Process ID of the Claude process"},
+		{Field: "repos.<name>.agents.<name>.task", Type: "string", Description: "Task description (workers only, omitempty)"},
+		{Field: "repos.<name>.agents.<name>.created_at", Type: "time.Time", Description: "When the agent was created"},
+		{Field: "repos.<name>.agents.<name>.last_nudge", Type: "time.Time", Description: "Last time agent was nudged (omitempty)"},
+		{Field: "repos.<name>.agents.<name>.ready_for_cleanup", Type: "bool", Description: "Whether worker is ready to be cleaned up (workers only, omitempty)"},
+	}
+}
+
+// MessageDoc returns documentation for message file format
+type MessageFieldDoc struct {
+	Field       string
+	Type        string
+	Description string
+}
+
+// MessageDocs returns documentation for message JSON files
+func MessageDocs() []MessageFieldDoc {
+	return []MessageFieldDoc{
+		{Field: "id", Type: "string", Description: "Message ID in format msg-<uuid>"},
+		{Field: "from", Type: "string", Description: "Sender agent name"},
+		{Field: "to", Type: "string", Description: "Recipient agent name"},
+		{Field: "timestamp", Type: "time.Time", Description: "When the message was sent"},
+		{Field: "body", Type: "string", Description: "Message content (markdown text)"},
+		{Field: "status", Type: "string", Description: "Message status: pending, delivered, read, or acked"},
+		{Field: "acked_at", Type: "time.Time", Description: "When the message was acknowledged (omitempty)"},
+	}
+}


### PR DESCRIPTION
## Summary

- Implements issue #14: Add debugging docs for ~/.multiclaude directory structure
- Auto-generates `docs/DIRECTORY_STRUCTURE.md` from code constants in `pkg/config/doc.go`
- Adds CI verification to ensure docs stay in sync with code

## Changes

1. **pkg/config/doc.go**: Documentation metadata as Go constants
   - `DirectoryDocs()` - Describes all paths in ~/.multiclaude/
   - `StateDocs()` - Documents state.json fields
   - `MessageDocs()` - Documents message file format

2. **cmd/generate-docs/main.go**: Documentation generator
   - Uses `go generate` to produce markdown
   - Finds project root automatically
   - Creates comprehensive debugging documentation

3. **docs/DIRECTORY_STRUCTURE.md**: Generated documentation
   - Directory tree layout
   - Detailed path descriptions with notes
   - state.json schema and field reference
   - Message file format
   - Debugging tips for common operations

4. **.github/workflows/ci.yml**: CI verification
   - New `verify-generated-docs` job
   - Runs `go generate` and checks for diffs
   - Fails if docs are out of sync

## How it works

The documentation is generated from code constants, so it cannot drift:
- Update `pkg/config/doc.go` to change documentation
- Run `go generate ./pkg/config/...` to regenerate
- CI will fail if the committed docs don't match

## Test plan

- [x] `go build -v ./...` succeeds
- [x] `go test -v ./pkg/config/...` passes
- [x] `go generate ./pkg/config/...` produces expected output
- [ ] CI passes on this PR

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)