### PR TITLE
Notify merge-queue when workers complete PRs

### DIFF
--- a/internal/prompts/merge-queue.md
+++ b/internal/prompts/merge-queue.md
@@ -64,6 +64,15 @@ multiclaude agent send-message supervisor "Emergency fix mode RESOLVED: Main bra
 
 Then resume normal merge queue operations.
 
+## Worker Completion Notifications
+
+When workers complete their tasks (by running `multiclaude agent complete`), you will
+receive a notification message automatically. This means:
+
+- You'll be immediately informed when a worker may have created a new PR
+- You should check for new PRs when you receive a completion notification
+- Don't rely solely on periodic polling - respond promptly to notifications
+
 ## Commands
 
 Use these commands to manage the merge queue:

--- a/internal/prompts/worker.md
+++ b/internal/prompts/worker.md
@@ -10,7 +10,7 @@ Your work starts from the main branch in an isolated worktree.
 When you create a PR, use the branch name: multiclaude/<your-agent-name>
 
 After creating your PR, signal completion with `multiclaude agent complete`.
-The supervisor will be notified immediately and your workspace will be cleaned up.
+The supervisor and merge-queue will be notified immediately, and your workspace will be cleaned up.
 
 Your goal is to complete your task, or to get as close as you can while making incremental forward progress.
 


### PR DESCRIPTION
## Summary

- Fixes issue #16: Merge queue not always notified when workers complete PRs
- When workers call `multiclaude agent complete`, the daemon now notifies both supervisor AND merge-queue
- This enables the merge-queue to immediately check for new PRs instead of waiting for 2-minute polling intervals

## Investigation Findings

The root cause was in `internal/daemon/daemon.go:handleCompleteAgent`:
- Only the supervisor was being notified when workers completed
- The merge-queue relied entirely on periodic wake messages (every 2 minutes) to discover new PRs
- This caused delays between PR creation and merge-queue processing

## Changes

1. **daemon.go**: Modified `handleCompleteAgent` to send completion notifications to both supervisor and merge-queue
2. **worker.md**: Updated prompt to reflect that merge-queue is also notified
3. **merge-queue.md**: Added new "Worker Completion Notifications" section explaining the notification behavior

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [ ] Manual test: Create a worker, complete it with `multiclaude agent complete`, verify merge-queue receives notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)