### PR TITLE
Exclude workspace agent from wake loop and message routing

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -284,6 +284,11 @@ func (d *Daemon) routeMessages() {
 	for repoName, repo := range repos {
 		// Check each agent for messages
 		for agentName, agent := range repo.Agents {
+			// Skip workspace agent - it should only receive direct user input
+			if agent.Type == state.AgentTypeWorkspace {
+				continue
+			}
+
 			// Get unread messages (pending or delivered but not yet read)
 			unreadMsgs, err := msgMgr.ListUnread(repoName, agentName)
 			if err != nil {
@@ -360,6 +365,11 @@ func (d *Daemon) wakeAgents() {
 	repos := d.state.GetAllRepos()
 	for repoName, repo := range repos {
 		for agentName, agent := range repo.Agents {
+			// Skip workspace agent - it should only receive direct user input
+			if agent.Type == state.AgentTypeWorkspace {
+				continue
+			}
+
 			// Skip if nudged recently (within last 2 minutes)
 			if !agent.LastNudge.IsZero() && now.Sub(agent.LastNudge) < 2*time.Minute {
 				continue


### PR DESCRIPTION
## Summary

- Fixes #35: Exclude workspace agent from automated daemon messages
- Add skip for `AgentTypeWorkspace` in `wakeAgents()` to prevent status check messages
- Add skip for `AgentTypeWorkspace` in `routeMessages()` to prevent inter-agent messages being delivered to workspace
- Add tests to verify workspace agents are properly excluded from both functions

## Test plan

- [x] All existing daemon tests pass
- [x] New test `TestWorkspaceAgentExcludedFromRouteMessages` verifies messages to workspace are not delivered
- [x] New test `TestWorkspaceAgentExcludedFromWakeLoop` verifies workspace agent's LastNudge is never updated
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)