### PR TITLE
Implement agent output capture to flat files via tmux pipe-pane (#46)

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -335,6 +335,7 @@ func setupTestEnvironment(t *testing.T) (*CLI, *daemon.Daemon, func()) {
 		ReposDir:     filepath.Join(tmpDir, "repos"),
 		WorktreesDir: filepath.Join(tmpDir, "wts"),
 		MessagesDir:  filepath.Join(tmpDir, "messages"),
+		OutputDir:    filepath.Join(tmpDir, "output"),
 	}
 
 	if err := paths.EnsureDirectories(); err != nil {
@@ -888,6 +889,7 @@ func TestNewWithPaths(t *testing.T) {
 		ReposDir:     filepath.Join(tmpDir, "repos"),
 		WorktreesDir: filepath.Join(tmpDir, "wts"),
 		MessagesDir:  filepath.Join(tmpDir, "messages"),
+		OutputDir:    filepath.Join(tmpDir, "output"),
 	}
 
 	// Test with empty claude path

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -32,6 +32,7 @@ func setupTestDaemon(t *testing.T) (*Daemon, func()) {
 		ReposDir:     filepath.Join(tmpDir, "repos"),
 		WorktreesDir: filepath.Join(tmpDir, "wts"),
 		MessagesDir:  filepath.Join(tmpDir, "messages"),
+		OutputDir:    filepath.Join(tmpDir, "output"),
 	}
 
 	// Create directories

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -204,3 +204,27 @@ func (c *Client) GetPanePID(session, windowName string) (int, error) {
 
 	return pid, nil
 }
+
+// StartPipePane sets up pipe-pane to capture output to a file
+// The output is appended to the file, so it persists across daemon restarts
+func (c *Client) StartPipePane(session, windowName, outputFile string) error {
+	target := fmt.Sprintf("%s:%s", session, windowName)
+	// Use -o to open a pipe (output only, not input)
+	// cat >> appends to the file so output is preserved
+	cmd := exec.Command("tmux", "pipe-pane", "-o", "-t", target, fmt.Sprintf("cat >> '%s'", outputFile))
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to start pipe-pane: %w", err)
+	}
+	return nil
+}
+
+// StopPipePane stops the pipe-pane for a window
+func (c *Client) StopPipePane(session, windowName string) error {
+	target := fmt.Sprintf("%s:%s", session, windowName)
+	// Running pipe-pane with no command stops any existing pipe
+	cmd := exec.Command("tmux", "pipe-pane", "-t", target)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to stop pipe-pane: %w", err)
+	}
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ type Paths struct {
 	ReposDir     string // repos/
 	WorktreesDir string // wts/
 	MessagesDir  string // messages/
+	OutputDir    string // output/
 }
 
 // DefaultPaths returns the default paths for multiclaude
@@ -37,6 +38,7 @@ func DefaultPaths() (*Paths, error) {
 		ReposDir:     filepath.Join(root, "repos"),
 		WorktreesDir: filepath.Join(root, "wts"),
 		MessagesDir:  filepath.Join(root, "messages"),
+		OutputDir:    filepath.Join(root, "output"),
 	}, nil
 }
 
@@ -47,6 +49,7 @@ func (p *Paths) EnsureDirectories() error {
 		p.ReposDir,
 		p.WorktreesDir,
 		p.MessagesDir,
+		p.OutputDir,
 	}
 
 	for _, dir := range dirs {
@@ -81,4 +84,22 @@ func (p *Paths) RepoMessagesDir(repoName string) string {
 // AgentMessagesDir returns the path for a specific agent's messages
 func (p *Paths) AgentMessagesDir(repoName, agentName string) string {
 	return filepath.Join(p.RepoMessagesDir(repoName), agentName)
+}
+
+// RepoOutputDir returns the path for a repository's output logs
+func (p *Paths) RepoOutputDir(repoName string) string {
+	return filepath.Join(p.OutputDir, repoName)
+}
+
+// WorkersOutputDir returns the path for worker agent output logs
+func (p *Paths) WorkersOutputDir(repoName string) string {
+	return filepath.Join(p.RepoOutputDir(repoName), "workers")
+}
+
+// AgentLogFile returns the path to an agent's log file
+func (p *Paths) AgentLogFile(repoName, agentName string, isWorker bool) string {
+	if isWorker {
+		return filepath.Join(p.WorkersOutputDir(repoName), agentName+".log")
+	}
+	return filepath.Join(p.RepoOutputDir(repoName), agentName+".log")
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -54,6 +54,7 @@ func TestEnsureDirectories(t *testing.T) {
 		ReposDir:     filepath.Join(tmpDir, "test-multiclaude", "repos"),
 		WorktreesDir: filepath.Join(tmpDir, "test-multiclaude", "wts"),
 		MessagesDir:  filepath.Join(tmpDir, "test-multiclaude", "messages"),
+		OutputDir:    filepath.Join(tmpDir, "test-multiclaude", "output"),
 	}
 
 	if err := paths.EnsureDirectories(); err != nil {
@@ -61,7 +62,7 @@ func TestEnsureDirectories(t *testing.T) {
 	}
 
 	// Verify directories were created
-	dirs := []string{paths.Root, paths.ReposDir, paths.WorktreesDir, paths.MessagesDir}
+	dirs := []string{paths.Root, paths.ReposDir, paths.WorktreesDir, paths.MessagesDir, paths.OutputDir}
 	for _, dir := range dirs {
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
 			t.Errorf("Directory not created: %s", dir)
@@ -115,5 +116,44 @@ func TestRepoPaths(t *testing.T) {
 	expected = filepath.Join(tmpDir, "messages", repoName, agentName)
 	if agentMsgDir != expected {
 		t.Errorf("AgentMessagesDir() = %q, want %q", agentMsgDir, expected)
+	}
+}
+
+func TestOutputPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	paths := &Paths{
+		Root:         tmpDir,
+		OutputDir:    filepath.Join(tmpDir, "output"),
+	}
+
+	repoName := "test-repo"
+
+	// Test RepoOutputDir
+	repoOutputDir := paths.RepoOutputDir(repoName)
+	expected := filepath.Join(tmpDir, "output", repoName)
+	if repoOutputDir != expected {
+		t.Errorf("RepoOutputDir() = %q, want %q", repoOutputDir, expected)
+	}
+
+	// Test WorkersOutputDir
+	workersDir := paths.WorkersOutputDir(repoName)
+	expected = filepath.Join(tmpDir, "output", repoName, "workers")
+	if workersDir != expected {
+		t.Errorf("WorkersOutputDir() = %q, want %q", workersDir, expected)
+	}
+
+	// Test AgentLogFile for system agent (not worker)
+	supervisorLog := paths.AgentLogFile(repoName, "supervisor", false)
+	expected = filepath.Join(tmpDir, "output", repoName, "supervisor.log")
+	if supervisorLog != expected {
+		t.Errorf("AgentLogFile(supervisor, false) = %q, want %q", supervisorLog, expected)
+	}
+
+	// Test AgentLogFile for worker
+	workerLog := paths.AgentLogFile(repoName, "happy-eagle", true)
+	expected = filepath.Join(tmpDir, "output", repoName, "workers", "happy-eagle.log")
+	if workerLog != expected {
+		t.Errorf("AgentLogFile(happy-eagle, true) = %q, want %q", workerLog, expected)
 	}
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -45,6 +45,7 @@ func TestPhase2Integration(t *testing.T) {
 		ReposDir:     filepath.Join(tmpDir, "repos"),
 		WorktreesDir: filepath.Join(tmpDir, "wts"),
 		MessagesDir:  filepath.Join(tmpDir, "messages"),
+		OutputDir:    filepath.Join(tmpDir, "output"),
 	}
 
 	if err := paths.EnsureDirectories(); err != nil {

--- a/test/recovery_test.go
+++ b/test/recovery_test.go
@@ -110,6 +110,7 @@ func TestOrphanedTmuxSessionCleanup(t *testing.T) {
 		ReposDir:     filepath.Join(tmpDir, "repos"),
 		WorktreesDir: filepath.Join(tmpDir, "wts"),
 		MessagesDir:  filepath.Join(tmpDir, "messages"),
+		OutputDir:    filepath.Join(tmpDir, "output"),
 	}
 
 	if err := paths.EnsureDirectories(); err != nil {
@@ -256,6 +257,7 @@ func TestStaleSocketCleanup(t *testing.T) {
 		ReposDir:     filepath.Join(tmpDir, "repos"),
 		WorktreesDir: filepath.Join(tmpDir, "wts"),
 		MessagesDir:  filepath.Join(tmpDir, "messages"),
+		OutputDir:    filepath.Join(tmpDir, "output"),
 	}
 
 	if err := paths.EnsureDirectories(); err != nil {
@@ -371,6 +373,7 @@ func TestDaemonCrashRecovery(t *testing.T) {
 		ReposDir:     filepath.Join(tmpDir, "repos"),
 		WorktreesDir: filepath.Join(tmpDir, "wts"),
 		MessagesDir:  filepath.Join(tmpDir, "messages"),
+		OutputDir:    filepath.Join(tmpDir, "output"),
 	}
 
 	if err := paths.EnsureDirectories(); err != nil {


### PR DESCRIPTION
## Summary

- Implements agent output capture to flat files via tmux's `pipe-pane` feature per issue #46
- Adds new `multiclaude logs` CLI commands for viewing, searching, and managing logs
- Includes automatic log rotation when files exceed 10MB threshold
- Output capture survives daemon/agent crashes since tmux manages the pipe

## Changes

### Config (`pkg/config/config.go`)
- Added `OutputDir` path for storing agent output logs
- Added helper methods: `RepoOutputDir`, `WorkersOutputDir`, `AgentLogFile`

### tmux Client (`internal/tmux/tmux.go`)
- Added `StartPipePane(session, window, outputFile)` to start capturing output
- Added `StopPipePane(session, window)` to stop capturing

### CLI Commands (`internal/cli/cli.go`)
- `multiclaude logs <agent>` - View recent output (with `--lines N`, `--follow` options)
- `multiclaude logs list` - List all log files
- `multiclaude logs search <pattern>` - Search across logs (with `--repo` filter)
- `multiclaude logs clean --older-than <duration>` - Clean old logs (e.g., 7d, 24h)
- `setupOutputCapture()` helper called after each agent starts

### Daemon (`internal/daemon/daemon.go`)
- Added `rotateLogsIfNeeded()` method for automatic log rotation
- Rotation runs during health check loop every 2 minutes
- Rotates logs exceeding 10MB by renaming with timestamp suffix

### File Structure
```
~/.multiclaude/output/
└── <repo>/
    ├── supervisor.log
    ├── merge-queue.log
    ├── workspace.log
    └── workers/
        ├── swift-eagle.log
        └── cool-elephant.log
```

## Test plan

- [x] Added tests for output path helpers (`TestOutputPaths`)
- [x] Added tests for pipe-pane functionality (`TestPipePane`, `TestPipePaneErrorHandling`)
- [x] Updated existing tests to include new `OutputDir` field
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)