### PR TITLE
Fix missing newlines in agent messages (#33)

### DIFF
--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -305,6 +305,41 @@ func TestSendKeysLiteral(t *testing.T) {
 	}
 }
 
+func TestSendKeysLiteralWithNewlines(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create session
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Create a window
+	windowName := "test-window"
+	if err := client.CreateWindow(sessionName, windowName); err != nil {
+		t.Fatalf("Failed to create window: %v", err)
+	}
+
+	// Test sending text with newlines - should not error
+	multiLineText := "line1\nline2\nline3"
+	if err := client.SendKeysLiteral(sessionName, windowName, multiLineText); err != nil {
+		t.Fatalf("Failed to send multi-line text: %v", err)
+	}
+
+	// Test with empty lines
+	textWithEmptyLines := "first\n\nlast"
+	if err := client.SendKeysLiteral(sessionName, windowName, textWithEmptyLines); err != nil {
+		t.Fatalf("Failed to send text with empty lines: %v", err)
+	}
+
+	// Test with trailing newline
+	textWithTrailingNewline := "content\n"
+	if err := client.SendKeysLiteral(sessionName, windowName, textWithTrailingNewline); err != nil {
+		t.Fatalf("Failed to send text with trailing newline: %v", err)
+	}
+}
+
 func TestListSessions(t *testing.T) {
 	client := NewClient()
 


### PR DESCRIPTION
## Summary

- Fixed issue where newlines in agent messages were being lost when delivered via tmux
- `SendKeysLiteral` now splits multi-line text and sends each line separately with Enter keys between them
- Added test coverage for multi-line text handling including edge cases (empty lines, trailing newlines)

## Problem

When `SendKeysLiteral` sent text containing actual newline characters (`\n`) to tmux using `tmux send-keys -l`, the newlines didn't translate to proper line breaks in the terminal input. This caused multi-line messages between agents to run together, making them hard to read and parse.

## Solution

Modified `SendKeysLiteral` in `internal/tmux/tmux.go` to:
1. Check if text contains newlines
2. If so, split the text by `\n`
3. Send each line separately with `tmux send-keys -l`
4. Send Enter key (`C-m`) after each line except the last

This preserves the original behavior for single-line text while properly handling multi-line messages.

Fixes #33

## Test plan

- [x] All existing tests pass
- [x] Added `TestSendKeysLiteralWithNewlines` covering multi-line text, empty lines, and trailing newlines
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)