### PR TITLE
Fix: Send Enter twice after large initial message paste

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2313,6 +2313,10 @@ func (c *CLI) startClaudeInTmux(tmuxSession, tmuxWindow, workDir, sessionID, pro
 		if err := tmuxClient.SendEnter(tmuxSession, tmuxWindow); err != nil {
 			return pid, fmt.Errorf("failed to send Enter for initial message to Claude: %w", err)
 		}
+		// Send Enter twice - Claude Code may swallow the first Enter when processing large pasted text
+		if err := tmuxClient.SendEnter(tmuxSession, tmuxWindow); err != nil {
+			return pid, fmt.Errorf("failed to send second Enter for initial message to Claude: %w", err)
+		}
 	}
 
 	return pid, nil


### PR DESCRIPTION
## Summary

- Send Enter keystroke twice after pasting large initial messages to Claude Code
- Claude Code may swallow the first Enter when processing/abbreviating large pasted text
- Sending twice is safe and ensures the message is submitted

## Context

When spawning workers with large task descriptions, Claude Code would display the text but not submit it - requiring manual Enter press. This appeared to be Claude Code's paste handling behavior when it abbreviates large text.

## Test plan

- [x] All tests pass
- [ ] Spawn a worker with a large task description and verify it starts automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)