### PR TITLE
Extract tmux and claude-runner as public libraries (fixes #65)

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1,249 +1,33 @@
+// Package tmux provides tmux operations for internal use.
+//
+// This package re-exports functionality from pkg/tmux for backward compatibility.
+// New code should prefer importing pkg/tmux directly.
 package tmux
 
 import (
-	"fmt"
-	"os/exec"
-	"strings"
+	pkgtmux "github.com/dlorenc/multiclaude/pkg/tmux"
 )
 
-// Client wraps tmux operations
-type Client struct{}
+// Client wraps tmux operations.
+// This is an alias to pkg/tmux.Client for backward compatibility.
+type Client = pkgtmux.Client
 
-// NewClient creates a new tmux client
-func NewClient() *Client {
-	return &Client{}
+// NewClient creates a new tmux client.
+// This is an alias to pkg/tmux.NewClient for backward compatibility.
+func NewClient(opts ...pkgtmux.ClientOption) *Client {
+	return pkgtmux.NewClient(opts...)
 }
 
-// HasSession checks if a tmux session exists
-func (c *Client) HasSession(name string) (bool, error) {
-	cmd := exec.Command("tmux", "has-session", "-t", name)
-	err := cmd.Run()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			// Exit code 1 means session doesn't exist
-			if exitErr.ExitCode() == 1 {
-				return false, nil
-			}
-		}
-		return false, fmt.Errorf("failed to check session: %w", err)
-	}
-	return true, nil
-}
+// ClientOption is a functional option for configuring a Client.
+// This is an alias to pkg/tmux.ClientOption for backward compatibility.
+type ClientOption = pkgtmux.ClientOption
 
-// CreateSession creates a new tmux session
-// If detached is true, creates session in detached mode
-func (c *Client) CreateSession(name string, detached bool) error {
-	args := []string{"new-session", "-s", name}
-	if detached {
-		args = append(args, "-d")
-	}
+// WithTmuxPath sets a custom path to the tmux binary.
+// This is an alias to pkg/tmux.WithTmuxPath for backward compatibility.
+var WithTmuxPath = pkgtmux.WithTmuxPath
 
-	cmd := exec.Command("tmux", args...)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to create session: %w", err)
-	}
-	return nil
-}
-
-// CreateWindow creates a new window in a session
-func (c *Client) CreateWindow(session, windowName string) error {
-	target := fmt.Sprintf("%s:", session)
-	cmd := exec.Command("tmux", "new-window", "-t", target, "-n", windowName)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to create window: %w", err)
-	}
-	return nil
-}
-
-// HasWindow checks if a window exists in a session
-func (c *Client) HasWindow(session, windowName string) (bool, error) {
-	cmd := exec.Command("tmux", "list-windows", "-t", session)
-	output, err := cmd.Output()
-	if err != nil {
-		return false, fmt.Errorf("failed to list windows: %w", err)
-	}
-
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		if strings.Contains(line, windowName) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// KillWindow kills a window in a session
-func (c *Client) KillWindow(session, windowName string) error {
-	target := fmt.Sprintf("%s:%s", session, windowName)
-	cmd := exec.Command("tmux", "kill-window", "-t", target)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to kill window: %w", err)
-	}
-	return nil
-}
-
-// KillSession kills a tmux session
-func (c *Client) KillSession(name string) error {
-	cmd := exec.Command("tmux", "kill-session", "-t", name)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to kill session: %w", err)
-	}
-	return nil
-}
-
-// SendKeys sends text to a window followed by Enter
-func (c *Client) SendKeys(session, windowName, text string) error {
-	target := fmt.Sprintf("%s:%s", session, windowName)
-	cmd := exec.Command("tmux", "send-keys", "-t", target, text, "C-m")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to send keys: %w", err)
-	}
-	return nil
-}
-
-// SendKeysLiteral sends text to a window without Enter (using -l for literal mode)
-// For multiline text, it uses tmux's paste buffer to send the entire message at once
-// without triggering intermediate processing.
-func (c *Client) SendKeysLiteral(session, windowName, text string) error {
-	target := fmt.Sprintf("%s:%s", session, windowName)
-
-	// For multiline text, use paste buffer to avoid triggering processing on each line
-	if strings.Contains(text, "\n") {
-		// Set the buffer with the text
-		setCmd := exec.Command("tmux", "set-buffer", text)
-		if err := setCmd.Run(); err != nil {
-			return fmt.Errorf("failed to set buffer: %w", err)
-		}
-
-		// Paste the buffer to the target
-		pasteCmd := exec.Command("tmux", "paste-buffer", "-t", target)
-		if err := pasteCmd.Run(); err != nil {
-			return fmt.Errorf("failed to paste buffer: %w", err)
-		}
-		return nil
-	}
-
-	// No newlines, send the text using send-keys with literal mode
-	cmd := exec.Command("tmux", "send-keys", "-t", target, "-l", text)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to send keys: %w", err)
-	}
-	return nil
-}
-
-// SendEnter sends just the Enter key to a window
-func (c *Client) SendEnter(session, windowName string) error {
-	target := fmt.Sprintf("%s:%s", session, windowName)
-	cmd := exec.Command("tmux", "send-keys", "-t", target, "C-m")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to send enter: %w", err)
-	}
-	return nil
-}
-
-// SendKeysLiteralWithEnter sends text + Enter atomically using shell command chaining.
-// This prevents race conditions where Enter might be lost between separate exec calls.
-// Uses sh -c with && to chain tmux commands in a single shell execution.
-// This approach works reliably for both single-line and multiline messages.
-func (c *Client) SendKeysLiteralWithEnter(session, windowName, text string) error {
-	target := fmt.Sprintf("%s:%s", session, windowName)
-
-	// Use sh -c to chain tmux commands atomically with &&
-	// The text is passed as $1 to avoid shell escaping issues with special characters
-	// Commands: set-buffer (load text) -> paste-buffer (insert to pane) -> send-keys Enter (submit)
-	cmdStr := fmt.Sprintf("tmux set-buffer -- \"$1\" && tmux paste-buffer -t %s && tmux send-keys -t %s Enter",
-		target, target)
-	cmd := exec.Command("sh", "-c", cmdStr, "sh", text)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to send keys atomically: %w", err)
-	}
-	return nil
-}
-
-// ListSessions returns a list of all tmux sessions
-func (c *Client) ListSessions() ([]string, error) {
-	cmd := exec.Command("tmux", "list-sessions", "-F", "#{session_name}")
-	output, err := cmd.Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			// No sessions running
-			if exitErr.ExitCode() == 1 {
-				return []string{}, nil
-			}
-		}
-		return nil, fmt.Errorf("failed to list sessions: %w", err)
-	}
-
-	sessions := strings.Split(strings.TrimSpace(string(output)), "\n")
-	if len(sessions) == 1 && sessions[0] == "" {
-		return []string{}, nil
-	}
-	return sessions, nil
-}
-
-// ListWindows returns a list of windows in a session
-func (c *Client) ListWindows(session string) ([]string, error) {
-	cmd := exec.Command("tmux", "list-windows", "-t", session, "-F", "#{window_name}")
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list windows: %w", err)
-	}
-
-	windows := strings.Split(strings.TrimSpace(string(output)), "\n")
-	if len(windows) == 1 && windows[0] == "" {
-		return []string{}, nil
-	}
-	return windows, nil
-}
-
-// IsTmuxAvailable checks if tmux is installed and available
-func (c *Client) IsTmuxAvailable() bool {
-	cmd := exec.Command("tmux", "-V")
-	return cmd.Run() == nil
-}
-
-// GetPaneInfo returns information about a pane
+// PaneInfo is kept for backward compatibility.
+// Deprecated: This type was unused and is kept only for API compatibility.
 type PaneInfo struct {
 	PID int
-}
-
-// GetPanePID gets the PID of the process running in a pane
-func (c *Client) GetPanePID(session, windowName string) (int, error) {
-	target := fmt.Sprintf("%s:%s", session, windowName)
-	cmd := exec.Command("tmux", "display-message", "-t", target, "-p", "#{pane_pid}")
-	output, err := cmd.Output()
-	if err != nil {
-		return 0, fmt.Errorf("failed to get pane PID: %w", err)
-	}
-
-	var pid int
-	if _, err := fmt.Sscanf(strings.TrimSpace(string(output)), "%d", &pid); err != nil {
-		return 0, fmt.Errorf("failed to parse PID: %w", err)
-	}
-
-	return pid, nil
-}
-
-// StartPipePane sets up pipe-pane to capture output to a file
-// The output is appended to the file, so it persists across daemon restarts
-func (c *Client) StartPipePane(session, windowName, outputFile string) error {
-	target := fmt.Sprintf("%s:%s", session, windowName)
-	// Use -o to open a pipe (output only, not input)
-	// cat >> appends to the file so output is preserved
-	cmd := exec.Command("tmux", "pipe-pane", "-o", "-t", target, fmt.Sprintf("cat >> '%s'", outputFile))
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to start pipe-pane: %w", err)
-	}
-	return nil
-}
-
-// StopPipePane stops the pipe-pane for a window
-func (c *Client) StopPipePane(session, windowName string) error {
-	target := fmt.Sprintf("%s:%s", session, windowName)
-	// Running pipe-pane with no command stops any existing pipe
-	cmd := exec.Command("tmux", "pipe-pane", "-t", target)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to stop pipe-pane: %w", err)
-	}
-	return nil
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -9,11 +9,12 @@ import (
 	"time"
 )
 
+// These tests verify that the internal/tmux package correctly re-exports
+// functionality from pkg/tmux. The comprehensive tests are in pkg/tmux.
+
 // TestMain ensures clean tmux environment for tests
 func TestMain(m *testing.M) {
 	// Skip tmux integration tests in CI environments unless TMUX_TESTS=1 is set
-	// CI environments (like GitHub Actions) often have tmux installed but without
-	// proper terminal support, causing flaky session creation failures
 	if os.Getenv("CI") != "" && os.Getenv("TMUX_TESTS") != "1" {
 		fmt.Fprintln(os.Stderr, "Skipping tmux tests in CI (set TMUX_TESTS=1 to enable)")
 		os.Exit(0)
@@ -25,27 +26,20 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
-	// Verify we can actually create sessions (not just that tmux is installed)
-	// Some environments have tmux installed but unable to create sessions
+	// Verify we can actually create sessions
 	testSession := fmt.Sprintf("test-tmux-probe-%d", time.Now().UnixNano())
 	cmd := exec.Command("tmux", "new-session", "-d", "-s", testSession)
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, "Warning: tmux cannot create sessions (no terminal?), skipping tmux tests")
 		os.Exit(0)
 	}
-	// Clean up probe session
 	exec.Command("tmux", "kill-session", "-t", testSession).Run()
 
-	// Run tests
 	code := m.Run()
-
-	// Cleanup any test sessions that might have leaked
 	cleanupTestSessions()
-
 	os.Exit(code)
 }
 
-// cleanupTestSessions removes any test sessions that leaked
 func cleanupTestSessions() {
 	cmd := exec.Command("tmux", "list-sessions", "-F", "#{session_name}")
 	output, err := cmd.Output()
@@ -61,14 +55,10 @@ func cleanupTestSessions() {
 	}
 }
 
-// uniqueSessionName generates a unique test session name
 func uniqueSessionName() string {
 	return fmt.Sprintf("test-tmux-%d", time.Now().UnixNano())
 }
 
-// waitForSession polls until a session exists or timeout is reached.
-// This handles the race condition where tmux reports success but the session
-// isn't immediately visible in subsequent queries.
 func waitForSession(client *Client, sessionName string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	pollInterval := 10 * time.Millisecond
@@ -86,7 +76,6 @@ func waitForSession(client *Client, sessionName string, timeout time.Duration) e
 	return fmt.Errorf("session %s did not appear within %v", sessionName, timeout)
 }
 
-// waitForNoSession polls until a session no longer exists or timeout is reached.
 func waitForNoSession(client *Client, sessionName string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	pollInterval := 10 * time.Millisecond
@@ -104,25 +93,21 @@ func waitForNoSession(client *Client, sessionName string, timeout time.Duration)
 	return fmt.Errorf("session %s still exists after %v", sessionName, timeout)
 }
 
-func TestIsTmuxAvailable(t *testing.T) {
+// TestReexport verifies that the re-exported types work correctly.
+func TestReexport(t *testing.T) {
 	client := NewClient()
+	if client == nil {
+		t.Fatal("NewClient() returned nil")
+	}
 	if !client.IsTmuxAvailable() {
 		t.Error("Expected tmux to be available")
 	}
 }
 
-func TestHasSession(t *testing.T) {
+// TestBasicOperations verifies core tmux operations through the re-export.
+func TestBasicOperations(t *testing.T) {
 	client := NewClient()
 	sessionName := uniqueSessionName()
-
-	// Session should not exist initially
-	exists, err := client.HasSession(sessionName)
-	if err != nil {
-		t.Fatalf("HasSession failed: %v", err)
-	}
-	if exists {
-		t.Error("Session should not exist initially")
-	}
 
 	// Create session
 	if err := client.CreateSession(sessionName, true); err != nil {
@@ -130,61 +115,9 @@ func TestHasSession(t *testing.T) {
 	}
 	defer client.KillSession(sessionName)
 
-	// Wait for session to be visible (handles tmux timing race)
 	if err := waitForSession(client, sessionName, 2*time.Second); err != nil {
-		t.Fatalf("Session not visible after creation: %v", err)
+		t.Fatalf("Session not visible: %v", err)
 	}
-
-	// Session should now exist
-	exists, err = client.HasSession(sessionName)
-	if err != nil {
-		t.Fatalf("HasSession failed: %v", err)
-	}
-	if !exists {
-		t.Error("Session should exist after creation")
-	}
-}
-
-func TestCreateSession(t *testing.T) {
-	client := NewClient()
-	sessionName := uniqueSessionName()
-
-	// Create detached session
-	if err := client.CreateSession(sessionName, true); err != nil {
-		t.Fatalf("Failed to create session: %v", err)
-	}
-	defer client.KillSession(sessionName)
-
-	// Wait for session to be visible (handles tmux timing race)
-	if err := waitForSession(client, sessionName, 2*time.Second); err != nil {
-		t.Fatalf("Session not visible after creation: %v", err)
-	}
-
-	// Verify session exists
-	exists, err := client.HasSession(sessionName)
-	if err != nil {
-		t.Fatalf("HasSession failed: %v", err)
-	}
-	if !exists {
-		t.Error("Session should exist after creation")
-	}
-
-	// Creating duplicate session should fail
-	err = client.CreateSession(sessionName, true)
-	if err == nil {
-		t.Error("Creating duplicate session should fail")
-	}
-}
-
-func TestCreateWindow(t *testing.T) {
-	client := NewClient()
-	sessionName := uniqueSessionName()
-
-	// Create session first
-	if err := client.CreateSession(sessionName, true); err != nil {
-		t.Fatalf("Failed to create session: %v", err)
-	}
-	defer client.KillSession(sessionName)
 
 	// Create window
 	windowName := "test-window"
@@ -198,455 +131,79 @@ func TestCreateWindow(t *testing.T) {
 		t.Fatalf("HasWindow failed: %v", err)
 	}
 	if !exists {
-		t.Error("Window should exist after creation")
+		t.Error("Window should exist")
+	}
+
+	// Get PID
+	pid, err := client.GetPanePID(sessionName, windowName)
+	if err != nil {
+		t.Fatalf("GetPanePID failed: %v", err)
+	}
+	if pid <= 0 {
+		t.Errorf("Expected positive PID, got %d", pid)
 	}
 }
 
-func TestHasWindow(t *testing.T) {
-	client := NewClient()
-	sessionName := uniqueSessionName()
-
-	// Create session
-	if err := client.CreateSession(sessionName, true); err != nil {
-		t.Fatalf("Failed to create session: %v", err)
-	}
-	defer client.KillSession(sessionName)
-
-	// Non-existent window should return false
-	exists, err := client.HasWindow(sessionName, "nonexistent")
-	if err != nil {
-		t.Fatalf("HasWindow failed: %v", err)
-	}
-	if exists {
-		t.Error("Non-existent window should return false")
-	}
-
-	// Create window
-	windowName := "test-window"
-	if err := client.CreateWindow(sessionName, windowName); err != nil {
-		t.Fatalf("Failed to create window: %v", err)
-	}
-
-	// Window should now exist
-	exists, err = client.HasWindow(sessionName, windowName)
-	if err != nil {
-		t.Fatalf("HasWindow failed: %v", err)
-	}
-	if !exists {
-		t.Error("Window should exist after creation")
-	}
-}
-
-func TestKillWindow(t *testing.T) {
-	client := NewClient()
-	sessionName := uniqueSessionName()
-
-	// Create session
-	if err := client.CreateSession(sessionName, true); err != nil {
-		t.Fatalf("Failed to create session: %v", err)
-	}
-	defer client.KillSession(sessionName)
-
-	// Create two windows (we need at least 2 to kill one)
-	if err := client.CreateWindow(sessionName, "window1"); err != nil {
-		t.Fatalf("Failed to create window1: %v", err)
-	}
-	if err := client.CreateWindow(sessionName, "window2"); err != nil {
-		t.Fatalf("Failed to create window2: %v", err)
-	}
-
-	// Kill window1
-	if err := client.KillWindow(sessionName, "window1"); err != nil {
-		t.Fatalf("Failed to kill window: %v", err)
-	}
-
-	// Verify window1 no longer exists
-	exists, err := client.HasWindow(sessionName, "window1")
-	if err != nil {
-		t.Fatalf("HasWindow failed: %v", err)
-	}
-	if exists {
-		t.Error("Window should not exist after killing")
-	}
-
-	// Verify window2 still exists
-	exists, err = client.HasWindow(sessionName, "window2")
-	if err != nil {
-		t.Fatalf("HasWindow failed: %v", err)
-	}
-	if !exists {
-		t.Error("Window2 should still exist")
-	}
-}
-
-func TestKillSession(t *testing.T) {
-	client := NewClient()
-	sessionName := uniqueSessionName()
-
-	// Create session
-	if err := client.CreateSession(sessionName, true); err != nil {
-		t.Fatalf("Failed to create session: %v", err)
-	}
-
-	// Wait for session to be visible before killing
-	if err := waitForSession(client, sessionName, 2*time.Second); err != nil {
-		t.Fatalf("Session not visible after creation: %v", err)
-	}
-
-	// Kill session
-	if err := client.KillSession(sessionName); err != nil {
-		t.Fatalf("Failed to kill session: %v", err)
-	}
-
-	// Wait for session to be gone (handles tmux timing race)
-	if err := waitForNoSession(client, sessionName, 2*time.Second); err != nil {
-		t.Fatalf("Session still visible after killing: %v", err)
-	}
-
-	// Verify session no longer exists
-	exists, err := client.HasSession(sessionName)
-	if err != nil {
-		t.Fatalf("HasSession failed: %v", err)
-	}
-	if exists {
-		t.Error("Session should not exist after killing")
-	}
-}
-
+// TestSendKeys verifies send keys through the re-export.
 func TestSendKeys(t *testing.T) {
 	client := NewClient()
 	sessionName := uniqueSessionName()
 
-	// Create session with a window running a shell
 	if err := client.CreateSession(sessionName, true); err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}
 	defer client.KillSession(sessionName)
 
-	// Create a window
 	windowName := "test-window"
 	if err := client.CreateWindow(sessionName, windowName); err != nil {
 		t.Fatalf("Failed to create window: %v", err)
 	}
 
-	// Send keys to create a file (this tests that send-keys works)
-	testFile := fmt.Sprintf("/tmp/tmux-test-%d", time.Now().UnixNano())
-	defer os.Remove(testFile)
-
-	if err := client.SendKeys(sessionName, windowName, fmt.Sprintf("touch %s", testFile)); err != nil {
-		t.Fatalf("Failed to send keys: %v", err)
-	}
-
-	// Poll for the file to be created with timeout
-	// CI environments may be slow, so we use a generous timeout with polling
-	timeout := 5 * time.Second
-	pollInterval := 50 * time.Millisecond
-	deadline := time.Now().Add(timeout)
-
-	fileCreated := false
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(testFile); err == nil {
-			fileCreated = true
-			break
-		}
-		time.Sleep(pollInterval)
-	}
-
-	// Verify the file was created (proves send-keys worked)
-	if !fileCreated {
-		t.Error("SendKeys did not execute command - file was not created within timeout")
-	}
-}
-
-func TestSendKeysLiteral(t *testing.T) {
-	client := NewClient()
-	sessionName := uniqueSessionName()
-
-	// Create session
-	if err := client.CreateSession(sessionName, true); err != nil {
-		t.Fatalf("Failed to create session: %v", err)
-	}
-	defer client.KillSession(sessionName)
-
-	// Create a window
-	windowName := "test-window"
-	if err := client.CreateWindow(sessionName, windowName); err != nil {
-		t.Fatalf("Failed to create window: %v", err)
-	}
-
-	// SendKeysLiteral should not execute (no Enter key)
-	// We can't easily verify this without reading pane content,
-	// but we can at least verify it doesn't error
+	// SendKeysLiteral should not error
 	if err := client.SendKeysLiteral(sessionName, windowName, "echo test"); err != nil {
 		t.Fatalf("Failed to send keys literal: %v", err)
 	}
+
+	// SendEnter should not error
+	if err := client.SendEnter(sessionName, windowName); err != nil {
+		t.Fatalf("Failed to send enter: %v", err)
+	}
 }
 
-func TestSendKeysLiteralWithNewlines(t *testing.T) {
+// TestMultilineText verifies multiline text through the re-export.
+func TestMultilineText(t *testing.T) {
 	client := NewClient()
 	sessionName := uniqueSessionName()
 
-	// Create session
 	if err := client.CreateSession(sessionName, true); err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}
 	defer client.KillSession(sessionName)
 
-	// Create a window
 	windowName := "test-window"
 	if err := client.CreateWindow(sessionName, windowName); err != nil {
 		t.Fatalf("Failed to create window: %v", err)
 	}
 
-	// Test sending text with newlines - should not error
+	// Test multiline text
 	multiLineText := "line1\nline2\nline3"
 	if err := client.SendKeysLiteral(sessionName, windowName, multiLineText); err != nil {
 		t.Fatalf("Failed to send multi-line text: %v", err)
 	}
-
-	// Test with empty lines
-	textWithEmptyLines := "first\n\nlast"
-	if err := client.SendKeysLiteral(sessionName, windowName, textWithEmptyLines); err != nil {
-		t.Fatalf("Failed to send text with empty lines: %v", err)
-	}
-
-	// Test with trailing newline
-	textWithTrailingNewline := "content\n"
-	if err := client.SendKeysLiteral(sessionName, windowName, textWithTrailingNewline); err != nil {
-		t.Fatalf("Failed to send text with trailing newline: %v", err)
-	}
 }
 
-func TestListSessions(t *testing.T) {
-	client := NewClient()
-
-	// Create a test session
-	sessionName := uniqueSessionName()
-	if err := client.CreateSession(sessionName, true); err != nil {
-		t.Fatalf("Failed to create session: %v", err)
-	}
-	defer client.KillSession(sessionName)
-
-	// Wait for session to be visible (handles tmux timing race)
-	if err := waitForSession(client, sessionName, 2*time.Second); err != nil {
-		t.Fatalf("Session not visible after creation: %v", err)
-	}
-
-	// List sessions
-	sessions, err := client.ListSessions()
-	if err != nil {
-		t.Fatalf("Failed to list sessions: %v", err)
-	}
-
-	// Our test session should be in the list
-	// Note: We don't check exact count because external processes may create/delete
-	// sessions concurrently, making count-based assertions flaky
-	found := false
-	for _, s := range sessions {
-		if s == sessionName {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("Session %s not found in list: %v", sessionName, sessions)
-	}
-}
-
-func TestListWindows(t *testing.T) {
-	client := NewClient()
-	sessionName := uniqueSessionName()
-
-	// Create session
-	if err := client.CreateSession(sessionName, true); err != nil {
-		t.Fatalf("Failed to create session: %v", err)
-	}
-	defer client.KillSession(sessionName)
-
-	// List windows (should have default window)
-	windows, err := client.ListWindows(sessionName)
-	if err != nil {
-		t.Fatalf("Failed to list windows: %v", err)
-	}
-	if len(windows) == 0 {
-		t.Error("Expected at least one default window")
-	}
-
-	// Create additional windows
-	if err := client.CreateWindow(sessionName, "window1"); err != nil {
-		t.Fatalf("Failed to create window1: %v", err)
-	}
-	if err := client.CreateWindow(sessionName, "window2"); err != nil {
-		t.Fatalf("Failed to create window2: %v", err)
-	}
-
-	// List windows again
-	windows, err = client.ListWindows(sessionName)
-	if err != nil {
-		t.Fatalf("Failed to list windows: %v", err)
-	}
-
-	// Should have at least 3 windows (default + 2 created)
-	if len(windows) < 3 {
-		t.Errorf("Expected at least 3 windows, got %d: %v", len(windows), windows)
-	}
-
-	// Verify our windows are in the list
-	foundWindow1 := false
-	foundWindow2 := false
-	for _, w := range windows {
-		if w == "window1" {
-			foundWindow1 = true
-		}
-		if w == "window2" {
-			foundWindow2 = true
-		}
-	}
-	if !foundWindow1 || !foundWindow2 {
-		t.Errorf("Created windows not found in list: %v", windows)
-	}
-}
-
-func TestGetPanePID(t *testing.T) {
-	client := NewClient()
-	sessionName := uniqueSessionName()
-
-	// Create session
-	if err := client.CreateSession(sessionName, true); err != nil {
-		t.Fatalf("Failed to create session: %v", err)
-	}
-	defer client.KillSession(sessionName)
-
-	// Create a window
-	windowName := "test-window"
-	if err := client.CreateWindow(sessionName, windowName); err != nil {
-		t.Fatalf("Failed to create window: %v", err)
-	}
-
-	// Get pane PID
-	pid, err := client.GetPanePID(sessionName, windowName)
-	if err != nil {
-		t.Fatalf("Failed to get pane PID: %v", err)
-	}
-
-	// PID should be positive
-	if pid <= 0 {
-		t.Errorf("Expected positive PID, got %d", pid)
-	}
-
-	// Verify PID corresponds to a running process
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		t.Errorf("Failed to find process with PID %d: %v", pid, err)
-	}
-	if process == nil {
-		t.Errorf("Process with PID %d not found", pid)
-	}
-}
-
-func TestMultipleSessions(t *testing.T) {
-	client := NewClient()
-
-	// Create multiple test sessions with unique names
-	session1 := fmt.Sprintf("test-tmux-%d-1", time.Now().UnixNano())
-	time.Sleep(1 * time.Millisecond)
-	session2 := fmt.Sprintf("test-tmux-%d-2", time.Now().UnixNano())
-	time.Sleep(1 * time.Millisecond)
-	session3 := fmt.Sprintf("test-tmux-%d-3", time.Now().UnixNano())
-
-	if err := client.CreateSession(session1, true); err != nil {
-		t.Fatalf("Failed to create session1: %v", err)
-	}
-	defer client.KillSession(session1)
-
-	if err := client.CreateSession(session2, true); err != nil {
-		t.Fatalf("Failed to create session2: %v", err)
-	}
-	defer client.KillSession(session2)
-
-	if err := client.CreateSession(session3, true); err != nil {
-		t.Fatalf("Failed to create session3: %v", err)
-	}
-	defer client.KillSession(session3)
-
-	// Verify all sessions exist
-	sessions, err := client.ListSessions()
-	if err != nil {
-		t.Fatalf("Failed to list sessions: %v", err)
-	}
-
-	sessionMap := make(map[string]bool)
-	for _, s := range sessions {
-		sessionMap[s] = true
-	}
-
-	if !sessionMap[session1] || !sessionMap[session2] || !sessionMap[session3] {
-		t.Error("Not all created sessions found in list")
-	}
-
-	// Create windows in different sessions
-	if err := client.CreateWindow(session1, "win1"); err != nil {
-		t.Fatalf("Failed to create window in session1: %v", err)
-	}
-	if err := client.CreateWindow(session2, "win2"); err != nil {
-		t.Fatalf("Failed to create window in session2: %v", err)
-	}
-
-	// Verify windows are in correct sessions
-	hasWin1, _ := client.HasWindow(session1, "win1")
-	hasWin2, _ := client.HasWindow(session2, "win2")
-	hasWin1InSession2, _ := client.HasWindow(session2, "win1")
-
-	if !hasWin1 {
-		t.Error("win1 should exist in session1")
-	}
-	if !hasWin2 {
-		t.Error("win2 should exist in session2")
-	}
-	if hasWin1InSession2 {
-		t.Error("win1 should not exist in session2")
-	}
-}
-
-func TestErrorHandling(t *testing.T) {
-	client := NewClient()
-
-	// Test operations on non-existent session
-	err := client.CreateWindow("nonexistent-session", "window")
-	if err == nil {
-		t.Error("CreateWindow on non-existent session should fail")
-	}
-
-	err = client.KillWindow("nonexistent-session", "window")
-	if err == nil {
-		t.Error("KillWindow on non-existent session should fail")
-	}
-
-	_, err = client.GetPanePID("nonexistent-session", "window")
-	if err == nil {
-		t.Error("GetPanePID on non-existent session should fail")
-	}
-
-	// Test ListWindows on non-existent session
-	_, err = client.ListWindows("nonexistent-session")
-	if err == nil {
-		t.Error("ListWindows on non-existent session should fail")
-	}
-}
-
+// TestPipePane verifies pipe-pane through the re-export.
 func TestPipePane(t *testing.T) {
 	client := NewClient()
 	session := uniqueSessionName()
 	window := "testwindow"
 
-	// Create session with a named window using tmux directly
 	cmd := exec.Command("tmux", "new-session", "-d", "-s", session, "-n", window)
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}
 	defer client.KillSession(session)
 
-	// Create a temp file to capture output
 	tmpFile, err := os.CreateTemp("", "pipe-pane-test-*.log")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
@@ -659,22 +216,20 @@ func TestPipePane(t *testing.T) {
 		t.Fatalf("StartPipePane failed: %v", err)
 	}
 
-	// Send some output to the pane
+	// Send output
 	testMessage := "Hello from pipe-pane test"
 	if err := client.SendKeys(session, window, fmt.Sprintf("echo '%s'", testMessage)); err != nil {
 		t.Fatalf("Failed to send keys: %v", err)
 	}
 
-	// Wait for output to be captured
 	time.Sleep(500 * time.Millisecond)
 
-	// Read the captured output
+	// Read output
 	content, err := os.ReadFile(tmpFile.Name())
 	if err != nil {
 		t.Fatalf("Failed to read output file: %v", err)
 	}
 
-	// Verify the output was captured
 	if !strings.Contains(string(content), testMessage) {
 		t.Errorf("Expected output to contain %q, got %q", testMessage, string(content))
 	}
@@ -682,40 +237,6 @@ func TestPipePane(t *testing.T) {
 	// Stop pipe-pane
 	if err := client.StopPipePane(session, window); err != nil {
 		t.Fatalf("StopPipePane failed: %v", err)
-	}
-
-	// Send more output after stopping
-	if err := client.SendKeys(session, window, "echo 'This should not be captured'"); err != nil {
-		t.Fatalf("Failed to send keys: %v", err)
-	}
-	time.Sleep(500 * time.Millisecond)
-
-	// Verify the file size hasn't changed much (new output shouldn't be captured)
-	content2, err := os.ReadFile(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("Failed to read output file: %v", err)
-	}
-
-	// The file might have grown a bit due to the echo command appearing in the prompt
-	// but the actual "This should not be captured" message should not appear
-	if strings.Contains(string(content2), "This should not be captured") {
-		t.Error("Output was captured after StopPipePane was called")
-	}
-}
-
-func TestPipePaneErrorHandling(t *testing.T) {
-	client := NewClient()
-
-	// Test StartPipePane on non-existent session
-	err := client.StartPipePane("nonexistent-session", "window", "/tmp/test.log")
-	if err == nil {
-		t.Error("StartPipePane on non-existent session should fail")
-	}
-
-	// Test StopPipePane on non-existent session
-	err = client.StopPipePane("nonexistent-session", "window")
-	if err == nil {
-		t.Error("StopPipePane on non-existent session should fail")
 	}
 }
 

--- a/pkg/claude/README.md
+++ b/pkg/claude/README.md
@@ -1,0 +1,178 @@
+# pkg/claude
+
+A Go library for programmatically running and interacting with Claude Code CLI.
+
+## Installation
+
+```bash
+go get github.com/dlorenc/multiclaude/pkg/claude
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "log"
+    "github.com/dlorenc/multiclaude/pkg/claude"
+    "github.com/dlorenc/multiclaude/pkg/tmux"
+)
+
+func main() {
+    // Create terminal runner (tmux)
+    tmuxClient := tmux.NewClient()
+
+    // Create Claude runner
+    runner := claude.NewRunner(
+        claude.WithTerminal(tmuxClient),
+        claude.WithBinaryPath(claude.ResolveBinaryPath()),
+    )
+
+    // Create tmux session and window
+    tmuxClient.CreateSession("my-session", true)
+    defer tmuxClient.KillSession("my-session")
+    tmuxClient.CreateWindow("my-session", "claude")
+
+    // Start Claude
+    result, err := runner.Start("my-session", "claude", claude.Config{
+        SystemPromptFile: "/path/to/prompt.md",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Claude started: session=%s, pid=%d", result.SessionID, result.PID)
+
+    // Send a message
+    if err := runner.SendMessage("my-session", "claude", "Hello, Claude!"); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+## Key Features
+
+### TerminalRunner Interface
+
+The package uses the `TerminalRunner` interface to abstract terminal operations:
+
+```go
+type TerminalRunner interface {
+    SendKeys(session, window, text string) error
+    SendKeysLiteral(session, window, text string) error
+    SendEnter(session, window string) error
+    GetPanePID(session, window string) (int, error)
+    StartPipePane(session, window, outputFile string) error
+    StopPipePane(session, window string) error
+}
+```
+
+The `pkg/tmux.Client` implements this interface, but you can create custom implementations for other terminal emulators.
+
+### Session ID Management
+
+Each Claude instance gets a unique UUID v4 session ID:
+
+```go
+// Generate a new session ID
+sessionID, err := claude.GenerateSessionID()
+
+// Or let Start() generate one
+result, _ := runner.Start("session", "window", claude.Config{})
+fmt.Println(result.SessionID)
+
+// Or provide your own
+result, _ := runner.Start("session", "window", claude.Config{
+    SessionID: "my-custom-id",
+})
+```
+
+### Output Capture
+
+Capture Claude's output to a file:
+
+```go
+result, err := runner.Start("session", "window", claude.Config{
+    OutputFile: "/tmp/claude-output.log",
+})
+```
+
+### Multiline Messages
+
+The `SendMessage` method properly handles multiline text:
+
+```go
+message := `Please review this code:
+
+func hello() {
+    fmt.Println("Hello, World!")
+}
+
+What improvements would you suggest?`
+
+runner.SendMessage("session", "window", message)
+```
+
+## Configuration Options
+
+```go
+runner := claude.NewRunner(
+    // Path to claude binary (default: "claude")
+    claude.WithBinaryPath("/usr/local/bin/claude"),
+
+    // Terminal runner (required for Start/SendMessage)
+    claude.WithTerminal(tmuxClient),
+
+    // Time to wait after starting before getting PID (default: 500ms)
+    claude.WithStartupDelay(1 * time.Second),
+
+    // Time to wait before sending initial message (default: 1s)
+    claude.WithMessageDelay(2 * time.Second),
+
+    // Whether to skip permission prompts (default: true)
+    claude.WithPermissions(true),
+)
+```
+
+## CLI Flags
+
+The runner constructs Claude commands with these flags:
+
+| Flag | Description |
+|------|-------------|
+| `--session-id <uuid>` | Unique session identifier |
+| `--dangerously-skip-permissions` | Skip interactive permission prompts |
+| `--append-system-prompt-file <path>` | Path to system prompt file |
+
+## Prompt Building
+
+For building complex prompts, see the `pkg/claude/prompt` subpackage:
+
+```go
+import "github.com/dlorenc/multiclaude/pkg/claude/prompt"
+
+builder := prompt.NewBuilder()
+builder.AddSection("Role", "You are a helpful coding assistant.")
+builder.AddSection("Context", "Working on a Go project.")
+
+promptText := builder.Build()
+```
+
+## Use Cases
+
+- Running multiple Claude instances in parallel
+- Automated code review with Claude
+- CI/CD integration
+- Interactive development assistants
+- Pair programming automation
+
+## Requirements
+
+- Claude Code CLI installed and in PATH
+- tmux (if using tmux as terminal runner)
+- Go 1.21 or later
+
+## License
+
+See the main project LICENSE file.

--- a/pkg/claude/doc.go
+++ b/pkg/claude/doc.go
@@ -1,0 +1,85 @@
+// Package claude provides utilities for programmatically running Claude Code CLI.
+//
+// This package abstracts the details of launching and interacting with Claude Code
+// instances running in terminal emulators. It handles:
+//
+//   - CLI flag construction (--session-id, --dangerously-skip-permissions, --append-system-prompt-file)
+//   - Session ID generation (UUID v4)
+//   - Startup timing quirks
+//   - Terminal integration via the [TerminalRunner] interface
+//
+// # Installation
+//
+//	go get github.com/dlorenc/multiclaude/pkg/claude
+//
+// # Requirements
+//
+// This package requires the Claude Code CLI to be installed. The binary is typically
+// named "claude" and should be available in PATH. Use [ResolveBinaryPath] to find it.
+//
+// # Example Usage
+//
+//	package main
+//
+//	import (
+//	    "log"
+//	    "github.com/dlorenc/multiclaude/pkg/claude"
+//	    "github.com/dlorenc/multiclaude/pkg/tmux"
+//	)
+//
+//	func main() {
+//	    // Create terminal runner (tmux in this case)
+//	    tmuxClient := tmux.NewClient()
+//
+//	    // Create Claude runner with tmux as the terminal
+//	    runner := claude.NewRunner(
+//	        claude.WithTerminal(tmuxClient),
+//	        claude.WithBinaryPath(claude.ResolveBinaryPath()),
+//	    )
+//
+//	    // Prepare a session
+//	    tmuxClient.CreateSession("demo", true)
+//	    tmuxClient.CreateWindow("demo", "claude")
+//
+//	    // Start Claude
+//	    result, err := runner.Start("demo", "claude", claude.Config{
+//	        SystemPromptFile: "/path/to/prompt.md",
+//	        OutputFile:       "/tmp/claude-output.log",
+//	    })
+//	    if err != nil {
+//	        log.Fatal(err)
+//	    }
+//
+//	    log.Printf("Claude started with session ID: %s, PID: %d", result.SessionID, result.PID)
+//
+//	    // Send a message
+//	    if err := runner.SendMessage("demo", "claude", "Hello, Claude!"); err != nil {
+//	        log.Fatal(err)
+//	    }
+//	}
+//
+// # The TerminalRunner Interface
+//
+// The [TerminalRunner] interface abstracts terminal operations, allowing this package
+// to work with any terminal emulator that implements it. The [pkg/tmux.Client] provides
+// a ready-to-use implementation for tmux.
+//
+// # Session Management
+//
+// Each Claude instance is identified by a session ID (UUID v4). This allows:
+//
+//   - Resuming sessions across process restarts
+//   - Tracking multiple concurrent Claude instances
+//   - Correlating logs with specific sessions
+//
+// Use [GenerateSessionID] to create new session IDs, or provide your own via [Config.SessionID].
+//
+// # Timing Considerations
+//
+// Starting Claude and sending messages requires careful timing:
+//
+//   - [Runner.StartupDelay] (default 500ms): Wait after launching before getting PID
+//   - [Runner.MessageDelay] (default 1s): Wait before sending initial message
+//
+// These can be adjusted via [WithStartupDelay] and [WithMessageDelay] options.
+package claude

--- a/pkg/claude/prompt/builder.go
+++ b/pkg/claude/prompt/builder.go
@@ -1,0 +1,228 @@
+// Package prompt provides utilities for building Claude system prompts.
+//
+// This package helps construct layered prompts by combining:
+//   - Default prompts (embedded in code)
+//   - Custom prompts (from repository configuration)
+//   - Dynamic sections (CLI docs, context, etc.)
+//
+// # Quick Start
+//
+//	builder := prompt.NewBuilder()
+//	builder.AddSection("Role", "You are a helpful coding assistant.")
+//	builder.AddSection("Guidelines", "Write clean, readable code.")
+//	text := builder.Build()
+package prompt
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Builder constructs layered system prompts for Claude.
+type Builder struct {
+	sections []section
+}
+
+type section struct {
+	header  string
+	content string
+}
+
+// NewBuilder creates a new prompt builder.
+func NewBuilder() *Builder {
+	return &Builder{}
+}
+
+// AddSection adds a named section to the prompt.
+// The section header will be formatted as a markdown header (## header).
+func (b *Builder) AddSection(header, content string) *Builder {
+	if content != "" {
+		b.sections = append(b.sections, section{header: header, content: content})
+	}
+	return b
+}
+
+// AddRaw adds raw content without a section header.
+func (b *Builder) AddRaw(content string) *Builder {
+	if content != "" {
+		b.sections = append(b.sections, section{content: content})
+	}
+	return b
+}
+
+// Build constructs the final prompt string.
+func (b *Builder) Build() string {
+	var parts []string
+	for _, s := range b.sections {
+		if s.header != "" {
+			parts = append(parts, fmt.Sprintf("## %s\n\n%s", s.header, s.content))
+		} else {
+			parts = append(parts, s.content)
+		}
+	}
+	return strings.Join(parts, "\n\n---\n\n")
+}
+
+// Len returns the number of sections in the builder.
+func (b *Builder) Len() int {
+	return len(b.sections)
+}
+
+// Clear removes all sections from the builder.
+func (b *Builder) Clear() *Builder {
+	b.sections = nil
+	return b
+}
+
+// AgentType represents the type of agent for prompt loading.
+type AgentType string
+
+// Standard agent types.
+const (
+	TypeSupervisor AgentType = "supervisor"
+	TypeWorker     AgentType = "worker"
+	TypeMergeQueue AgentType = "merge-queue"
+	TypeWorkspace  AgentType = "workspace"
+	TypeReview     AgentType = "review"
+)
+
+// Loader loads prompts from the filesystem.
+type Loader struct {
+	// DefaultPrompts maps agent types to their default prompts.
+	// These are typically embedded in the application.
+	DefaultPrompts map[AgentType]string
+
+	// CustomPromptDir is the directory to look for custom prompts.
+	// Custom prompts are loaded from <dir>/<AGENT_TYPE>.md
+	CustomPromptDir string
+}
+
+// NewLoader creates a new prompt loader.
+func NewLoader() *Loader {
+	return &Loader{
+		DefaultPrompts: make(map[AgentType]string),
+	}
+}
+
+// SetDefault sets the default prompt for an agent type.
+func (l *Loader) SetDefault(agentType AgentType, content string) *Loader {
+	l.DefaultPrompts[agentType] = content
+	return l
+}
+
+// SetCustomDir sets the directory for custom prompts.
+func (l *Loader) SetCustomDir(dir string) *Loader {
+	l.CustomPromptDir = dir
+	return l
+}
+
+// customPromptFilename returns the filename for a custom prompt.
+func customPromptFilename(agentType AgentType) string {
+	switch agentType {
+	case TypeSupervisor:
+		return "SUPERVISOR.md"
+	case TypeWorker:
+		return "WORKER.md"
+	case TypeMergeQueue:
+		return "REVIEWER.md"
+	case TypeWorkspace:
+		return "WORKSPACE.md"
+	case TypeReview:
+		return "REVIEW.md"
+	default:
+		return ""
+	}
+}
+
+// LoadCustom loads a custom prompt from the configured directory.
+// Returns empty string if the file doesn't exist.
+func (l *Loader) LoadCustom(agentType AgentType) (string, error) {
+	if l.CustomPromptDir == "" {
+		return "", nil
+	}
+
+	filename := customPromptFilename(agentType)
+	if filename == "" {
+		return "", fmt.Errorf("unknown agent type: %s", agentType)
+	}
+
+	path := filepath.Join(l.CustomPromptDir, filename)
+
+	// Check if file exists
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return "", nil
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read custom prompt: %w", err)
+	}
+
+	return string(content), nil
+}
+
+// Load loads the complete prompt for an agent type.
+// It combines the default prompt with any custom prompt from the configured directory.
+func (l *Loader) Load(agentType AgentType) (string, error) {
+	builder := NewBuilder()
+
+	// Add default prompt
+	if defaultPrompt, ok := l.DefaultPrompts[agentType]; ok {
+		builder.AddRaw(defaultPrompt)
+	}
+
+	// Add custom prompt if it exists
+	customPrompt, err := l.LoadCustom(agentType)
+	if err != nil {
+		return "", err
+	}
+	if customPrompt != "" {
+		builder.AddSection("Repository-specific instructions", customPrompt)
+	}
+
+	return builder.Build(), nil
+}
+
+// LoadWithExtras loads a prompt with additional sections.
+// extras is a map of section headers to content.
+func (l *Loader) LoadWithExtras(agentType AgentType, extras map[string]string) (string, error) {
+	builder := NewBuilder()
+
+	// Add default prompt
+	if defaultPrompt, ok := l.DefaultPrompts[agentType]; ok {
+		builder.AddRaw(defaultPrompt)
+	}
+
+	// Add extra sections
+	for header, content := range extras {
+		builder.AddSection(header, content)
+	}
+
+	// Add custom prompt if it exists
+	customPrompt, err := l.LoadCustom(agentType)
+	if err != nil {
+		return "", err
+	}
+	if customPrompt != "" {
+		builder.AddSection("Repository-specific instructions", customPrompt)
+	}
+
+	return builder.Build(), nil
+}
+
+// WriteToFile writes the prompt to a file.
+func WriteToFile(path, content string) error {
+	// Ensure parent directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create prompt directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write prompt file: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/claude/prompt/builder_test.go
+++ b/pkg/claude/prompt/builder_test.go
@@ -1,0 +1,406 @@
+package prompt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewBuilder(t *testing.T) {
+	b := NewBuilder()
+	if b == nil {
+		t.Fatal("NewBuilder() returned nil")
+	}
+	if b.Len() != 0 {
+		t.Errorf("expected empty builder, got %d sections", b.Len())
+	}
+}
+
+func TestBuilderAddSection(t *testing.T) {
+	b := NewBuilder()
+	b.AddSection("Role", "You are a helpful assistant.")
+	b.AddSection("Guidelines", "Write clean code.")
+
+	if b.Len() != 2 {
+		t.Errorf("expected 2 sections, got %d", b.Len())
+	}
+
+	result := b.Build()
+	if !strings.Contains(result, "## Role") {
+		t.Error("expected result to contain '## Role'")
+	}
+	if !strings.Contains(result, "You are a helpful assistant.") {
+		t.Error("expected result to contain role content")
+	}
+	if !strings.Contains(result, "## Guidelines") {
+		t.Error("expected result to contain '## Guidelines'")
+	}
+}
+
+func TestBuilderAddSectionEmpty(t *testing.T) {
+	b := NewBuilder()
+	b.AddSection("Empty", "")
+	b.AddSection("Role", "Content")
+
+	// Empty section should be skipped
+	if b.Len() != 1 {
+		t.Errorf("expected 1 section (empty skipped), got %d", b.Len())
+	}
+}
+
+func TestBuilderAddRaw(t *testing.T) {
+	b := NewBuilder()
+	b.AddRaw("Raw content without header")
+
+	result := b.Build()
+	if !strings.Contains(result, "Raw content without header") {
+		t.Error("expected result to contain raw content")
+	}
+	if strings.Contains(result, "## ") {
+		t.Error("raw content should not have a header")
+	}
+}
+
+func TestBuilderAddRawEmpty(t *testing.T) {
+	b := NewBuilder()
+	b.AddRaw("")
+
+	if b.Len() != 0 {
+		t.Errorf("expected 0 sections (empty skipped), got %d", b.Len())
+	}
+}
+
+func TestBuilderBuild(t *testing.T) {
+	b := NewBuilder()
+	b.AddSection("First", "First content")
+	b.AddSection("Second", "Second content")
+
+	result := b.Build()
+
+	// Sections should be separated by ---
+	if !strings.Contains(result, "---") {
+		t.Error("expected sections to be separated by ---")
+	}
+
+	// Check order
+	firstIdx := strings.Index(result, "First content")
+	secondIdx := strings.Index(result, "Second content")
+	if firstIdx > secondIdx {
+		t.Error("expected first section to come before second")
+	}
+}
+
+func TestBuilderBuildEmpty(t *testing.T) {
+	b := NewBuilder()
+	result := b.Build()
+
+	if result != "" {
+		t.Errorf("expected empty string from empty builder, got %q", result)
+	}
+}
+
+func TestBuilderChaining(t *testing.T) {
+	result := NewBuilder().
+		AddSection("A", "Content A").
+		AddSection("B", "Content B").
+		AddRaw("Raw").
+		Build()
+
+	if !strings.Contains(result, "Content A") {
+		t.Error("expected result to contain Content A")
+	}
+	if !strings.Contains(result, "Content B") {
+		t.Error("expected result to contain Content B")
+	}
+	if !strings.Contains(result, "Raw") {
+		t.Error("expected result to contain Raw")
+	}
+}
+
+func TestBuilderClear(t *testing.T) {
+	b := NewBuilder()
+	b.AddSection("Test", "Content")
+	b.Clear()
+
+	if b.Len() != 0 {
+		t.Errorf("expected 0 sections after clear, got %d", b.Len())
+	}
+}
+
+func TestNewLoader(t *testing.T) {
+	l := NewLoader()
+	if l == nil {
+		t.Fatal("NewLoader() returned nil")
+	}
+	if l.DefaultPrompts == nil {
+		t.Error("DefaultPrompts should be initialized")
+	}
+}
+
+func TestLoaderSetDefault(t *testing.T) {
+	l := NewLoader()
+	l.SetDefault(TypeSupervisor, "Default supervisor prompt")
+
+	if l.DefaultPrompts[TypeSupervisor] != "Default supervisor prompt" {
+		t.Error("expected default prompt to be set")
+	}
+}
+
+func TestLoaderSetCustomDir(t *testing.T) {
+	l := NewLoader()
+	l.SetCustomDir("/path/to/prompts")
+
+	if l.CustomPromptDir != "/path/to/prompts" {
+		t.Error("expected custom dir to be set")
+	}
+}
+
+func TestLoaderLoad(t *testing.T) {
+	l := NewLoader()
+	l.SetDefault(TypeSupervisor, "You are a supervisor.")
+
+	result, err := l.Load(TypeSupervisor)
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if !strings.Contains(result, "You are a supervisor.") {
+		t.Error("expected result to contain default prompt")
+	}
+}
+
+func TestLoaderLoadWithCustomPrompt(t *testing.T) {
+	// Create temp directory with custom prompt
+	tmpDir, err := os.MkdirTemp("", "prompt-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	customContent := "Custom supervisor instructions."
+	if err := os.WriteFile(filepath.Join(tmpDir, "SUPERVISOR.md"), []byte(customContent), 0644); err != nil {
+		t.Fatalf("failed to write custom prompt: %v", err)
+	}
+
+	l := NewLoader()
+	l.SetDefault(TypeSupervisor, "Default supervisor prompt")
+	l.SetCustomDir(tmpDir)
+
+	result, err := l.Load(TypeSupervisor)
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	// Should contain both default and custom
+	if !strings.Contains(result, "Default supervisor prompt") {
+		t.Error("expected result to contain default prompt")
+	}
+	if !strings.Contains(result, "Custom supervisor instructions.") {
+		t.Error("expected result to contain custom prompt")
+	}
+	if !strings.Contains(result, "Repository-specific instructions") {
+		t.Error("expected result to have custom prompt section header")
+	}
+}
+
+func TestLoaderLoadCustom(t *testing.T) {
+	// Create temp directory with custom prompt
+	tmpDir, err := os.MkdirTemp("", "prompt-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	customContent := "Custom worker instructions."
+	if err := os.WriteFile(filepath.Join(tmpDir, "WORKER.md"), []byte(customContent), 0644); err != nil {
+		t.Fatalf("failed to write custom prompt: %v", err)
+	}
+
+	l := NewLoader()
+	l.SetCustomDir(tmpDir)
+
+	result, err := l.LoadCustom(TypeWorker)
+	if err != nil {
+		t.Fatalf("LoadCustom() failed: %v", err)
+	}
+
+	if result != customContent {
+		t.Errorf("expected %q, got %q", customContent, result)
+	}
+}
+
+func TestLoaderLoadCustomMissing(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "prompt-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	l := NewLoader()
+	l.SetCustomDir(tmpDir)
+
+	result, err := l.LoadCustom(TypeSupervisor)
+	if err != nil {
+		t.Fatalf("LoadCustom() failed: %v", err)
+	}
+
+	// Should return empty string for missing file
+	if result != "" {
+		t.Errorf("expected empty string for missing file, got %q", result)
+	}
+}
+
+func TestLoaderLoadCustomNoDir(t *testing.T) {
+	l := NewLoader()
+	// No custom dir set
+
+	result, err := l.LoadCustom(TypeSupervisor)
+	if err != nil {
+		t.Fatalf("LoadCustom() failed: %v", err)
+	}
+
+	if result != "" {
+		t.Errorf("expected empty string when no custom dir, got %q", result)
+	}
+}
+
+func TestLoaderLoadCustomUnknownType(t *testing.T) {
+	l := NewLoader()
+	l.SetCustomDir("/tmp")
+
+	_, err := l.LoadCustom(AgentType("unknown"))
+	if err == nil {
+		t.Error("expected error for unknown agent type")
+	}
+}
+
+func TestLoaderLoadWithExtras(t *testing.T) {
+	l := NewLoader()
+	l.SetDefault(TypeWorker, "Default worker prompt")
+
+	extras := map[string]string{
+		"CLI Documentation":  "Available commands: ...",
+		"Additional Context": "Some context here.",
+	}
+
+	result, err := l.LoadWithExtras(TypeWorker, extras)
+	if err != nil {
+		t.Fatalf("LoadWithExtras() failed: %v", err)
+	}
+
+	if !strings.Contains(result, "Default worker prompt") {
+		t.Error("expected result to contain default prompt")
+	}
+	if !strings.Contains(result, "CLI Documentation") {
+		t.Error("expected result to contain extras header")
+	}
+	if !strings.Contains(result, "Available commands:") {
+		t.Error("expected result to contain extras content")
+	}
+}
+
+func TestCustomPromptFilename(t *testing.T) {
+	tests := []struct {
+		agentType AgentType
+		expected  string
+	}{
+		{TypeSupervisor, "SUPERVISOR.md"},
+		{TypeWorker, "WORKER.md"},
+		{TypeMergeQueue, "REVIEWER.md"},
+		{TypeWorkspace, "WORKSPACE.md"},
+		{TypeReview, "REVIEW.md"},
+		{AgentType("unknown"), ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.agentType), func(t *testing.T) {
+			result := customPromptFilename(tc.agentType)
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestWriteToFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "prompt-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Test writing to nested directory (should create it)
+	path := filepath.Join(tmpDir, "nested", "dir", "prompt.md")
+	content := "Test prompt content"
+
+	if err := WriteToFile(path, content); err != nil {
+		t.Fatalf("WriteToFile() failed: %v", err)
+	}
+
+	// Verify file exists and has correct content
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+
+	if string(data) != content {
+		t.Errorf("expected %q, got %q", content, string(data))
+	}
+}
+
+func TestWriteToFileExisting(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "prompt-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	path := filepath.Join(tmpDir, "prompt.md")
+
+	// Write first content
+	if err := WriteToFile(path, "First"); err != nil {
+		t.Fatalf("WriteToFile() failed: %v", err)
+	}
+
+	// Overwrite with new content
+	if err := WriteToFile(path, "Second"); err != nil {
+		t.Fatalf("WriteToFile() failed: %v", err)
+	}
+
+	// Verify new content
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+
+	if string(data) != "Second" {
+		t.Errorf("expected 'Second', got %q", string(data))
+	}
+}
+
+func TestLoaderChaining(t *testing.T) {
+	l := NewLoader().
+		SetDefault(TypeSupervisor, "Default").
+		SetCustomDir("/tmp")
+
+	if l.DefaultPrompts[TypeSupervisor] != "Default" {
+		t.Error("chained SetDefault failed")
+	}
+	if l.CustomPromptDir != "/tmp" {
+		t.Error("chained SetCustomDir failed")
+	}
+}
+
+// BenchmarkBuilderBuild measures the performance of building prompts.
+func BenchmarkBuilderBuild(b *testing.B) {
+	builder := NewBuilder().
+		AddSection("Section 1", strings.Repeat("Content ", 100)).
+		AddSection("Section 2", strings.Repeat("Content ", 100)).
+		AddSection("Section 3", strings.Repeat("Content ", 100))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		builder.Build()
+	}
+}

--- a/pkg/claude/runner.go
+++ b/pkg/claude/runner.go
@@ -1,0 +1,294 @@
+// Package claude provides utilities for programmatically running Claude Code CLI.
+//
+// This package abstracts the details of launching and interacting with Claude Code
+// instances running in terminal emulators like tmux. It handles:
+//
+//   - CLI flag construction
+//   - Session ID generation
+//   - Startup timing quirks
+//   - Terminal integration via the TerminalRunner interface
+//
+// # Quick Start
+//
+//	import (
+//	    "github.com/dlorenc/multiclaude/pkg/claude"
+//	    "github.com/dlorenc/multiclaude/pkg/tmux"
+//	)
+//
+//	// Create a tmux client and claude runner
+//	tmuxClient := tmux.NewClient()
+//	runner := claude.NewRunner(claude.WithTerminal(tmuxClient))
+//
+//	// Start Claude in a tmux session
+//	config := claude.Config{
+//	    WorkDir:      "/path/to/workspace",
+//	    SystemPrompt: "You are a helpful coding assistant.",
+//	}
+//	pid, err := runner.Start("my-session", "claude-window", config)
+package claude
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// TerminalRunner abstracts terminal interaction for running Claude.
+// The tmux.Client implements this interface.
+type TerminalRunner interface {
+	// SendKeys sends text followed by Enter to submit.
+	SendKeys(session, window, text string) error
+
+	// SendKeysLiteral sends text without pressing Enter (supports multiline via paste-buffer).
+	SendKeysLiteral(session, window, text string) error
+
+	// SendEnter sends just the Enter key.
+	SendEnter(session, window string) error
+
+	// GetPanePID gets the process ID running in a pane.
+	GetPanePID(session, window string) (int, error)
+
+	// StartPipePane starts capturing pane output to a file.
+	StartPipePane(session, window, outputFile string) error
+
+	// StopPipePane stops capturing pane output.
+	StopPipePane(session, window string) error
+}
+
+// Runner manages Claude Code instances.
+type Runner struct {
+	// BinaryPath is the path to the claude binary.
+	// Defaults to "claude" (relies on PATH).
+	BinaryPath string
+
+	// Terminal is the terminal runner for sending commands.
+	Terminal TerminalRunner
+
+	// StartupDelay is how long to wait after starting Claude before
+	// attempting to get the PID. Defaults to 500ms.
+	StartupDelay time.Duration
+
+	// MessageDelay is how long to wait after startup before sending
+	// the first message. Defaults to 1s.
+	MessageDelay time.Duration
+
+	// SkipPermissions controls whether to pass --dangerously-skip-permissions.
+	// This is required for non-interactive use. Defaults to true.
+	SkipPermissions bool
+}
+
+// RunnerOption is a functional option for configuring a Runner.
+type RunnerOption func(*Runner)
+
+// WithBinaryPath sets a custom path to the claude binary.
+func WithBinaryPath(path string) RunnerOption {
+	return func(r *Runner) {
+		r.BinaryPath = path
+	}
+}
+
+// WithTerminal sets the terminal runner.
+func WithTerminal(t TerminalRunner) RunnerOption {
+	return func(r *Runner) {
+		r.Terminal = t
+	}
+}
+
+// WithStartupDelay sets the startup delay.
+func WithStartupDelay(d time.Duration) RunnerOption {
+	return func(r *Runner) {
+		r.StartupDelay = d
+	}
+}
+
+// WithMessageDelay sets the message delay.
+func WithMessageDelay(d time.Duration) RunnerOption {
+	return func(r *Runner) {
+		r.MessageDelay = d
+	}
+}
+
+// WithPermissions controls whether to skip permission checks.
+// Set to false to require interactive permission prompts.
+func WithPermissions(skip bool) RunnerOption {
+	return func(r *Runner) {
+		r.SkipPermissions = skip
+	}
+}
+
+// NewRunner creates a new Claude runner with the given options.
+func NewRunner(opts ...RunnerOption) *Runner {
+	r := &Runner{
+		BinaryPath:      "claude",
+		StartupDelay:    500 * time.Millisecond,
+		MessageDelay:    1 * time.Second,
+		SkipPermissions: true,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// ResolveBinaryPath attempts to find the claude binary in PATH.
+// Returns the full path if found, otherwise returns "claude".
+func ResolveBinaryPath() string {
+	if path, err := exec.LookPath("claude"); err == nil {
+		return path
+	}
+	return "claude"
+}
+
+// Config contains configuration for starting a Claude instance.
+type Config struct {
+	// SessionID is the unique identifier for this Claude session.
+	// If empty, a new UUID will be generated.
+	SessionID string
+
+	// WorkDir is the working directory for Claude.
+	// If empty, uses the current directory.
+	WorkDir string
+
+	// SystemPromptFile is the path to a file containing the system prompt.
+	// This is passed via --append-system-prompt-file.
+	SystemPromptFile string
+
+	// InitialMessage is an optional message to send to Claude after startup.
+	// If non-empty, sent after MessageDelay.
+	InitialMessage string
+
+	// OutputFile is the path to capture Claude's output.
+	// If non-empty, StartPipePane is called with this file.
+	OutputFile string
+}
+
+// StartResult contains information about a started Claude instance.
+type StartResult struct {
+	// SessionID is the session ID used for this Claude instance.
+	SessionID string
+
+	// PID is the process ID of the Claude process.
+	PID int
+
+	// Command is the full command that was executed.
+	Command string
+}
+
+// Start launches Claude in the specified tmux session/window.
+func (r *Runner) Start(session, window string, cfg Config) (*StartResult, error) {
+	if r.Terminal == nil {
+		return nil, fmt.Errorf("terminal runner not configured")
+	}
+
+	// Generate session ID if not provided
+	sessionID := cfg.SessionID
+	if sessionID == "" {
+		var err error
+		sessionID, err = GenerateSessionID()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate session ID: %w", err)
+		}
+	}
+
+	// Build the command
+	cmd := r.buildCommand(sessionID, cfg)
+
+	// Start output capture if configured
+	if cfg.OutputFile != "" {
+		if err := r.Terminal.StartPipePane(session, window, cfg.OutputFile); err != nil {
+			return nil, fmt.Errorf("failed to start output capture: %w", err)
+		}
+	}
+
+	// Send the command to start Claude
+	if err := r.Terminal.SendKeys(session, window, cmd); err != nil {
+		return nil, fmt.Errorf("failed to send claude command: %w", err)
+	}
+
+	// Wait for Claude to start
+	time.Sleep(r.StartupDelay)
+
+	// Get the PID
+	pid, err := r.Terminal.GetPanePID(session, window)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Claude PID: %w", err)
+	}
+
+	// Send initial message if configured
+	if cfg.InitialMessage != "" {
+		time.Sleep(r.MessageDelay)
+		if err := r.Terminal.SendKeysLiteral(session, window, cfg.InitialMessage); err != nil {
+			return nil, fmt.Errorf("failed to send initial message: %w", err)
+		}
+		if err := r.Terminal.SendEnter(session, window); err != nil {
+			return nil, fmt.Errorf("failed to submit initial message: %w", err)
+		}
+	}
+
+	return &StartResult{
+		SessionID: sessionID,
+		PID:       pid,
+		Command:   cmd,
+	}, nil
+}
+
+// buildCommand constructs the claude CLI command string.
+func (r *Runner) buildCommand(sessionID string, cfg Config) string {
+	cmd := r.BinaryPath
+
+	// Add session ID
+	cmd += fmt.Sprintf(" --session-id %s", sessionID)
+
+	// Add skip permissions flag
+	if r.SkipPermissions {
+		cmd += " --dangerously-skip-permissions"
+	}
+
+	// Add system prompt file
+	if cfg.SystemPromptFile != "" {
+		cmd += fmt.Sprintf(" --append-system-prompt-file %s", cfg.SystemPromptFile)
+	}
+
+	return cmd
+}
+
+// SendMessage sends a message to a running Claude instance.
+// This properly handles multiline messages using paste-buffer.
+func (r *Runner) SendMessage(session, window, message string) error {
+	if r.Terminal == nil {
+		return fmt.Errorf("terminal runner not configured")
+	}
+
+	// Send the message text
+	if err := r.Terminal.SendKeysLiteral(session, window, message); err != nil {
+		return fmt.Errorf("failed to send message: %w", err)
+	}
+
+	// Press Enter to submit
+	if err := r.Terminal.SendEnter(session, window); err != nil {
+		return fmt.Errorf("failed to submit message: %w", err)
+	}
+
+	return nil
+}
+
+// GenerateSessionID generates a UUID v4 session ID.
+func GenerateSessionID() (string, error) {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("failed to generate session ID: %w", err)
+	}
+
+	// Set version (4) and variant bits for UUID v4
+	bytes[6] = (bytes[6] & 0x0f) | 0x40 // Version 4
+	bytes[8] = (bytes[8] & 0x3f) | 0x80 // Variant 10
+
+	return fmt.Sprintf("%x-%x-%x-%x-%x",
+		bytes[0:4],
+		bytes[4:6],
+		bytes[6:8],
+		bytes[8:10],
+		bytes[10:16],
+	), nil
+}

--- a/pkg/claude/runner_test.go
+++ b/pkg/claude/runner_test.go
@@ -1,0 +1,462 @@
+package claude
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockTerminal implements TerminalRunner for testing.
+type mockTerminal struct {
+	sendKeysCalls        []sendKeysCall
+	sendKeysLiteralCalls []sendKeysCall
+	sendEnterCalls       []targetCall
+	getPanePIDCalls      []targetCall
+	startPipePaneCalls   []pipePaneCall
+	stopPipePaneCalls    []targetCall
+
+	getPanePIDReturn int
+	getPanePIDError  error
+	sendKeysError    error
+}
+
+type sendKeysCall struct {
+	session string
+	window  string
+	text    string
+}
+
+type targetCall struct {
+	session string
+	window  string
+}
+
+type pipePaneCall struct {
+	session    string
+	window     string
+	outputFile string
+}
+
+func (m *mockTerminal) SendKeys(session, window, text string) error {
+	m.sendKeysCalls = append(m.sendKeysCalls, sendKeysCall{session, window, text})
+	return m.sendKeysError
+}
+
+func (m *mockTerminal) SendKeysLiteral(session, window, text string) error {
+	m.sendKeysLiteralCalls = append(m.sendKeysLiteralCalls, sendKeysCall{session, window, text})
+	return m.sendKeysError
+}
+
+func (m *mockTerminal) SendEnter(session, window string) error {
+	m.sendEnterCalls = append(m.sendEnterCalls, targetCall{session, window})
+	return nil
+}
+
+func (m *mockTerminal) GetPanePID(session, window string) (int, error) {
+	m.getPanePIDCalls = append(m.getPanePIDCalls, targetCall{session, window})
+	return m.getPanePIDReturn, m.getPanePIDError
+}
+
+func (m *mockTerminal) StartPipePane(session, window, outputFile string) error {
+	m.startPipePaneCalls = append(m.startPipePaneCalls, pipePaneCall{session, window, outputFile})
+	return nil
+}
+
+func (m *mockTerminal) StopPipePane(session, window string) error {
+	m.stopPipePaneCalls = append(m.stopPipePaneCalls, targetCall{session, window})
+	return nil
+}
+
+func TestNewRunner(t *testing.T) {
+	runner := NewRunner()
+	if runner == nil {
+		t.Fatal("NewRunner() returned nil")
+	}
+	if runner.BinaryPath != "claude" {
+		t.Errorf("expected default BinaryPath to be 'claude', got %q", runner.BinaryPath)
+	}
+	if runner.StartupDelay != 500*time.Millisecond {
+		t.Errorf("expected default StartupDelay to be 500ms, got %v", runner.StartupDelay)
+	}
+	if runner.MessageDelay != 1*time.Second {
+		t.Errorf("expected default MessageDelay to be 1s, got %v", runner.MessageDelay)
+	}
+	if !runner.SkipPermissions {
+		t.Error("expected default SkipPermissions to be true")
+	}
+}
+
+func TestNewRunnerWithOptions(t *testing.T) {
+	terminal := &mockTerminal{}
+	runner := NewRunner(
+		WithBinaryPath("/custom/claude"),
+		WithTerminal(terminal),
+		WithStartupDelay(1*time.Second),
+		WithMessageDelay(2*time.Second),
+		WithPermissions(false),
+	)
+
+	if runner.BinaryPath != "/custom/claude" {
+		t.Errorf("expected BinaryPath to be '/custom/claude', got %q", runner.BinaryPath)
+	}
+	if runner.Terminal != terminal {
+		t.Error("expected Terminal to be set")
+	}
+	if runner.StartupDelay != 1*time.Second {
+		t.Errorf("expected StartupDelay to be 1s, got %v", runner.StartupDelay)
+	}
+	if runner.MessageDelay != 2*time.Second {
+		t.Errorf("expected MessageDelay to be 2s, got %v", runner.MessageDelay)
+	}
+	if runner.SkipPermissions {
+		t.Error("expected SkipPermissions to be false")
+	}
+}
+
+func TestStart(t *testing.T) {
+	terminal := &mockTerminal{
+		getPanePIDReturn: 12345,
+	}
+
+	runner := NewRunner(
+		WithTerminal(terminal),
+		WithBinaryPath("/path/to/claude"),
+		WithStartupDelay(0), // No delay for tests
+	)
+
+	result, err := runner.Start("my-session", "my-window", Config{
+		SystemPromptFile: "/path/to/prompt.md",
+	})
+
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	if result.SessionID == "" {
+		t.Error("expected SessionID to be generated")
+	}
+
+	if result.PID != 12345 {
+		t.Errorf("expected PID to be 12345, got %d", result.PID)
+	}
+
+	// Verify SendKeys was called
+	if len(terminal.sendKeysCalls) != 1 {
+		t.Fatalf("expected 1 SendKeys call, got %d", len(terminal.sendKeysCalls))
+	}
+
+	call := terminal.sendKeysCalls[0]
+	if call.session != "my-session" {
+		t.Errorf("expected session 'my-session', got %q", call.session)
+	}
+	if call.window != "my-window" {
+		t.Errorf("expected window 'my-window', got %q", call.window)
+	}
+
+	// Verify command structure
+	if !strings.Contains(call.text, "/path/to/claude") {
+		t.Errorf("expected command to contain binary path, got %q", call.text)
+	}
+	if !strings.Contains(call.text, "--session-id") {
+		t.Errorf("expected command to contain --session-id, got %q", call.text)
+	}
+	if !strings.Contains(call.text, "--dangerously-skip-permissions") {
+		t.Errorf("expected command to contain --dangerously-skip-permissions, got %q", call.text)
+	}
+	if !strings.Contains(call.text, "--append-system-prompt-file /path/to/prompt.md") {
+		t.Errorf("expected command to contain prompt file, got %q", call.text)
+	}
+}
+
+func TestStartWithCustomSessionID(t *testing.T) {
+	terminal := &mockTerminal{
+		getPanePIDReturn: 12345,
+	}
+
+	runner := NewRunner(
+		WithTerminal(terminal),
+		WithStartupDelay(0),
+	)
+
+	result, err := runner.Start("session", "window", Config{
+		SessionID: "my-custom-session-id",
+	})
+
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	if result.SessionID != "my-custom-session-id" {
+		t.Errorf("expected SessionID to be 'my-custom-session-id', got %q", result.SessionID)
+	}
+
+	// Verify command contains custom session ID
+	if !strings.Contains(terminal.sendKeysCalls[0].text, "--session-id my-custom-session-id") {
+		t.Errorf("expected command to contain custom session ID, got %q", terminal.sendKeysCalls[0].text)
+	}
+}
+
+func TestStartWithOutputCapture(t *testing.T) {
+	terminal := &mockTerminal{
+		getPanePIDReturn: 12345,
+	}
+
+	runner := NewRunner(
+		WithTerminal(terminal),
+		WithStartupDelay(0),
+	)
+
+	_, err := runner.Start("session", "window", Config{
+		OutputFile: "/tmp/output.log",
+	})
+
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	// Verify StartPipePane was called
+	if len(terminal.startPipePaneCalls) != 1 {
+		t.Fatalf("expected 1 StartPipePane call, got %d", len(terminal.startPipePaneCalls))
+	}
+
+	call := terminal.startPipePaneCalls[0]
+	if call.outputFile != "/tmp/output.log" {
+		t.Errorf("expected outputFile to be '/tmp/output.log', got %q", call.outputFile)
+	}
+}
+
+func TestStartWithInitialMessage(t *testing.T) {
+	terminal := &mockTerminal{
+		getPanePIDReturn: 12345,
+	}
+
+	runner := NewRunner(
+		WithTerminal(terminal),
+		WithStartupDelay(0),
+		WithMessageDelay(0),
+	)
+
+	_, err := runner.Start("session", "window", Config{
+		InitialMessage: "Hello, Claude!",
+	})
+
+	if err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	// Verify SendKeysLiteral was called for the initial message
+	if len(terminal.sendKeysLiteralCalls) != 1 {
+		t.Fatalf("expected 1 SendKeysLiteral call, got %d", len(terminal.sendKeysLiteralCalls))
+	}
+
+	if terminal.sendKeysLiteralCalls[0].text != "Hello, Claude!" {
+		t.Errorf("expected initial message 'Hello, Claude!', got %q", terminal.sendKeysLiteralCalls[0].text)
+	}
+
+	// Verify SendEnter was called
+	if len(terminal.sendEnterCalls) != 1 {
+		t.Fatalf("expected 1 SendEnter call, got %d", len(terminal.sendEnterCalls))
+	}
+}
+
+func TestStartNoTerminal(t *testing.T) {
+	runner := NewRunner()
+
+	_, err := runner.Start("session", "window", Config{})
+	if err == nil {
+		t.Error("expected error when terminal not configured")
+	}
+	if !strings.Contains(err.Error(), "terminal runner not configured") {
+		t.Errorf("expected 'terminal runner not configured' error, got %q", err.Error())
+	}
+}
+
+func TestStartSendKeysError(t *testing.T) {
+	terminal := &mockTerminal{
+		sendKeysError: errors.New("send keys failed"),
+	}
+
+	runner := NewRunner(
+		WithTerminal(terminal),
+		WithStartupDelay(0),
+	)
+
+	_, err := runner.Start("session", "window", Config{})
+	if err == nil {
+		t.Error("expected error when SendKeys fails")
+	}
+	if !strings.Contains(err.Error(), "send keys failed") {
+		t.Errorf("expected 'send keys failed' error, got %q", err.Error())
+	}
+}
+
+func TestStartGetPIDError(t *testing.T) {
+	terminal := &mockTerminal{
+		getPanePIDError: errors.New("get PID failed"),
+	}
+
+	runner := NewRunner(
+		WithTerminal(terminal),
+		WithStartupDelay(0),
+	)
+
+	_, err := runner.Start("session", "window", Config{})
+	if err == nil {
+		t.Error("expected error when GetPanePID fails")
+	}
+	if !strings.Contains(err.Error(), "get PID failed") {
+		t.Errorf("expected 'get PID failed' error, got %q", err.Error())
+	}
+}
+
+func TestSendMessage(t *testing.T) {
+	terminal := &mockTerminal{}
+
+	runner := NewRunner(WithTerminal(terminal))
+
+	err := runner.SendMessage("session", "window", "Hello, Claude!")
+	if err != nil {
+		t.Fatalf("SendMessage() failed: %v", err)
+	}
+
+	// Verify SendKeysLiteral was called
+	if len(terminal.sendKeysLiteralCalls) != 1 {
+		t.Fatalf("expected 1 SendKeysLiteral call, got %d", len(terminal.sendKeysLiteralCalls))
+	}
+
+	call := terminal.sendKeysLiteralCalls[0]
+	if call.text != "Hello, Claude!" {
+		t.Errorf("expected message 'Hello, Claude!', got %q", call.text)
+	}
+
+	// Verify SendEnter was called
+	if len(terminal.sendEnterCalls) != 1 {
+		t.Fatalf("expected 1 SendEnter call, got %d", len(terminal.sendEnterCalls))
+	}
+}
+
+func TestSendMessageMultiline(t *testing.T) {
+	terminal := &mockTerminal{}
+
+	runner := NewRunner(WithTerminal(terminal))
+
+	multilineMsg := "Line 1\nLine 2\nLine 3"
+	err := runner.SendMessage("session", "window", multilineMsg)
+	if err != nil {
+		t.Fatalf("SendMessage() failed: %v", err)
+	}
+
+	// Verify the full multiline message was sent
+	if terminal.sendKeysLiteralCalls[0].text != multilineMsg {
+		t.Errorf("expected multiline message preserved, got %q", terminal.sendKeysLiteralCalls[0].text)
+	}
+}
+
+func TestSendMessageNoTerminal(t *testing.T) {
+	runner := NewRunner()
+
+	err := runner.SendMessage("session", "window", "Hello")
+	if err == nil {
+		t.Error("expected error when terminal not configured")
+	}
+}
+
+func TestGenerateSessionID(t *testing.T) {
+	id1, err := GenerateSessionID()
+	if err != nil {
+		t.Fatalf("GenerateSessionID() failed: %v", err)
+	}
+
+	// Check format (UUID v4: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
+	parts := strings.Split(id1, "-")
+	if len(parts) != 5 {
+		t.Errorf("expected 5 parts in UUID, got %d", len(parts))
+	}
+
+	// Verify uniqueness
+	id2, err := GenerateSessionID()
+	if err != nil {
+		t.Fatalf("GenerateSessionID() failed: %v", err)
+	}
+
+	if id1 == id2 {
+		t.Error("expected different session IDs for each call")
+	}
+}
+
+func TestBuildCommand(t *testing.T) {
+	runner := NewRunner(
+		WithBinaryPath("/path/to/claude"),
+		WithPermissions(true),
+	)
+
+	tests := []struct {
+		name     string
+		config   Config
+		contains []string
+		excludes []string
+	}{
+		{
+			name: "basic",
+			config: Config{
+				SessionID: "test-session",
+			},
+			contains: []string{
+				"/path/to/claude",
+				"--session-id test-session",
+				"--dangerously-skip-permissions",
+			},
+		},
+		{
+			name: "with prompt file",
+			config: Config{
+				SessionID:        "test-session",
+				SystemPromptFile: "/path/to/prompt.md",
+			},
+			contains: []string{
+				"--append-system-prompt-file /path/to/prompt.md",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := runner.buildCommand(tc.config.SessionID, tc.config)
+
+			for _, s := range tc.contains {
+				if !strings.Contains(cmd, s) {
+					t.Errorf("expected command to contain %q, got %q", s, cmd)
+				}
+			}
+
+			for _, s := range tc.excludes {
+				if strings.Contains(cmd, s) {
+					t.Errorf("expected command not to contain %q, got %q", s, cmd)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildCommandWithoutSkipPermissions(t *testing.T) {
+	runner := NewRunner(
+		WithBinaryPath("claude"),
+		WithPermissions(false),
+	)
+
+	cmd := runner.buildCommand("session-id", Config{})
+
+	if strings.Contains(cmd, "--dangerously-skip-permissions") {
+		t.Error("expected command not to contain --dangerously-skip-permissions when disabled")
+	}
+}
+
+func TestResolveBinaryPath(t *testing.T) {
+	// This test is environment-dependent, so we just verify it doesn't panic
+	// and returns something
+	path := ResolveBinaryPath()
+	if path == "" {
+		t.Error("ResolveBinaryPath() returned empty string")
+	}
+}

--- a/pkg/tmux/README.md
+++ b/pkg/tmux/README.md
@@ -1,0 +1,180 @@
+# pkg/tmux
+
+A Go client for programmatic interaction with tmux terminal multiplexer.
+
+## Why This Package?
+
+Existing Go tmux libraries ([gotmux](https://github.com/GianlucaP106/gotmux), [go-tmux](https://github.com/jubnzv/go-tmux), [gomux](https://github.com/wricardo/gomux)) focus on workspace setup (session/window/pane creation) but lack features needed for **programmatic interaction with running CLI applications**:
+
+| Feature | Existing libraries | This package |
+|---------|-------------------|--------------|
+| Multiline text via paste-buffer | No | **Yes** |
+| Pane PID extraction | No | **Yes** |
+| pipe-pane output capture | No | **Yes** |
+
+## Installation
+
+```bash
+go get github.com/dlorenc/multiclaude/pkg/tmux
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "log"
+    "github.com/dlorenc/multiclaude/pkg/tmux"
+)
+
+func main() {
+    client := tmux.NewClient()
+
+    // Check if tmux is available
+    if !client.IsTmuxAvailable() {
+        log.Fatal("tmux is not installed")
+    }
+
+    // Create a detached session
+    if err := client.CreateSession("my-session", true); err != nil {
+        log.Fatal(err)
+    }
+    defer client.KillSession("my-session")
+
+    // Send a command
+    if err := client.SendKeys("my-session", "0", "echo hello"); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+## Key Features
+
+### Multiline Text Input
+
+The killer feature of this package. When interacting with CLI applications that process input on Enter, you need a way to send multiline text without triggering on each line.
+
+```go
+// Send multiline text without triggering intermediate processing
+message := `This is line 1
+This is line 2
+This is line 3`
+
+// SendKeysLiteral uses tmux's paste-buffer for multiline text
+if err := client.SendKeysLiteral("session", "window", message); err != nil {
+    log.Fatal(err)
+}
+
+// Now send Enter to submit
+if err := client.SendEnter("session", "window"); err != nil {
+    log.Fatal(err)
+}
+```
+
+**How it works:** For multiline text, the package uses tmux's paste-buffer mechanism:
+1. `tmux set-buffer "..."` - stores the entire text
+2. `tmux paste-buffer -t target` - pastes it atomically
+
+This ensures the application receives the complete text before any processing is triggered.
+
+### Process PID Extraction
+
+Monitor whether a process running in a tmux pane is still alive:
+
+```go
+pid, err := client.GetPanePID("session", "window")
+if err != nil {
+    log.Fatal(err)
+}
+
+// Check if process is alive
+process, err := os.FindProcess(pid)
+if err != nil {
+    log.Printf("Process %d not found", pid)
+}
+```
+
+### Output Capture with pipe-pane
+
+Capture all output from a tmux pane to a file:
+
+```go
+// Start capturing output
+if err := client.StartPipePane("session", "window", "/tmp/output.log"); err != nil {
+    log.Fatal(err)
+}
+
+// ... run commands in the pane ...
+
+// Stop capturing
+if err := client.StopPipePane("session", "window"); err != nil {
+    log.Fatal(err)
+}
+```
+
+## API Reference
+
+### Session Management
+
+```go
+HasSession(name string) (bool, error)      // Check if session exists
+CreateSession(name string, detached bool) error  // Create new session
+KillSession(name string) error             // Terminate session
+ListSessions() ([]string, error)           // List all sessions
+```
+
+### Window Management
+
+```go
+CreateWindow(session, name string) error   // Create window in session
+HasWindow(session, name string) (bool, error)  // Check if window exists
+KillWindow(session, name string) error     // Terminate window
+ListWindows(session string) ([]string, error)  // List windows in session
+```
+
+### Text Input
+
+```go
+SendKeys(session, window, text string) error     // Send text + Enter
+SendKeysLiteral(session, window, text string) error  // Send text (paste-buffer for multiline)
+SendEnter(session, window string) error          // Send just Enter
+```
+
+### Process Monitoring
+
+```go
+GetPanePID(session, window string) (int, error)  // Get process PID in pane
+```
+
+### Output Capture
+
+```go
+StartPipePane(session, window, outputFile string) error  // Start capturing
+StopPipePane(session, window string) error               // Stop capturing
+```
+
+### Configuration
+
+```go
+// Use a custom tmux binary path
+client := tmux.NewClient(tmux.WithTmuxPath("/usr/local/bin/tmux"))
+```
+
+## Use Cases
+
+This package was designed for orchestrating multiple Claude Code agents, but is useful for any scenario requiring programmatic control of CLI applications:
+
+- Running multiple AI assistants in parallel
+- Automated testing of interactive CLI tools
+- CI/CD pipelines that need to interact with terminal applications
+- DevOps automation with interactive prompts
+
+## Requirements
+
+- tmux 2.0 or later (uses paste-buffer and pipe-pane)
+- Go 1.21 or later
+
+## License
+
+See the main project LICENSE file.

--- a/pkg/tmux/client.go
+++ b/pkg/tmux/client.go
@@ -1,0 +1,334 @@
+// Package tmux provides a Go client for interacting with tmux terminal multiplexer.
+//
+// This package differs from existing Go tmux libraries (gotmux, go-tmux, gomux) by
+// focusing on programmatic interaction with running CLI applications:
+//
+//   - Multiline text input via paste-buffer (avoids triggering intermediate processing)
+//   - Process PID extraction from panes
+//   - Output capture via pipe-pane
+//
+// # Quick Start
+//
+//	client := tmux.NewClient()
+//
+//	// Check if tmux is available
+//	if !client.IsTmuxAvailable() {
+//	    log.Fatal("tmux is not installed")
+//	}
+//
+//	// Create a detached session
+//	if err := client.CreateSession("my-session", true); err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Send commands to the session
+//	if err := client.SendKeys("my-session", "0", "echo hello"); err != nil {
+//	    log.Fatal(err)
+//	}
+package tmux
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Client wraps tmux operations for programmatic control of tmux sessions,
+// windows, and panes.
+type Client struct {
+	// tmuxPath allows overriding the default "tmux" binary path.
+	// If empty, "tmux" is used (relies on PATH).
+	tmuxPath string
+}
+
+// ClientOption is a functional option for configuring a Client.
+type ClientOption func(*Client)
+
+// WithTmuxPath sets a custom path to the tmux binary.
+func WithTmuxPath(path string) ClientOption {
+	return func(c *Client) {
+		c.tmuxPath = path
+	}
+}
+
+// NewClient creates a new tmux client with the given options.
+func NewClient(opts ...ClientOption) *Client {
+	c := &Client{
+		tmuxPath: "tmux",
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// tmuxCmd creates an exec.Cmd for the configured tmux binary.
+func (c *Client) tmuxCmd(args ...string) *exec.Cmd {
+	return exec.Command(c.tmuxPath, args...)
+}
+
+// IsTmuxAvailable checks if tmux is installed and available.
+func (c *Client) IsTmuxAvailable() bool {
+	cmd := c.tmuxCmd("-V")
+	return cmd.Run() == nil
+}
+
+// =============================================================================
+// Session Management
+// =============================================================================
+
+// HasSession checks if a tmux session with the given name exists.
+func (c *Client) HasSession(name string) (bool, error) {
+	cmd := c.tmuxCmd("has-session", "-t", name)
+	err := cmd.Run()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			// Exit code 1 means session doesn't exist
+			if exitErr.ExitCode() == 1 {
+				return false, nil
+			}
+		}
+		return false, fmt.Errorf("failed to check session: %w", err)
+	}
+	return true, nil
+}
+
+// CreateSession creates a new tmux session with the given name.
+// If detached is true, creates the session in detached mode (-d).
+func (c *Client) CreateSession(name string, detached bool) error {
+	args := []string{"new-session", "-s", name}
+	if detached {
+		args = append(args, "-d")
+	}
+
+	cmd := c.tmuxCmd(args...)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to create session: %w", err)
+	}
+	return nil
+}
+
+// KillSession terminates a tmux session.
+func (c *Client) KillSession(name string) error {
+	cmd := c.tmuxCmd("kill-session", "-t", name)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to kill session: %w", err)
+	}
+	return nil
+}
+
+// ListSessions returns a list of all tmux session names.
+func (c *Client) ListSessions() ([]string, error) {
+	cmd := c.tmuxCmd("list-sessions", "-F", "#{session_name}")
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			// No sessions running
+			if exitErr.ExitCode() == 1 {
+				return []string{}, nil
+			}
+		}
+		return nil, fmt.Errorf("failed to list sessions: %w", err)
+	}
+
+	sessions := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(sessions) == 1 && sessions[0] == "" {
+		return []string{}, nil
+	}
+	return sessions, nil
+}
+
+// =============================================================================
+// Window Management
+// =============================================================================
+
+// CreateWindow creates a new window in the specified session.
+func (c *Client) CreateWindow(session, windowName string) error {
+	target := fmt.Sprintf("%s:", session)
+	cmd := c.tmuxCmd("new-window", "-t", target, "-n", windowName)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to create window: %w", err)
+	}
+	return nil
+}
+
+// HasWindow checks if a window with the given name exists in the session.
+func (c *Client) HasWindow(session, windowName string) (bool, error) {
+	cmd := c.tmuxCmd("list-windows", "-t", session)
+	output, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to list windows: %w", err)
+	}
+
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, windowName) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// KillWindow terminates a specific window in a session.
+func (c *Client) KillWindow(session, windowName string) error {
+	target := fmt.Sprintf("%s:%s", session, windowName)
+	cmd := c.tmuxCmd("kill-window", "-t", target)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to kill window: %w", err)
+	}
+	return nil
+}
+
+// ListWindows returns a list of window names in the specified session.
+func (c *Client) ListWindows(session string) ([]string, error) {
+	cmd := c.tmuxCmd("list-windows", "-t", session, "-F", "#{window_name}")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list windows: %w", err)
+	}
+
+	windows := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(windows) == 1 && windows[0] == "" {
+		return []string{}, nil
+	}
+	return windows, nil
+}
+
+// =============================================================================
+// Text Input - The Key Differentiator
+// =============================================================================
+
+// SendKeys sends text to a window followed by Enter (C-m).
+// This is equivalent to typing the text and pressing Enter.
+func (c *Client) SendKeys(session, windowName, text string) error {
+	target := fmt.Sprintf("%s:%s", session, windowName)
+	cmd := c.tmuxCmd("send-keys", "-t", target, text, "C-m")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to send keys: %w", err)
+	}
+	return nil
+}
+
+// SendKeysLiteral sends text to a window without pressing Enter.
+//
+// For single-line text, this uses tmux's send-keys with -l (literal mode).
+// For multiline text, it uses tmux's paste buffer mechanism to send the
+// entire message at once without triggering intermediate command processing.
+//
+// This is the key differentiator from other tmux libraries - it properly
+// handles multiline text when interacting with CLI applications that might
+// interpret newlines as command submission.
+func (c *Client) SendKeysLiteral(session, windowName, text string) error {
+	target := fmt.Sprintf("%s:%s", session, windowName)
+
+	// For multiline text, use paste buffer to avoid triggering processing on each line
+	if strings.Contains(text, "\n") {
+		// Set the buffer with the text
+		setCmd := c.tmuxCmd("set-buffer", text)
+		if err := setCmd.Run(); err != nil {
+			return fmt.Errorf("failed to set buffer: %w", err)
+		}
+
+		// Paste the buffer to the target
+		pasteCmd := c.tmuxCmd("paste-buffer", "-t", target)
+		if err := pasteCmd.Run(); err != nil {
+			return fmt.Errorf("failed to paste buffer: %w", err)
+		}
+		return nil
+	}
+
+	// No newlines, send the text using send-keys with literal mode
+	cmd := c.tmuxCmd("send-keys", "-t", target, "-l", text)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to send keys: %w", err)
+	}
+	return nil
+}
+
+// SendEnter sends just the Enter key (C-m) to a window.
+// Useful when you want to send text with SendKeysLiteral and then
+// separately trigger command execution.
+func (c *Client) SendEnter(session, windowName string) error {
+	target := fmt.Sprintf("%s:%s", session, windowName)
+	cmd := c.tmuxCmd("send-keys", "-t", target, "C-m")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to send enter: %w", err)
+	}
+	return nil
+}
+
+// SendKeysLiteralWithEnter sends text + Enter atomically using shell command chaining.
+// This prevents race conditions where Enter might be lost between separate exec calls.
+// Uses sh -c with && to chain tmux commands in a single shell execution.
+// This approach works reliably for both single-line and multiline messages.
+func (c *Client) SendKeysLiteralWithEnter(session, windowName, text string) error {
+	target := fmt.Sprintf("%s:%s", session, windowName)
+
+	// Use sh -c to chain tmux commands atomically with &&
+	// The text is passed as $1 to avoid shell escaping issues with special characters
+	// Commands: set-buffer (load text) -> paste-buffer (insert to pane) -> send-keys Enter (submit)
+	cmdStr := fmt.Sprintf("%s set-buffer -- \"$1\" && %s paste-buffer -t %s && %s send-keys -t %s Enter",
+		c.tmuxPath, c.tmuxPath, target, c.tmuxPath, target)
+	cmd := exec.Command("sh", "-c", cmdStr, "sh", text)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to send keys atomically: %w", err)
+	}
+	return nil
+}
+
+// =============================================================================
+// Process Monitoring - Another Differentiator
+// =============================================================================
+
+// GetPanePID gets the PID of the process running in the first pane of a window.
+// This allows monitoring whether the process in a tmux pane is still alive.
+func (c *Client) GetPanePID(session, windowName string) (int, error) {
+	target := fmt.Sprintf("%s:%s", session, windowName)
+	cmd := c.tmuxCmd("display-message", "-t", target, "-p", "#{pane_pid}")
+	output, err := cmd.Output()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get pane PID: %w", err)
+	}
+
+	var pid int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(output)), "%d", &pid); err != nil {
+		return 0, fmt.Errorf("failed to parse PID: %w", err)
+	}
+
+	return pid, nil
+}
+
+// =============================================================================
+// Output Capture - Third Differentiator
+// =============================================================================
+
+// StartPipePane starts capturing pane output to a file.
+// The output is appended to the file, so it persists across restarts.
+//
+// Example:
+//
+//	client.StartPipePane("my-session", "my-window", "/tmp/output.log")
+//	// ... run commands in the pane ...
+//	client.StopPipePane("my-session", "my-window")
+func (c *Client) StartPipePane(session, windowName, outputFile string) error {
+	target := fmt.Sprintf("%s:%s", session, windowName)
+	// Use -o to open a pipe (output only, not input)
+	// cat >> appends to the file so output is preserved
+	cmd := c.tmuxCmd("pipe-pane", "-o", "-t", target, fmt.Sprintf("cat >> '%s'", outputFile))
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to start pipe-pane: %w", err)
+	}
+	return nil
+}
+
+// StopPipePane stops the pipe-pane for a window.
+// After calling this, output is no longer captured to the file.
+func (c *Client) StopPipePane(session, windowName string) error {
+	target := fmt.Sprintf("%s:%s", session, windowName)
+	// Running pipe-pane with no command stops any existing pipe
+	cmd := c.tmuxCmd("pipe-pane", "-t", target)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to stop pipe-pane: %w", err)
+	}
+	return nil
+}

--- a/pkg/tmux/client_test.go
+++ b/pkg/tmux/client_test.go
@@ -1,0 +1,803 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMain ensures clean tmux environment for tests
+func TestMain(m *testing.M) {
+	// Skip tmux integration tests in CI environments unless TMUX_TESTS=1 is set
+	// CI environments (like GitHub Actions) often have tmux installed but without
+	// proper terminal support, causing flaky session creation failures
+	if os.Getenv("CI") != "" && os.Getenv("TMUX_TESTS") != "1" {
+		fmt.Fprintln(os.Stderr, "Skipping tmux tests in CI (set TMUX_TESTS=1 to enable)")
+		os.Exit(0)
+	}
+
+	// Check if tmux is available
+	if exec.Command("tmux", "-V").Run() != nil {
+		fmt.Fprintln(os.Stderr, "Warning: tmux not available, skipping tmux tests")
+		os.Exit(0)
+	}
+
+	// Verify we can actually create sessions (not just that tmux is installed)
+	// Some environments have tmux installed but unable to create sessions
+	testSession := fmt.Sprintf("test-tmux-probe-%d", time.Now().UnixNano())
+	cmd := exec.Command("tmux", "new-session", "-d", "-s", testSession)
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "Warning: tmux cannot create sessions (no terminal?), skipping tmux tests")
+		os.Exit(0)
+	}
+	// Clean up probe session
+	exec.Command("tmux", "kill-session", "-t", testSession).Run()
+
+	// Run tests
+	code := m.Run()
+
+	// Cleanup any test sessions that might have leaked
+	cleanupTestSessions()
+
+	os.Exit(code)
+}
+
+// cleanupTestSessions removes any test sessions that leaked
+func cleanupTestSessions() {
+	cmd := exec.Command("tmux", "list-sessions", "-F", "#{session_name}")
+	output, err := cmd.Output()
+	if err != nil {
+		return
+	}
+
+	sessions := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for _, session := range sessions {
+		if strings.HasPrefix(session, "test-") {
+			exec.Command("tmux", "kill-session", "-t", session).Run()
+		}
+	}
+}
+
+// uniqueSessionName generates a unique test session name
+func uniqueSessionName() string {
+	return fmt.Sprintf("test-tmux-%d", time.Now().UnixNano())
+}
+
+// waitForSession polls until a session exists or timeout is reached.
+// This handles the race condition where tmux reports success but the session
+// isn't immediately visible in subsequent queries.
+func waitForSession(client *Client, sessionName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	pollInterval := 10 * time.Millisecond
+
+	for time.Now().Before(deadline) {
+		exists, err := client.HasSession(sessionName)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("session %s did not appear within %v", sessionName, timeout)
+}
+
+// waitForNoSession polls until a session no longer exists or timeout is reached.
+func waitForNoSession(client *Client, sessionName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	pollInterval := 10 * time.Millisecond
+
+	for time.Now().Before(deadline) {
+		exists, err := client.HasSession(sessionName)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("session %s still exists after %v", sessionName, timeout)
+}
+
+func TestNewClient(t *testing.T) {
+	client := NewClient()
+	if client == nil {
+		t.Fatal("NewClient() returned nil")
+	}
+	if client.tmuxPath != "tmux" {
+		t.Errorf("expected default tmuxPath to be 'tmux', got %q", client.tmuxPath)
+	}
+}
+
+func TestNewClientWithOptions(t *testing.T) {
+	client := NewClient(WithTmuxPath("/custom/path/tmux"))
+	if client.tmuxPath != "/custom/path/tmux" {
+		t.Errorf("expected tmuxPath to be '/custom/path/tmux', got %q", client.tmuxPath)
+	}
+}
+
+func TestIsTmuxAvailable(t *testing.T) {
+	client := NewClient()
+	if !client.IsTmuxAvailable() {
+		t.Error("Expected tmux to be available")
+	}
+}
+
+func TestHasSession(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Session should not exist initially
+	exists, err := client.HasSession(sessionName)
+	if err != nil {
+		t.Fatalf("HasSession failed: %v", err)
+	}
+	if exists {
+		t.Error("Session should not exist initially")
+	}
+
+	// Create session
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Wait for session to be visible (handles tmux timing race)
+	if err := waitForSession(client, sessionName, 2*time.Second); err != nil {
+		t.Fatalf("Session not visible after creation: %v", err)
+	}
+
+	// Session should now exist
+	exists, err = client.HasSession(sessionName)
+	if err != nil {
+		t.Fatalf("HasSession failed: %v", err)
+	}
+	if !exists {
+		t.Error("Session should exist after creation")
+	}
+}
+
+func TestCreateSession(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create detached session
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Wait for session to be visible (handles tmux timing race)
+	if err := waitForSession(client, sessionName, 2*time.Second); err != nil {
+		t.Fatalf("Session not visible after creation: %v", err)
+	}
+
+	// Verify session exists
+	exists, err := client.HasSession(sessionName)
+	if err != nil {
+		t.Fatalf("HasSession failed: %v", err)
+	}
+	if !exists {
+		t.Error("Session should exist after creation")
+	}
+
+	// Creating duplicate session should fail
+	err = client.CreateSession(sessionName, true)
+	if err == nil {
+		t.Error("Creating duplicate session should fail")
+	}
+}
+
+func TestCreateWindow(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create session first
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Create window
+	windowName := "test-window"
+	if err := client.CreateWindow(sessionName, windowName); err != nil {
+		t.Fatalf("Failed to create window: %v", err)
+	}
+
+	// Verify window exists
+	exists, err := client.HasWindow(sessionName, windowName)
+	if err != nil {
+		t.Fatalf("HasWindow failed: %v", err)
+	}
+	if !exists {
+		t.Error("Window should exist after creation")
+	}
+}
+
+func TestHasWindow(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create session
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Non-existent window should return false
+	exists, err := client.HasWindow(sessionName, "nonexistent")
+	if err != nil {
+		t.Fatalf("HasWindow failed: %v", err)
+	}
+	if exists {
+		t.Error("Non-existent window should return false")
+	}
+
+	// Create window
+	windowName := "test-window"
+	if err := client.CreateWindow(sessionName, windowName); err != nil {
+		t.Fatalf("Failed to create window: %v", err)
+	}
+
+	// Window should now exist
+	exists, err = client.HasWindow(sessionName, windowName)
+	if err != nil {
+		t.Fatalf("HasWindow failed: %v", err)
+	}
+	if !exists {
+		t.Error("Window should exist after creation")
+	}
+}
+
+func TestKillWindow(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create session
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Create two windows (we need at least 2 to kill one)
+	if err := client.CreateWindow(sessionName, "window1"); err != nil {
+		t.Fatalf("Failed to create window1: %v", err)
+	}
+	if err := client.CreateWindow(sessionName, "window2"); err != nil {
+		t.Fatalf("Failed to create window2: %v", err)
+	}
+
+	// Kill window1
+	if err := client.KillWindow(sessionName, "window1"); err != nil {
+		t.Fatalf("Failed to kill window: %v", err)
+	}
+
+	// Verify window1 no longer exists
+	exists, err := client.HasWindow(sessionName, "window1")
+	if err != nil {
+		t.Fatalf("HasWindow failed: %v", err)
+	}
+	if exists {
+		t.Error("Window should not exist after killing")
+	}
+
+	// Verify window2 still exists
+	exists, err = client.HasWindow(sessionName, "window2")
+	if err != nil {
+		t.Fatalf("HasWindow failed: %v", err)
+	}
+	if !exists {
+		t.Error("Window2 should still exist")
+	}
+}
+
+func TestKillSession(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create session
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	// Wait for session to be visible before killing
+	if err := waitForSession(client, sessionName, 2*time.Second); err != nil {
+		t.Fatalf("Session not visible after creation: %v", err)
+	}
+
+	// Kill session
+	if err := client.KillSession(sessionName); err != nil {
+		t.Fatalf("Failed to kill session: %v", err)
+	}
+
+	// Wait for session to be gone (handles tmux timing race)
+	if err := waitForNoSession(client, sessionName, 2*time.Second); err != nil {
+		t.Fatalf("Session still visible after killing: %v", err)
+	}
+
+	// Verify session no longer exists
+	exists, err := client.HasSession(sessionName)
+	if err != nil {
+		t.Fatalf("HasSession failed: %v", err)
+	}
+	if exists {
+		t.Error("Session should not exist after killing")
+	}
+}
+
+func TestSendKeys(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create session with a window running a shell
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Create a window
+	windowName := "test-window"
+	if err := client.CreateWindow(sessionName, windowName); err != nil {
+		t.Fatalf("Failed to create window: %v", err)
+	}
+
+	// Send keys to create a file (this tests that send-keys works)
+	testFile := fmt.Sprintf("/tmp/tmux-test-%d", time.Now().UnixNano())
+	defer os.Remove(testFile)
+
+	if err := client.SendKeys(sessionName, windowName, fmt.Sprintf("touch %s", testFile)); err != nil {
+		t.Fatalf("Failed to send keys: %v", err)
+	}
+
+	// Poll for the file to be created with timeout
+	// CI environments may be slow, so we use a generous timeout with polling
+	timeout := 5 * time.Second
+	pollInterval := 50 * time.Millisecond
+	deadline := time.Now().Add(timeout)
+
+	fileCreated := false
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(testFile); err == nil {
+			fileCreated = true
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+
+	// Verify the file was created (proves send-keys worked)
+	if !fileCreated {
+		t.Error("SendKeys did not execute command - file was not created within timeout")
+	}
+}
+
+func TestSendKeysLiteral(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create session
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Create a window
+	windowName := "test-window"
+	if err := client.CreateWindow(sessionName, windowName); err != nil {
+		t.Fatalf("Failed to create window: %v", err)
+	}
+
+	// SendKeysLiteral should not execute (no Enter key)
+	// We can't easily verify this without reading pane content,
+	// but we can at least verify it doesn't error
+	if err := client.SendKeysLiteral(sessionName, windowName, "echo test"); err != nil {
+		t.Fatalf("Failed to send keys literal: %v", err)
+	}
+}
+
+func TestSendKeysLiteralWithNewlines(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create session
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Create a window
+	windowName := "test-window"
+	if err := client.CreateWindow(sessionName, windowName); err != nil {
+		t.Fatalf("Failed to create window: %v", err)
+	}
+
+	// Test sending text with newlines - should not error
+	multiLineText := "line1\nline2\nline3"
+	if err := client.SendKeysLiteral(sessionName, windowName, multiLineText); err != nil {
+		t.Fatalf("Failed to send multi-line text: %v", err)
+	}
+
+	// Test with empty lines
+	textWithEmptyLines := "first\n\nlast"
+	if err := client.SendKeysLiteral(sessionName, windowName, textWithEmptyLines); err != nil {
+		t.Fatalf("Failed to send text with empty lines: %v", err)
+	}
+
+	// Test with trailing newline
+	textWithTrailingNewline := "content\n"
+	if err := client.SendKeysLiteral(sessionName, windowName, textWithTrailingNewline); err != nil {
+		t.Fatalf("Failed to send text with trailing newline: %v", err)
+	}
+}
+
+func TestSendEnter(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create session
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Create a window
+	windowName := "test-window"
+	if err := client.CreateWindow(sessionName, windowName); err != nil {
+		t.Fatalf("Failed to create window: %v", err)
+	}
+
+	// SendEnter should work without error
+	if err := client.SendEnter(sessionName, windowName); err != nil {
+		t.Fatalf("Failed to send enter: %v", err)
+	}
+}
+
+func TestListSessions(t *testing.T) {
+	client := NewClient()
+
+	// Create a test session
+	sessionName := uniqueSessionName()
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Wait for session to be visible (handles tmux timing race)
+	if err := waitForSession(client, sessionName, 2*time.Second); err != nil {
+		t.Fatalf("Session not visible after creation: %v", err)
+	}
+
+	// List sessions
+	sessions, err := client.ListSessions()
+	if err != nil {
+		t.Fatalf("Failed to list sessions: %v", err)
+	}
+
+	// Our test session should be in the list
+	// Note: We don't check exact count because external processes may create/delete
+	// sessions concurrently, making count-based assertions flaky
+	found := false
+	for _, s := range sessions {
+		if s == sessionName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Session %s not found in list: %v", sessionName, sessions)
+	}
+}
+
+func TestListWindows(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create session
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// List windows (should have default window)
+	windows, err := client.ListWindows(sessionName)
+	if err != nil {
+		t.Fatalf("Failed to list windows: %v", err)
+	}
+	if len(windows) == 0 {
+		t.Error("Expected at least one default window")
+	}
+
+	// Create additional windows
+	if err := client.CreateWindow(sessionName, "window1"); err != nil {
+		t.Fatalf("Failed to create window1: %v", err)
+	}
+	if err := client.CreateWindow(sessionName, "window2"); err != nil {
+		t.Fatalf("Failed to create window2: %v", err)
+	}
+
+	// List windows again
+	windows, err = client.ListWindows(sessionName)
+	if err != nil {
+		t.Fatalf("Failed to list windows: %v", err)
+	}
+
+	// Should have at least 3 windows (default + 2 created)
+	if len(windows) < 3 {
+		t.Errorf("Expected at least 3 windows, got %d: %v", len(windows), windows)
+	}
+
+	// Verify our windows are in the list
+	foundWindow1 := false
+	foundWindow2 := false
+	for _, w := range windows {
+		if w == "window1" {
+			foundWindow1 = true
+		}
+		if w == "window2" {
+			foundWindow2 = true
+		}
+	}
+	if !foundWindow1 || !foundWindow2 {
+		t.Errorf("Created windows not found in list: %v", windows)
+	}
+}
+
+func TestGetPanePID(t *testing.T) {
+	client := NewClient()
+	sessionName := uniqueSessionName()
+
+	// Create session
+	if err := client.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	// Create a window
+	windowName := "test-window"
+	if err := client.CreateWindow(sessionName, windowName); err != nil {
+		t.Fatalf("Failed to create window: %v", err)
+	}
+
+	// Get pane PID
+	pid, err := client.GetPanePID(sessionName, windowName)
+	if err != nil {
+		t.Fatalf("Failed to get pane PID: %v", err)
+	}
+
+	// PID should be positive
+	if pid <= 0 {
+		t.Errorf("Expected positive PID, got %d", pid)
+	}
+
+	// Verify PID corresponds to a running process
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		t.Errorf("Failed to find process with PID %d: %v", pid, err)
+	}
+	if process == nil {
+		t.Errorf("Process with PID %d not found", pid)
+	}
+}
+
+func TestMultipleSessions(t *testing.T) {
+	client := NewClient()
+
+	// Create multiple test sessions with unique names
+	session1 := fmt.Sprintf("test-tmux-%d-1", time.Now().UnixNano())
+	time.Sleep(1 * time.Millisecond)
+	session2 := fmt.Sprintf("test-tmux-%d-2", time.Now().UnixNano())
+	time.Sleep(1 * time.Millisecond)
+	session3 := fmt.Sprintf("test-tmux-%d-3", time.Now().UnixNano())
+
+	if err := client.CreateSession(session1, true); err != nil {
+		t.Fatalf("Failed to create session1: %v", err)
+	}
+	defer client.KillSession(session1)
+
+	if err := client.CreateSession(session2, true); err != nil {
+		t.Fatalf("Failed to create session2: %v", err)
+	}
+	defer client.KillSession(session2)
+
+	if err := client.CreateSession(session3, true); err != nil {
+		t.Fatalf("Failed to create session3: %v", err)
+	}
+	defer client.KillSession(session3)
+
+	// Verify all sessions exist
+	sessions, err := client.ListSessions()
+	if err != nil {
+		t.Fatalf("Failed to list sessions: %v", err)
+	}
+
+	sessionMap := make(map[string]bool)
+	for _, s := range sessions {
+		sessionMap[s] = true
+	}
+
+	if !sessionMap[session1] || !sessionMap[session2] || !sessionMap[session3] {
+		t.Error("Not all created sessions found in list")
+	}
+
+	// Create windows in different sessions
+	if err := client.CreateWindow(session1, "win1"); err != nil {
+		t.Fatalf("Failed to create window in session1: %v", err)
+	}
+	if err := client.CreateWindow(session2, "win2"); err != nil {
+		t.Fatalf("Failed to create window in session2: %v", err)
+	}
+
+	// Verify windows are in correct sessions
+	hasWin1, _ := client.HasWindow(session1, "win1")
+	hasWin2, _ := client.HasWindow(session2, "win2")
+	hasWin1InSession2, _ := client.HasWindow(session2, "win1")
+
+	if !hasWin1 {
+		t.Error("win1 should exist in session1")
+	}
+	if !hasWin2 {
+		t.Error("win2 should exist in session2")
+	}
+	if hasWin1InSession2 {
+		t.Error("win1 should not exist in session2")
+	}
+}
+
+func TestErrorHandling(t *testing.T) {
+	client := NewClient()
+
+	// Test operations on non-existent session
+	err := client.CreateWindow("nonexistent-session", "window")
+	if err == nil {
+		t.Error("CreateWindow on non-existent session should fail")
+	}
+
+	err = client.KillWindow("nonexistent-session", "window")
+	if err == nil {
+		t.Error("KillWindow on non-existent session should fail")
+	}
+
+	_, err = client.GetPanePID("nonexistent-session", "window")
+	if err == nil {
+		t.Error("GetPanePID on non-existent session should fail")
+	}
+
+	// Test ListWindows on non-existent session
+	_, err = client.ListWindows("nonexistent-session")
+	if err == nil {
+		t.Error("ListWindows on non-existent session should fail")
+	}
+}
+
+func TestPipePane(t *testing.T) {
+	client := NewClient()
+	session := uniqueSessionName()
+	window := "testwindow"
+
+	// Create session with a named window using tmux directly
+	cmd := exec.Command("tmux", "new-session", "-d", "-s", session, "-n", window)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(session)
+
+	// Create a temp file to capture output
+	tmpFile, err := os.CreateTemp("", "pipe-pane-test-*.log")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tmpFile.Close()
+	defer os.Remove(tmpFile.Name())
+
+	// Start pipe-pane
+	if err := client.StartPipePane(session, window, tmpFile.Name()); err != nil {
+		t.Fatalf("StartPipePane failed: %v", err)
+	}
+
+	// Send some output to the pane
+	testMessage := "Hello from pipe-pane test"
+	if err := client.SendKeys(session, window, fmt.Sprintf("echo '%s'", testMessage)); err != nil {
+		t.Fatalf("Failed to send keys: %v", err)
+	}
+
+	// Wait for output to be captured
+	time.Sleep(500 * time.Millisecond)
+
+	// Read the captured output
+	content, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	// Verify the output was captured
+	if !strings.Contains(string(content), testMessage) {
+		t.Errorf("Expected output to contain %q, got %q", testMessage, string(content))
+	}
+
+	// Stop pipe-pane
+	if err := client.StopPipePane(session, window); err != nil {
+		t.Fatalf("StopPipePane failed: %v", err)
+	}
+
+	// Send more output after stopping
+	if err := client.SendKeys(session, window, "echo 'This should not be captured'"); err != nil {
+		t.Fatalf("Failed to send keys: %v", err)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify the file size hasn't changed much (new output shouldn't be captured)
+	content2, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	// The file might have grown a bit due to the echo command appearing in the prompt
+	// but the actual "This should not be captured" message should not appear
+	if strings.Contains(string(content2), "This should not be captured") {
+		t.Error("Output was captured after StopPipePane was called")
+	}
+}
+
+func TestPipePaneErrorHandling(t *testing.T) {
+	client := NewClient()
+
+	// Test StartPipePane on non-existent session
+	err := client.StartPipePane("nonexistent-session", "window", "/tmp/test.log")
+	if err == nil {
+		t.Error("StartPipePane on non-existent session should fail")
+	}
+
+	// Test StopPipePane on non-existent session
+	err = client.StopPipePane("nonexistent-session", "window")
+	if err == nil {
+		t.Error("StopPipePane on non-existent session should fail")
+	}
+}
+
+// BenchmarkSendKeys measures the performance of sending keys to a tmux pane.
+func BenchmarkSendKeys(b *testing.B) {
+	client := NewClient()
+	sessionName := fmt.Sprintf("bench-tmux-%d", time.Now().UnixNano())
+
+	if err := client.CreateSession(sessionName, true); err != nil {
+		b.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	windowName := "bench-window"
+	if err := client.CreateWindow(sessionName, windowName); err != nil {
+		b.Fatalf("Failed to create window: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		client.SendKeysLiteral(sessionName, windowName, "test message")
+	}
+}
+
+// BenchmarkSendKeysMultiline measures sending multiline text via paste-buffer.
+func BenchmarkSendKeysMultiline(b *testing.B) {
+	client := NewClient()
+	sessionName := fmt.Sprintf("bench-tmux-%d", time.Now().UnixNano())
+
+	if err := client.CreateSession(sessionName, true); err != nil {
+		b.Fatalf("Failed to create session: %v", err)
+	}
+	defer client.KillSession(sessionName)
+
+	windowName := "bench-window"
+	if err := client.CreateWindow(sessionName, windowName); err != nil {
+		b.Fatalf("Failed to create window: %v", err)
+	}
+
+	multilineText := "line1\nline2\nline3\nline4\nline5"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		client.SendKeysLiteral(sessionName, windowName, multilineText)
+	}
+}

--- a/pkg/tmux/doc.go
+++ b/pkg/tmux/doc.go
@@ -1,0 +1,94 @@
+// Package tmux provides a Go client for programmatic interaction with tmux.
+//
+// This package focuses on features needed for interacting with running CLI
+// applications in tmux, which are not covered by existing Go tmux libraries:
+//
+//   - Multiline text input using paste-buffer (see [Client.SendKeysLiteral])
+//   - Process PID extraction from panes (see [Client.GetPanePID])
+//   - Output capture via pipe-pane (see [Client.StartPipePane], [Client.StopPipePane])
+//
+// # Installation
+//
+//	go get github.com/dlorenc/multiclaude/pkg/tmux
+//
+// # Requirements
+//
+// This package requires tmux to be installed and available in PATH.
+// Use [Client.IsTmuxAvailable] to check availability at runtime.
+//
+// # Example Usage
+//
+//	package main
+//
+//	import (
+//	    "log"
+//	    "github.com/dlorenc/multiclaude/pkg/tmux"
+//	)
+//
+//	func main() {
+//	    client := tmux.NewClient()
+//
+//	    // Verify tmux is available
+//	    if !client.IsTmuxAvailable() {
+//	        log.Fatal("tmux is not installed")
+//	    }
+//
+//	    // Create a detached session
+//	    if err := client.CreateSession("demo", true); err != nil {
+//	        log.Fatal(err)
+//	    }
+//	    defer client.KillSession("demo")
+//
+//	    // Create a named window
+//	    if err := client.CreateWindow("demo", "worker"); err != nil {
+//	        log.Fatal(err)
+//	    }
+//
+//	    // Start capturing output
+//	    if err := client.StartPipePane("demo", "worker", "/tmp/demo.log"); err != nil {
+//	        log.Fatal(err)
+//	    }
+//
+//	    // Send multiline text without triggering intermediate processing
+//	    multilineMessage := `This is a
+//	multiline message
+//	that won't trigger on each newline`
+//	    if err := client.SendKeysLiteral("demo", "worker", multilineMessage); err != nil {
+//	        log.Fatal(err)
+//	    }
+//
+//	    // Now send Enter to submit
+//	    if err := client.SendEnter("demo", "worker"); err != nil {
+//	        log.Fatal(err)
+//	    }
+//
+//	    // Get the PID of the process in the pane
+//	    pid, err := client.GetPanePID("demo", "worker")
+//	    if err != nil {
+//	        log.Fatal(err)
+//	    }
+//	    log.Printf("Process PID: %d", pid)
+//	}
+//
+// # The Paste-Buffer Technique
+//
+// When sending multiline text to a CLI application, naive approaches using
+// send-keys fail because the application may interpret each newline as a
+// command submission. This package uses tmux's paste-buffer to send the
+// entire text atomically:
+//
+//  1. Set the buffer with the full text: tmux set-buffer "..."
+//  2. Paste the buffer to the pane: tmux paste-buffer -t session:window
+//
+// This ensures the application receives the complete multiline text before
+// any processing is triggered.
+//
+// # Comparison to Other Libraries
+//
+// | Feature                    | gotmux | go-tmux | gomux | this package |
+// |----------------------------|--------|---------|-------|--------------|
+// | Session/window creation    | Yes    | Yes     | Yes   | Yes          |
+// | Multiline paste-buffer     | No     | No      | No    | Yes          |
+// | Pane PID extraction        | No     | No      | No    | Yes          |
+// | pipe-pane output capture   | No     | No      | No    | Yes          |
+package tmux


### PR DESCRIPTION
## Summary

- Creates `pkg/tmux` - A Go client for programmatic interaction with tmux, providing features not covered by existing Go tmux libraries (multiline paste-buffer, PID extraction, pipe-pane output capture)
- Creates `pkg/claude` - Utilities for programmatically running Claude Code CLI with TerminalRunner interface and session management
- Creates `pkg/claude/prompt` - Prompt building utilities for constructing layered prompts
- Updates `internal/tmux` to re-export from `pkg/tmux` for backward compatibility

## Test plan

- [x] All unit tests pass for new packages
- [x] Integration tests verify tmux operations work correctly
- [x] Existing internal tests continue to pass with the re-export
- [x] `go build ./...` succeeds
- [ ] Manual testing of imports by external projects

## Related

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)