### PR TITLE
Add review agent type for PR reviews

### DIFF
--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -15,6 +15,7 @@ const (
 	TypeWorker     AgentType = "worker"
 	TypeMergeQueue AgentType = "merge-queue"
 	TypeWorkspace  AgentType = "workspace"
+	TypeReview     AgentType = "review"
 )
 
 // Embedded default prompts
@@ -30,6 +31,9 @@ var defaultMergeQueuePrompt string
 //go:embed workspace.md
 var defaultWorkspacePrompt string
 
+//go:embed review.md
+var defaultReviewPrompt string
+
 // GetDefaultPrompt returns the default prompt for the given agent type
 func GetDefaultPrompt(agentType AgentType) string {
 	switch agentType {
@@ -41,6 +45,8 @@ func GetDefaultPrompt(agentType AgentType) string {
 		return defaultMergeQueuePrompt
 	case TypeWorkspace:
 		return defaultWorkspacePrompt
+	case TypeReview:
+		return defaultReviewPrompt
 	default:
 		return ""
 	}
@@ -59,6 +65,8 @@ func LoadCustomPrompt(repoPath string, agentType AgentType) (string, error) {
 		filename = "REVIEWER.md"
 	case TypeWorkspace:
 		filename = "WORKSPACE.md"
+	case TypeReview:
+		filename = "REVIEW.md"
 	default:
 		return "", fmt.Errorf("unknown agent type: %s", agentType)
 	}

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -17,6 +17,7 @@ func TestGetDefaultPrompt(t *testing.T) {
 		{"worker", TypeWorker, false},
 		{"merge-queue", TypeMergeQueue, false},
 		{"workspace", TypeWorkspace, false},
+		{"review", TypeReview, false},
 		{"unknown", AgentType("unknown"), true},
 	}
 
@@ -68,6 +69,21 @@ func TestGetDefaultPromptContent(t *testing.T) {
 	}
 	if !strings.Contains(workspacePrompt, "NOT receive messages from the supervisor") {
 		t.Error("workspace prompt should clarify that it doesn't receive supervisor messages")
+	}
+
+	// Verify review prompt
+	reviewPrompt := GetDefaultPrompt(TypeReview)
+	if !strings.Contains(reviewPrompt, "code review agent") {
+		t.Error("review prompt should mention 'code review agent'")
+	}
+	if !strings.Contains(reviewPrompt, "Forward progress is forward") {
+		t.Error("review prompt should mention the philosophy 'Forward progress is forward'")
+	}
+	if !strings.Contains(reviewPrompt, "[BLOCKING]") {
+		t.Error("review prompt should mention [BLOCKING] comment format")
+	}
+	if !strings.Contains(reviewPrompt, "multiclaude agent complete") {
+		t.Error("review prompt should mention complete command")
 	}
 }
 
@@ -151,6 +167,22 @@ func TestLoadCustomPrompt(t *testing.T) {
 		}
 
 		prompt, err := LoadCustomPrompt(tmpDir, TypeWorkspace)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if prompt != customContent {
+			t.Errorf("expected %q, got %q", customContent, prompt)
+		}
+	})
+
+	t.Run("with custom review prompt", func(t *testing.T) {
+		customContent := "Custom review instructions"
+		promptPath := filepath.Join(multiclaudeDir, "REVIEW.md")
+		if err := os.WriteFile(promptPath, []byte(customContent), 0644); err != nil {
+			t.Fatalf("failed to write custom prompt: %v", err)
+		}
+
+		prompt, err := LoadCustomPrompt(tmpDir, TypeReview)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/internal/prompts/review.md
+++ b/internal/prompts/review.md
@@ -1,0 +1,117 @@
+You are a code review agent in the multiclaude system.
+
+## Your Philosophy
+
+**Forward progress is forward.** Your job is to help code get merged safely,
+not to block progress unnecessarily. Default to non-blocking suggestions unless
+there's a genuine concern that warrants blocking.
+
+## When to Review
+
+You'll be spawned by the merge-queue agent to review a specific PR.
+Your initial message will contain the PR URL.
+
+## Review Process
+
+1. Fetch the PR diff: `gh pr diff <number>`
+2. Read the changed files to understand context
+3. Post comments using `gh pr comment`
+4. Send summary to merge-queue
+5. Run `multiclaude agent complete`
+
+## What to Check
+
+### Blocking Issues (use sparingly)
+- Security vulnerabilities (injection, auth bypass, secrets in code)
+- Obvious bugs (nil dereference, infinite loops, race conditions)
+- Breaking changes without migration
+- Missing critical error handling
+
+### Non-Blocking Suggestions (default)
+- Code style and consistency
+- Naming improvements
+- Documentation gaps
+- Test coverage suggestions
+- Performance optimizations
+- Refactoring opportunities
+
+## Posting Comments
+
+The review agent posts comments only - no formal approve/request-changes.
+The merge-queue interprets the summary message to decide what to do.
+
+### Non-blocking comment:
+```bash
+gh pr comment <number> --body "**Suggestion:** Consider using a constant here."
+```
+
+### Blocking comment:
+```bash
+gh pr comment <number> --body "**[BLOCKING]** SQL injection vulnerability - use parameterized queries."
+```
+
+### Line-specific comment:
+Use the GitHub API for line-specific comments:
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/comments \
+  -f body="**Suggestion:** Consider a constant here" \
+  -f commit_id="<sha>" -f path="file.go" -F line=42
+```
+
+## Comment Format
+
+### Non-Blocking (default)
+Regular GitHub comments - suggestions, style nits, improvements:
+```markdown
+**Suggestion:** Consider extracting this into a helper function for reusability.
+```
+
+### Blocking
+Prefixed with `[BLOCKING]` - must be addressed before merge:
+```markdown
+**[BLOCKING]** This SQL query is vulnerable to injection. Use parameterized queries instead.
+```
+
+### What makes something blocking?
+- Security vulnerabilities (injection, auth bypass, etc.)
+- Obvious bugs (nil dereference, race conditions)
+- Breaking changes without migration path
+- Missing error handling that could cause data loss
+
+### What stays non-blocking?
+- Code style suggestions
+- Naming improvements
+- Performance optimizations (unless severe)
+- Documentation gaps
+- Test coverage suggestions
+- Refactoring opportunities
+
+## Reporting to Merge-Queue
+
+After completing your review, send a summary to the merge-queue:
+
+If no blocking issues found:
+```bash
+multiclaude agent send-message merge-queue "Review complete for PR #123.
+Found 0 blocking issues, 3 non-blocking suggestions. Safe to merge."
+```
+
+If blocking issues found:
+```bash
+multiclaude agent send-message merge-queue "Review complete for PR #123.
+Found 2 blocking issues: SQL injection in handler.go, missing auth check in api.go.
+Recommend spawning fix worker before merge."
+```
+
+Then signal completion:
+```bash
+multiclaude agent complete
+```
+
+## Important Notes
+
+- Be thorough but efficient - focus on what matters
+- Read enough context to understand the changes
+- Prioritize security and correctness over style
+- When in doubt, make it a non-blocking suggestion
+- Trust the merge-queue to make the final decision

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -16,6 +16,7 @@ const (
 	AgentTypeWorker     AgentType = "worker"
 	AgentTypeMergeQueue AgentType = "merge-queue"
 	AgentTypeWorkspace  AgentType = "workspace"
+	AgentTypeReview     AgentType = "review"
 )
 
 // Agent represents an agent's state


### PR DESCRIPTION
## Summary

- Implements issue #28: Add a new review agent type for PR reviews
- Review agents are ephemeral (like workers) and can be spawned to review PRs
- They leave comments as blocking or non-blocking, then report back to the merge-queue
- Philosophy: "Forward progress is forward" - default to non-blocking suggestions

## Changes

### Agent Type Constants
- Added `AgentTypeReview` to `state.go` and `TypeReview` to `prompts.go`

### System Prompt (`review.md`)
- Philosophy section explaining "forward progress is forward"
- Review process workflow
- What to check (blocking vs non-blocking issues)
- How to post comments using `gh pr comment`
- How to report back to merge-queue

### CLI Command (`multiclaude review <pr-url>`)
- Parses PR URL to extract owner/repo/number
- Fetches and checks out the PR branch
- Creates a worktree and tmux window for the reviewer
- Starts Claude with the review prompt

### Daemon Updates
- Wake loop sends status checks to review agents
- Completion notifications sent to merge-queue
- Worktree cleanup on agent completion (same as workers)

### Merge-Queue Integration
- Added documentation on how to spawn and work with review agents
- Explains how to interpret review summaries
- Documents when to spawn fix workers for blocking issues

### Tests
- Added test cases for review agent type in `prompts_test.go`
- Verified all existing tests still pass

## Test plan

- [x] Run `go build ./...` - compiles successfully
- [x] Run `go test ./...` - all tests pass
- [ ] Manual test: Create a test PR and run `multiclaude review <pr-url>`
- [ ] Verify review agent posts comments correctly
- [ ] Verify completion message sent to merge-queue

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)