### PR TITLE
Implement event-based message delivery (#60)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1689,6 +1689,11 @@ func (c *CLI) sendMessage(args []string) error {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 
+	// Trigger immediate routing (best-effort, polling is fallback)
+	client := socket.NewClient(c.paths.DaemonSock)
+	_, _ = client.Send(socket.Request{Command: "route_messages"})
+	// Ignore errors - 2-minute polling fallback will catch it
+
 	fmt.Printf("Message sent to %s (ID: %s)\n", to, msg.ID)
 	return nil
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -503,6 +503,10 @@ func (d *Daemon) handleRequest(req socket.Request) socket.Response {
 	case "update_repo_config":
 		return d.handleUpdateRepoConfig(req)
 
+	case "route_messages":
+		go d.routeMessages()
+		return socket.Response{Success: true, Data: "Message routing triggered"}
+
 	default:
 		return socket.Response{
 			Success: false,


### PR DESCRIPTION
## Summary

Implements event-based message delivery per issue #60. This adds immediate message routing triggered by the CLI after sending messages, while keeping the 2-minute polling as a fallback for reliability.

**Key changes:**
- Add `route_messages` socket command to daemon that triggers immediate message routing
- Modify CLI `send-message` to call `route_messages` after writing the message (best-effort, errors ignored so polling fallback still works)
- Add comprehensive tests for the new functionality
- Fix a macOS symlink issue in test setup (`/var` -> `/private/var`)

**Flow change:**
```
Before: CLI writes message → waits up to 2min → daemon polls → delivers

After:  CLI writes message → CLI calls route_messages → daemon delivers immediately
                          ↘ (fallback: 2min poll if socket fails)
```

## Files Changed

- `internal/daemon/daemon.go` - Add `route_messages` socket command handler
- `internal/cli/cli.go` - Add socket call after SendMessage
- `internal/daemon/daemon_test.go` - Add tests for new socket command
- `internal/cli/cli_test.go` - Add integration tests for immediate delivery and fallback behavior

## Test plan

- [x] Test that `route_messages` socket command triggers immediate routing
- [x] Test that messages are delivered immediately after send-message CLI call
- [x] Test fallback behavior when daemon socket is unavailable
- [x] Run full test suite to ensure no regressions

All tests pass:
```
ok  	github.com/dlorenc/multiclaude/internal/cli
ok  	github.com/dlorenc/multiclaude/internal/daemon
```

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)