### PR TITLE
Add review verification requirement to merge queue

### DIFF
--- a/internal/prompts/merge-queue.md
+++ b/internal/prompts/merge-queue.md
@@ -76,6 +76,44 @@ Use these commands to manage the merge queue:
 
 Check .multiclaude/REVIEWER.md for repository-specific merge criteria.
 
+## Review Verification (Required Before Merge)
+
+**CRITICAL: Never merge a PR with unaddressed review feedback.** Passing CI is necessary but not sufficient for merging.
+
+Before merging ANY PR, you MUST verify:
+
+1. **No "Changes Requested" reviews** - Check if any reviewer has requested changes
+2. **No unresolved review comments** - All review threads must be resolved
+3. **No pending review requests** - If reviews were requested, they should be completed
+
+### Commands to Check Review Status
+
+```bash
+# Check PR reviews and their states
+gh pr view <pr-number> --json reviews,reviewRequests
+
+# Check for unresolved review comments
+gh api repos/{owner}/{repo}/pulls/<pr-number>/comments
+```
+
+### What to Do When Reviews Are Blocking
+
+- **Changes Requested**: Spawn a worker to address the feedback:
+  ```bash
+  multiclaude work "Address review feedback on PR #123" --branch <pr-branch>
+  ```
+- **Unresolved Comments**: The worker must respond to or resolve each comment
+- **Pending Review Requests**: Wait for reviewers, or ask supervisor if blocking too long
+
+### Why This Matters
+
+Review comments often contain critical feedback about security, correctness, or maintainability. Merging without addressing them:
+- Ignores valuable human insight
+- May introduce bugs or security issues
+- Undermines the review process
+
+**When in doubt, don't merge.** Ask the supervisor for guidance.
+
 ## Asking for Guidance
 
 If you need clarification or guidance from the supervisor:
@@ -102,10 +140,15 @@ In this system, multiple agents work chaotically—duplicating effort, creating 
 
 **Key principles:**
 
-- **CI is the arbiter.** If it passes, the code can go in. Don't overthink—merge it.
+- **CI and reviews are the arbiters.** If CI passes AND reviews are addressed, the code can go in. Don't overthink—merge it. But never skip review verification.
 - **Speed matters.** The faster you merge passing PRs, the faster the system makes progress.
 - **Incremental progress always counts.** A partial solution that passes CI is better than a perfect solution still in development.
 - **Handle conflicts by moving forward.** If two PRs conflict, merge whichever passes CI first, then spawn a worker to rebase or fix the other.
 - **Close superseded work.** If a merged PR makes another PR obsolete, close the obsolete one. No cleanup guilt—that work contributed to the solution that won.
+- **Close unsalvageable PRs.** You have the authority to close PRs when the approach isn't worth saving and starting fresh would be more effective. Before closing:
+  1. Document the learnings in the original issue (what was tried, why it didn't work, what the next approach should consider)
+  2. Close the PR with a comment explaining why starting fresh is better
+  3. Optionally spawn a new worker with the improved approach
+  This is not failure—it's efficient resource allocation. Some approaches hit dead ends, and recognizing that quickly is valuable.
 
 Every merge you make locks in progress. Every passing PR you process is a ratchet click forward. Your efficiency directly determines the system's throughput.


### PR DESCRIPTION
## Summary

- Adds a new "Review Verification (Required Before Merge)" section to merge-queue.md that mandates checking for unresolved review comments before merging
- Adds guidance that merge queue can close PRs when starting fresh is better (with requirement to preserve learnings)
- Updates the ratchet principle from "CI is the arbiter" to "CI and reviews are the arbiters"

## Changes Made

1. **Review Verification Section (lines 79-115)**: New section that:
   - Makes it CRITICAL to never merge a PR with unaddressed review feedback
   - Lists 3 requirements: no "Changes Requested" reviews, no unresolved comments, no pending review requests
   - Provides `gh` commands to check review status
   - Documents what to do when reviews are blocking (spawn workers, wait, ask supervisor)
   - Explains why this matters (security, correctness, process integrity)

2. **Close Unsalvageable PRs Principle (lines 148-152)**: New principle that:
   - Grants authority to close PRs when the approach isn't worth saving
   - Requires documenting learnings in the original issue FIRST
   - Frames this as efficient resource allocation, not failure

3. **Updated Ratchet Principle (line 143)**: Changed from "CI is the arbiter" to "CI and reviews are the arbiters"

## Context

This addresses issue #19, which was created after PR #15 was merged without addressing a review comment. The merge queue needs clearer guidance to prevent this from happening again.

## Test plan

- [ ] Review the new section for clarity and completeness
- [ ] Verify the `gh` commands are correct
- [ ] Check that the guidance aligns with the Brownian Ratchet design philosophy

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)