### PR TITLE
Add documentation for workspace management commands (fixes #66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,28 @@ multiclaude stop-all --clean   # Stop and remove all state files
 multiclaude init <github-url>              # Initialize repository tracking
 multiclaude init <github-url> [path] [name] # With custom local path or name
 multiclaude list                           # List tracked repositories
+multiclaude repo rm <name>                 # Remove a tracked repository
 ```
+
+### Workspaces
+
+Workspaces are persistent Claude sessions where you interact with the codebase, spawn workers, and manage your development flow. Each workspace has its own git worktree, tmux window, and Claude instance.
+
+```bash
+multiclaude workspace add <name>           # Create a new workspace
+multiclaude workspace add <name> --branch main  # Create from specific branch
+multiclaude workspace list                 # List all workspaces
+multiclaude workspace connect <name>       # Attach to a workspace
+multiclaude workspace rm <name>            # Remove workspace (warns if uncommitted work)
+multiclaude workspace                      # List workspaces (shorthand)
+multiclaude workspace <name>               # Connect to workspace (shorthand)
+```
+
+**Notes:**
+- Workspaces use the branch naming convention `workspace/<name>`
+- Workspace names follow git branch naming rules (no spaces, special characters, etc.)
+- A "default" workspace is created automatically when you run `multiclaude init`
+- Use `multiclaude attach <workspace-name>` as an alternative to `workspace connect`
 
 ### Workers
 


### PR DESCRIPTION
## Summary

- Added comprehensive documentation for workspace management commands to the README
- Documents the workspace add/rm/list/connect commands introduced in PR #62
- Also added the missing `repo rm` command to the Repositories section

## Changes

Added a new **Workspaces** section in the Commands documentation that includes:
- `multiclaude workspace add <name> [--branch <branch>]` - Create a new workspace
- `multiclaude workspace rm <name>` - Remove a workspace
- `multiclaude workspace list` - List all workspaces
- `multiclaude workspace connect <name>` - Attach to a workspace
- Shorthand commands (`workspace` and `workspace <name>`)

Also included helpful notes about:
- Branch naming convention (`workspace/<name>`)
- Workspace name validation (follows git branch naming rules)
- Default workspace created during `multiclaude init`
- Alternative connection method via `multiclaude attach`

## Test plan

- [x] Verified documentation matches implemented command syntax in `internal/cli/cli.go`
- [x] Confirmed examples are accurate based on issue #66 requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)