### PR TITLE
Rich list commands with colored output and detailed status info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,10 @@ module github.com/dlorenc/multiclaude
 
 go 1.25.1
 
-require github.com/google/uuid v1.6.0 // indirect
+require (
+	github.com/fatih/color v1.18.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	golang.org/x/sys v0.25.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,0 +1,333 @@
+// Package format provides utilities for rich terminal output formatting.
+package format
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+)
+
+// Status represents the status of an agent or resource
+type Status string
+
+const (
+	StatusHealthy   Status = "healthy"
+	StatusRunning   Status = "running"
+	StatusIdle      Status = "idle"
+	StatusCompleted Status = "completed"
+	StatusWarning   Status = "warning"
+	StatusError     Status = "error"
+	StatusPending   Status = "pending"
+)
+
+// Colors for different statuses
+var (
+	Green  = color.New(color.FgGreen)
+	Yellow = color.New(color.FgYellow)
+	Red    = color.New(color.FgRed)
+	Cyan   = color.New(color.FgCyan)
+	Bold   = color.New(color.Bold)
+	Dim    = color.New(color.Faint)
+)
+
+// StatusColor returns the appropriate color for a status
+func StatusColor(status Status) *color.Color {
+	switch status {
+	case StatusHealthy, StatusRunning, StatusCompleted:
+		return Green
+	case StatusWarning, StatusIdle, StatusPending:
+		return Yellow
+	case StatusError:
+		return Red
+	default:
+		return color.New()
+	}
+}
+
+// StatusIcon returns an icon for a status
+func StatusIcon(status Status) string {
+	switch status {
+	case StatusHealthy, StatusCompleted:
+		return "✓"
+	case StatusRunning:
+		return "●"
+	case StatusIdle:
+		return "○"
+	case StatusWarning:
+		return "⚠"
+	case StatusError:
+		return "✗"
+	case StatusPending:
+		return "◦"
+	default:
+		return "-"
+	}
+}
+
+// ColoredStatus returns a colored status string with icon
+func ColoredStatus(status Status) string {
+	c := StatusColor(status)
+	icon := StatusIcon(status)
+	return c.Sprintf("%s %s", icon, status)
+}
+
+// Header prints a bold header line
+func Header(format string, args ...interface{}) {
+	Bold.Printf(format+"\n", args...)
+}
+
+// Success prints a green success message
+func Success(format string, args ...interface{}) {
+	Green.Printf("✓ "+format+"\n", args...)
+}
+
+// Warning prints a yellow warning message
+func Warning(format string, args ...interface{}) {
+	Yellow.Printf("⚠ "+format+"\n", args...)
+}
+
+// Error prints a red error message
+func Error(format string, args ...interface{}) {
+	Red.Printf("✗ "+format+"\n", args...)
+}
+
+// Info prints an info message
+func Info(format string, args ...interface{}) {
+	Cyan.Printf(format+"\n", args...)
+}
+
+// Dimmed prints dimmed/muted text
+func Dimmed(format string, args ...interface{}) {
+	Dim.Printf(format+"\n", args...)
+}
+
+// TimeAgo formats a time as a human-readable relative time
+func TimeAgo(t time.Time) string {
+	if t.IsZero() {
+		return "never"
+	}
+
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		mins := int(d.Minutes())
+		if mins == 1 {
+			return "1 min ago"
+		}
+		return fmt.Sprintf("%d mins ago", mins)
+	case d < 24*time.Hour:
+		hours := int(d.Hours())
+		if hours == 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", hours)
+	default:
+		days := int(d.Hours() / 24)
+		if days == 1 {
+			return "1 day ago"
+		}
+		return fmt.Sprintf("%d days ago", days)
+	}
+}
+
+// Truncate truncates a string to maxLen, adding "..." if truncated
+func Truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// Table provides a simple table formatter
+type Table struct {
+	headers []string
+	rows    [][]string
+	widths  []int
+}
+
+// NewTable creates a new table with the given headers
+func NewTable(headers ...string) *Table {
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	return &Table{
+		headers: headers,
+		widths:  widths,
+	}
+}
+
+// AddRow adds a row to the table
+func (t *Table) AddRow(cells ...string) {
+	// Pad or truncate to match header count
+	row := make([]string, len(t.headers))
+	for i := range row {
+		if i < len(cells) {
+			row[i] = cells[i]
+		}
+		if len(row[i]) > t.widths[i] {
+			t.widths[i] = len(row[i])
+		}
+	}
+	t.rows = append(t.rows, row)
+}
+
+// String returns the formatted table as a string
+func (t *Table) String() string {
+	var sb strings.Builder
+
+	// Header
+	for i, h := range t.headers {
+		if i > 0 {
+			sb.WriteString("  ")
+		}
+		sb.WriteString(fmt.Sprintf("%-*s", t.widths[i], h))
+	}
+	sb.WriteString("\n")
+
+	// Separator
+	for i, w := range t.widths {
+		if i > 0 {
+			sb.WriteString("  ")
+		}
+		sb.WriteString(strings.Repeat("-", w))
+	}
+	sb.WriteString("\n")
+
+	// Rows
+	for _, row := range t.rows {
+		for i, cell := range row {
+			if i > 0 {
+				sb.WriteString("  ")
+			}
+			sb.WriteString(fmt.Sprintf("%-*s", t.widths[i], cell))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// Print prints the table
+func (t *Table) Print() {
+	fmt.Print(t.String())
+}
+
+// ColoredTable is a table that supports colored cells
+type ColoredTable struct {
+	headers      []string
+	rows         [][]ColoredCell
+	widths       []int
+	headerColors []*color.Color
+}
+
+// ColoredCell represents a cell with optional color
+type ColoredCell struct {
+	Text  string
+	Color *color.Color
+}
+
+// Cell creates a plain cell
+func Cell(text string) ColoredCell {
+	return ColoredCell{Text: text}
+}
+
+// ColorCell creates a colored cell
+func ColorCell(text string, c *color.Color) ColoredCell {
+	return ColoredCell{Text: text, Color: c}
+}
+
+// NewColoredTable creates a new colored table
+func NewColoredTable(headers ...string) *ColoredTable {
+	widths := make([]int, len(headers))
+	headerColors := make([]*color.Color, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+		headerColors[i] = Bold
+	}
+	return &ColoredTable{
+		headers:      headers,
+		widths:       widths,
+		headerColors: headerColors,
+	}
+}
+
+// AddRow adds a row to the colored table
+func (t *ColoredTable) AddRow(cells ...ColoredCell) {
+	row := make([]ColoredCell, len(t.headers))
+	for i := range row {
+		if i < len(cells) {
+			row[i] = cells[i]
+		}
+		if len(row[i].Text) > t.widths[i] {
+			t.widths[i] = len(row[i].Text)
+		}
+	}
+	t.rows = append(t.rows, row)
+}
+
+// Print prints the colored table
+func (t *ColoredTable) Print() {
+	// Header
+	for i, h := range t.headers {
+		if i > 0 {
+			fmt.Print("  ")
+		}
+		t.headerColors[i].Printf("%-*s", t.widths[i], h)
+	}
+	fmt.Println()
+
+	// Separator
+	Dim.Print(strings.Repeat("-", t.totalWidth()))
+	fmt.Println()
+
+	// Rows
+	for _, row := range t.rows {
+		for i, cell := range row {
+			if i > 0 {
+				fmt.Print("  ")
+			}
+			text := fmt.Sprintf("%-*s", t.widths[i], cell.Text)
+			if cell.Color != nil {
+				cell.Color.Print(text)
+			} else {
+				fmt.Print(text)
+			}
+		}
+		fmt.Println()
+	}
+}
+
+func (t *ColoredTable) totalWidth() int {
+	total := 0
+	for i, w := range t.widths {
+		total += w
+		if i > 0 {
+			total += 2 // spacing
+		}
+	}
+	return total
+}
+
+// MessageBadge formats a message count badge
+func MessageBadge(pending, total int) string {
+	if total == 0 {
+		return Dim.Sprint("-")
+	}
+	if pending > 0 {
+		return Yellow.Sprintf("%d/%d", pending, total)
+	}
+	return Dim.Sprintf("0/%d", total)
+}
+
+// BranchName formats a branch name with color
+func BranchName(branch string) string {
+	return Cyan.Sprint(branch)
+}

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -1,0 +1,206 @@
+package format
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStatusColor(t *testing.T) {
+	tests := []struct {
+		status   Status
+		wantNil  bool
+	}{
+		{StatusHealthy, false},
+		{StatusRunning, false},
+		{StatusCompleted, false},
+		{StatusWarning, false},
+		{StatusIdle, false},
+		{StatusPending, false},
+		{StatusError, false},
+		{Status("unknown"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := StatusColor(tt.status)
+			if tt.wantNil && got != nil {
+				t.Errorf("StatusColor(%v) = %v, want nil", tt.status, got)
+			}
+			if !tt.wantNil && got == nil {
+				t.Errorf("StatusColor(%v) = nil, want non-nil", tt.status)
+			}
+		})
+	}
+}
+
+func TestStatusIcon(t *testing.T) {
+	tests := []struct {
+		status Status
+		want   string
+	}{
+		{StatusHealthy, "✓"},
+		{StatusCompleted, "✓"},
+		{StatusRunning, "●"},
+		{StatusIdle, "○"},
+		{StatusWarning, "⚠"},
+		{StatusError, "✗"},
+		{StatusPending, "◦"},
+		{Status("unknown"), "-"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := StatusIcon(tt.status)
+			if got != tt.want {
+				t.Errorf("StatusIcon(%v) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeAgo(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name string
+		time time.Time
+		want string
+	}{
+		{"zero time", time.Time{}, "never"},
+		{"just now", now.Add(-30 * time.Second), "just now"},
+		{"1 min ago", now.Add(-1 * time.Minute), "1 min ago"},
+		{"5 mins ago", now.Add(-5 * time.Minute), "5 mins ago"},
+		{"1 hour ago", now.Add(-1 * time.Hour), "1 hour ago"},
+		{"3 hours ago", now.Add(-3 * time.Hour), "3 hours ago"},
+		{"1 day ago", now.Add(-24 * time.Hour), "1 day ago"},
+		{"5 days ago", now.Add(-5 * 24 * time.Hour), "5 days ago"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TimeAgo(tt.time)
+			if got != tt.want {
+				t.Errorf("TimeAgo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 5, "he..."},
+		{"hello", 5, "hello"},
+		{"hi", 2, "hi"},
+		{"hello", 3, "hel"},
+		{"", 5, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := Truncate(tt.input, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("Truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTable(t *testing.T) {
+	table := NewTable("Name", "Age", "City")
+	table.AddRow("Alice", "30", "NYC")
+	table.AddRow("Bob", "25", "LA")
+
+	output := table.String()
+
+	// Check headers are present
+	if !strings.Contains(output, "Name") {
+		t.Error("Table output missing 'Name' header")
+	}
+	if !strings.Contains(output, "Age") {
+		t.Error("Table output missing 'Age' header")
+	}
+	if !strings.Contains(output, "City") {
+		t.Error("Table output missing 'City' header")
+	}
+
+	// Check data is present
+	if !strings.Contains(output, "Alice") {
+		t.Error("Table output missing 'Alice'")
+	}
+	if !strings.Contains(output, "Bob") {
+		t.Error("Table output missing 'Bob'")
+	}
+
+	// Check separator line
+	if !strings.Contains(output, "---") {
+		t.Error("Table output missing separator line")
+	}
+}
+
+func TestColoredTable(t *testing.T) {
+	table := NewColoredTable("Status", "Name")
+	table.AddRow(
+		ColorCell("running", Green),
+		Cell("worker-1"),
+	)
+	table.AddRow(
+		ColorCell("stopped", Red),
+		Cell("worker-2"),
+	)
+
+	// Just ensure it doesn't panic
+	// Actual color output is hard to test without capturing stdout
+	if len(table.rows) != 2 {
+		t.Errorf("Expected 2 rows, got %d", len(table.rows))
+	}
+}
+
+func TestCell(t *testing.T) {
+	cell := Cell("hello")
+	if cell.Text != "hello" {
+		t.Errorf("Cell.Text = %q, want %q", cell.Text, "hello")
+	}
+	if cell.Color != nil {
+		t.Errorf("Cell.Color should be nil for plain cell")
+	}
+}
+
+func TestColorCell(t *testing.T) {
+	cell := ColorCell("hello", Green)
+	if cell.Text != "hello" {
+		t.Errorf("ColorCell.Text = %q, want %q", cell.Text, "hello")
+	}
+	if cell.Color != Green {
+		t.Errorf("ColorCell.Color should be Green")
+	}
+}
+
+func TestColoredStatus(t *testing.T) {
+	tests := []struct {
+		status Status
+	}{
+		{StatusHealthy},
+		{StatusRunning},
+		{StatusError},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := ColoredStatus(tt.status)
+			if got == "" {
+				t.Errorf("ColoredStatus(%v) returned empty string", tt.status)
+			}
+			// Should contain the status icon and name
+			icon := StatusIcon(tt.status)
+			if !strings.Contains(got, icon) {
+				t.Errorf("ColoredStatus(%v) = %q, should contain icon %q", tt.status, got, icon)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #44 by enhancing list commands with rich, colored output:

- **Colored status indicators**: Green for healthy/running, yellow for warning/idle, red for errors/stopped
- **Detailed agent status**: Shows running, completed, stopped, or idle state for each agent
- **Current branch display**: Shows the Git branch each worker is on
- **Message counts**: Shows pending/total message counts per agent (e.g., `2/5` means 2 pending of 5 total)
- **Table formatting**: Clean tabular output for better readability

### Changes

1. **New `internal/format` package** - Provides formatting utilities including:
   - Status colors and icons
   - Colored and plain table formatters
   - Time-ago formatting (e.g., "5 mins ago")
   - String truncation helpers
   - Message badge formatting

2. **Enhanced daemon handlers** - `list_repos` and `list_agents` now accept a `rich: true` parameter to return detailed status data (backward compatible)

3. **Updated CLI commands** - `multiclaude list` and `multiclaude work list` now use rich formatting

### Example Output

**`multiclaude list`:**
```
Tracked repositories (1):

REPO        AGENTS           STATUS       SESSION
----------  ---------------  -----------  ---------------
multiclaude 3 (2 workers)    ✓ healthy    mc-multiclaude
```

**`multiclaude work list`:**
```
Workers in 'multiclaude' (2):

NAME          STATUS      BRANCH            MSGS  TASK
------------  ----------  ----------------  ----  ----------------------------------------
swift-eagle   ● running   work/swift-eagle  0/3   Implement rich list commands...
bold-falcon   ✓ completed work/bold-falcon  -     Fix authentication bug
```

## Test plan

- [x] All existing tests pass
- [x] New format package tests added and pass
- [x] Build succeeds with no warnings
- [ ] Manual testing: Run `multiclaude list` and verify colored output
- [ ] Manual testing: Run `multiclaude work list` and verify status info

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)