### PR TITLE
Keep local main in sync with origin/main

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1260,8 +1260,28 @@ func (c *CLI) createWorker(args []string) error {
 		workerName = name
 	}
 
+	// Get repository path
+	repoPath := c.paths.RepoDir(repoName)
+
+	// Fetch latest main from origin before creating worktree
+	// This ensures workers start from the latest code, not stale local refs
+	fmt.Println("Fetching latest from origin...")
+	fetchSucceeded := false
+	fetchCmd := exec.Command("git", "fetch", "origin", "main:main")
+	fetchCmd.Dir = repoPath
+	if err := fetchCmd.Run(); err != nil {
+		// Best effort - don't fail if offline or fetch fails
+		fmt.Printf("Warning: failed to fetch origin/main: %v (continuing with local refs)\n", err)
+	} else {
+		fetchSucceeded = true
+	}
+
 	// Determine branch to start from
-	startBranch := "HEAD" // Default to current branch/HEAD
+	// Use origin/main if fetch succeeded, otherwise fall back to HEAD
+	startBranch := "HEAD"
+	if fetchSucceeded {
+		startBranch = "origin/main"
+	}
 	if branch, ok := flags["branch"]; ok {
 		startBranch = branch
 		fmt.Printf("Creating worker '%s' in repo '%s' from branch '%s'\n", workerName, repoName, branch)
@@ -1269,9 +1289,6 @@ func (c *CLI) createWorker(args []string) error {
 		fmt.Printf("Creating worker '%s' in repo '%s'\n", workerName, repoName)
 	}
 	fmt.Printf("Task: %s\n", task)
-
-	// Get repository path
-	repoPath := c.paths.RepoDir(repoName)
 
 	// Create worktree
 	wt := worktree.NewManager(repoPath)

--- a/internal/prompts/merge-queue.md
+++ b/internal/prompts/merge-queue.md
@@ -164,6 +164,21 @@ In this system, multiple agents work chaotically—duplicating effort, creating 
 
 Every merge you make locks in progress. Every passing PR you process is a ratchet click forward. Your efficiency directly determines the system's throughput.
 
+## Keeping Local Refs in Sync
+
+After successfully merging a PR, always update the local main branch to stay in sync with origin:
+
+```bash
+git fetch origin main:main
+```
+
+This is important because:
+- Workers branch off the local `main` ref when created
+- If local main is stale, new workers will start from old code
+- Stale refs cause unnecessary merge conflicts in future PRs
+
+**Always run this command immediately after each successful merge.** This ensures the next worker created will start from the latest code.
+
 ## PR Rejection Handling
 
 When a PR is rejected by human review or deemed unsalvageable, handle it gracefully while preserving all work and knowledge.


### PR DESCRIPTION
## Summary

- Fixes workers branching off stale local main refs by fetching before worker creation
- Updates merge-queue prompt to sync local refs after successful merges  
- Falls back gracefully when fetch fails (offline/test scenarios)

Fixes #76

## Changes

### `internal/cli/cli.go`
- Added `git fetch origin main:main` before worktree creation
- Uses `origin/main` as start branch if fetch succeeds
- Falls back to `HEAD` if fetch fails (maintains backward compatibility for tests/offline use)

### `internal/prompts/merge-queue.md`
- Added new "Keeping Local Refs in Sync" section
- Instructs merge-queue to run fetch after each successful merge
- Explains the importance for preventing stale refs in new workers

## Test plan

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] Verified `TestCLIWorkCreateWithRealTmux` test works with fallback logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)