### PR TITLE
Add optional Happy.engineering provider support

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1071,19 +1071,16 @@ func TestNewWithPaths(t *testing.T) {
 		OutputDir:    filepath.Join(tmpDir, "output"),
 	}
 
-	// Test with empty claude path
+	// Test CLI creation (second parameter is now ignored, provider resolved at runtime)
 	cli := NewWithPaths(paths, "")
 	if cli == nil {
 		t.Fatal("CLI should not be nil")
 	}
-	if cli.claudeBinaryPath != "claude" {
-		t.Errorf("claudeBinaryPath = %s, want 'claude'", cli.claudeBinaryPath)
-	}
 
-	// Test with custom claude path
+	// Test with custom path (now ignored - provider resolved per-repo at runtime)
 	cli = NewWithPaths(paths, "/custom/path/claude")
-	if cli.claudeBinaryPath != "/custom/path/claude" {
-		t.Errorf("claudeBinaryPath = %s, want '/custom/path/claude'", cli.claudeBinaryPath)
+	if cli == nil {
+		t.Fatal("CLI should not be nil")
 	}
 
 	// Verify commands are registered

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dlorenc/multiclaude/internal/logging"
 	"github.com/dlorenc/multiclaude/internal/messages"
 	"github.com/dlorenc/multiclaude/internal/prompts"
+	"github.com/dlorenc/multiclaude/internal/provider"
 	"github.com/dlorenc/multiclaude/internal/socket"
 	"github.com/dlorenc/multiclaude/internal/state"
 	"github.com/dlorenc/multiclaude/internal/tmux"
@@ -24,13 +25,12 @@ import (
 
 // Daemon represents the main daemon process
 type Daemon struct {
-	paths            *config.Paths
-	state            *state.State
-	tmux             *tmux.Client
-	logger           *logging.Logger
-	server           *socket.Server
-	pidFile          *PIDFile
-	claudeBinaryPath string // Full path to claude binary
+	paths   *config.Paths
+	state   *state.State
+	tmux    *tmux.Client
+	logger  *logging.Logger
+	server  *socket.Server
+	pidFile *PIDFile
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -56,24 +56,16 @@ func New(paths *config.Paths) (*Daemon, error) {
 		return nil, fmt.Errorf("failed to load state: %w", err)
 	}
 
-	// Resolve claude binary path
-	claudePath, err := exec.LookPath("claude")
-	if err != nil {
-		logger.Warn("Claude binary not found in PATH: %v", err)
-		claudePath = "claude" // Fall back to just "claude"
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 
 	d := &Daemon{
-		paths:            paths,
-		state:            st,
-		tmux:             tmux.NewClient(),
-		logger:           logger,
-		pidFile:          NewPIDFile(paths.DaemonPID),
-		claudeBinaryPath: claudePath,
-		ctx:              ctx,
-		cancel:           cancel,
+		paths:   paths,
+		state:   st,
+		tmux:    tmux.NewClient(),
+		logger:  logger,
+		pidFile: NewPIDFile(paths.DaemonPID),
+		ctx:     ctx,
+		cancel:  cancel,
 	}
 
 	// Create socket server
@@ -957,7 +949,7 @@ func (d *Daemon) handleRepairState(req socket.Request) socket.Response {
 	}
 }
 
-// handleGetRepoConfig returns the merge queue configuration for a repository
+// handleGetRepoConfig returns the configuration for a repository
 func (d *Daemon) handleGetRepoConfig(req socket.Request) socket.Response {
 	name, ok := req.Args["name"].(string)
 	if !ok {
@@ -975,51 +967,80 @@ func (d *Daemon) handleGetRepoConfig(req socket.Request) socket.Response {
 		mqConfig = state.DefaultMergeQueueConfig()
 	}
 
+	// Get provider config (use default if not set for backward compatibility)
+	providerConfig := repo.ProviderConfig
+	if providerConfig.Provider == "" {
+		providerConfig = state.DefaultProviderConfig()
+	}
+
 	return socket.Response{
 		Success: true,
 		Data: map[string]interface{}{
 			"mq_enabled":    mqConfig.Enabled,
 			"mq_track_mode": string(mqConfig.TrackMode),
+			"provider":      string(providerConfig.Provider),
 		},
 	}
 }
 
-// handleUpdateRepoConfig updates the merge queue configuration for a repository
+// handleUpdateRepoConfig updates the configuration for a repository
 func (d *Daemon) handleUpdateRepoConfig(req socket.Request) socket.Response {
 	name, ok := req.Args["name"].(string)
 	if !ok {
 		return socket.Response{Success: false, Error: "missing or invalid 'name' argument"}
 	}
 
-	// Get current config
-	currentConfig, err := d.state.GetMergeQueueConfig(name)
+	// Get current merge queue config
+	currentMQConfig, err := d.state.GetMergeQueueConfig(name)
 	if err != nil {
 		return socket.Response{Success: false, Error: err.Error()}
 	}
 
-	// Update with provided values
+	// Update merge queue config with provided values
+	mqUpdated := false
 	if mqEnabled, ok := req.Args["mq_enabled"].(bool); ok {
-		currentConfig.Enabled = mqEnabled
+		currentMQConfig.Enabled = mqEnabled
+		mqUpdated = true
 	}
 	if mqTrackMode, ok := req.Args["mq_track_mode"].(string); ok {
 		switch mqTrackMode {
 		case "all":
-			currentConfig.TrackMode = state.TrackModeAll
+			currentMQConfig.TrackMode = state.TrackModeAll
 		case "author":
-			currentConfig.TrackMode = state.TrackModeAuthor
+			currentMQConfig.TrackMode = state.TrackModeAuthor
 		case "assigned":
-			currentConfig.TrackMode = state.TrackModeAssigned
+			currentMQConfig.TrackMode = state.TrackModeAssigned
 		default:
 			return socket.Response{Success: false, Error: fmt.Sprintf("invalid track mode: %s", mqTrackMode)}
 		}
+		mqUpdated = true
 	}
 
-	// Save updated config
-	if err := d.state.UpdateMergeQueueConfig(name, currentConfig); err != nil {
-		return socket.Response{Success: false, Error: err.Error()}
+	if mqUpdated {
+		if err := d.state.UpdateMergeQueueConfig(name, currentMQConfig); err != nil {
+			return socket.Response{Success: false, Error: err.Error()}
+		}
+		d.logger.Info("Updated merge queue config for repo %s: enabled=%v, track=%s", name, currentMQConfig.Enabled, currentMQConfig.TrackMode)
 	}
 
-	d.logger.Info("Updated merge queue config for repo %s: enabled=%v, track=%s", name, currentConfig.Enabled, currentConfig.TrackMode)
+	// Handle provider config update
+	if providerVal, ok := req.Args["provider"].(string); ok {
+		switch providerVal {
+		case "claude", "happy":
+			// Validate the provider is available before setting
+			if _, err := provider.Resolve(state.ProviderType(providerVal)); err != nil {
+				return socket.Response{Success: false, Error: fmt.Sprintf("provider %s not available: %v", providerVal, err)}
+			}
+			providerConfig := state.ProviderConfig{Provider: state.ProviderType(providerVal)}
+			if err := d.state.UpdateProviderConfig(name, providerConfig); err != nil {
+				return socket.Response{Success: false, Error: err.Error()}
+			}
+			d.logger.Info("Updated provider for repo %s: %s", name, providerVal)
+		default:
+			return socket.Response{Success: false, Error: fmt.Sprintf("invalid provider: %s (must be 'claude' or 'happy')", providerVal)}
+		}
+	}
+
 	return socket.Response{Success: true}
 }
 
@@ -1224,8 +1245,29 @@ func (d *Daemon) restoreRepoAgents(repoName string, repo *state.Repository) erro
 	return nil
 }
 
+// getProviderBinaryPath resolves the CLI binary path for a repository based on its provider config
+func (d *Daemon) getProviderBinaryPath(repoName string) (string, error) {
+	providerConfig, err := d.state.GetProviderConfig(repoName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get provider config: %w", err)
+	}
+
+	info, err := provider.Resolve(providerConfig.Provider)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve provider: %w", err)
+	}
+
+	return info.BinaryPath, nil
+}
+
 // startAgent starts a Claude agent in a tmux window and registers it with state
 func (d *Daemon) startAgent(repoName string, repo *state.Repository, agentName string, agentType prompts.AgentType, workDir string) error {
+	// Resolve provider binary path for this repo
+	binaryPath, err := d.getProviderBinaryPath(repoName)
+	if err != nil {
+		return fmt.Errorf("failed to resolve provider: %w", err)
+	}
+
 	// Generate session ID
 	sessionID, err := generateSessionID()
 	if err != nil {
@@ -1244,9 +1286,9 @@ func (d *Daemon) startAgent(repoName string, repo *state.Repository, agentName s
 		d.logger.Warn("Failed to copy hooks config: %v", err)
 	}
 
-	// Build Claude command
+	// Build CLI command
 	claudeCmd := fmt.Sprintf("%s --session-id %s --dangerously-skip-permissions --append-system-prompt-file %s",
-		d.claudeBinaryPath, sessionID, promptFile)
+		binaryPath, sessionID, promptFile)
 
 	// Send command to tmux window
 	target := fmt.Sprintf("%s:%s", repo.TmuxSession, agentName)
@@ -1285,6 +1327,12 @@ func (d *Daemon) startAgent(repoName string, repo *state.Repository, agentName s
 
 // startMergeQueueAgent starts a merge-queue agent with tracking mode configuration
 func (d *Daemon) startMergeQueueAgent(repoName string, repo *state.Repository, workDir string, mqConfig state.MergeQueueConfig) error {
+	// Resolve provider binary path for this repo
+	binaryPath, err := d.getProviderBinaryPath(repoName)
+	if err != nil {
+		return fmt.Errorf("failed to resolve provider: %w", err)
+	}
+
 	// Generate session ID
 	sessionID, err := generateSessionID()
 	if err != nil {
@@ -1303,9 +1351,9 @@ func (d *Daemon) startMergeQueueAgent(repoName string, repo *state.Repository, w
 		d.logger.Warn("Failed to copy hooks config: %v", err)
 	}
 
-	// Build Claude command
+	// Build CLI command
 	claudeCmd := fmt.Sprintf("%s --session-id %s --dangerously-skip-permissions --append-system-prompt-file %s",
-		d.claudeBinaryPath, sessionID, promptFile)
+		binaryPath, sessionID, promptFile)
 
 	// Send command to tmux window
 	target := fmt.Sprintf("%s:merge-queue", repo.TmuxSession)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -230,6 +230,38 @@ func ClaudeNotFound(cause error) *CLIError {
 	}
 }
 
+// ProviderNotFound creates an error for when a provider binary is not found
+func ProviderNotFound(provider string, cause error) *CLIError {
+	suggestion := "install Claude Code CLI: https://docs.anthropic.com/claude-code"
+	if provider == "happy" {
+		suggestion = "install Happy CLI: https://happy.engineering/docs"
+	}
+	return &CLIError{
+		Category:   CategoryConfig,
+		Message:    fmt.Sprintf("%s binary not found in PATH", provider),
+		Cause:      cause,
+		Suggestion: suggestion,
+	}
+}
+
+// ProviderAuthNotConfigured creates an error for unconfigured provider auth
+func ProviderAuthNotConfigured(provider string) *CLIError {
+	return &CLIError{
+		Category:   CategoryConfig,
+		Message:    fmt.Sprintf("%s authentication not configured", provider),
+		Suggestion: fmt.Sprintf("run '%s auth login' to authenticate", provider),
+	}
+}
+
+// InvalidProvider creates an error for invalid provider values
+func InvalidProvider(value string) *CLIError {
+	return &CLIError{
+		Category:   CategoryUsage,
+		Message:    fmt.Sprintf("invalid provider: %s", value),
+		Suggestion: "use 'claude' or 'happy'",
+	}
+}
+
 // MissingArgument creates an error for missing required arguments
 func MissingArgument(argName, expectedType string) *CLIError {
 	msg := fmt.Sprintf("missing required argument: %s", argName)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,113 @@
+// Package provider handles CLI provider resolution and validation.
+// It supports multiple CLI backends (claude, happy) with per-repository configuration.
+package provider
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/dlorenc/multiclaude/internal/state"
+)
+
+const (
+	// HappyAuthFile is the path to happy's auth file relative to home directory
+	HappyAuthFile = ".happy/access.key"
+	// EnvProvider is the environment variable to override provider
+	EnvProvider = "MULTICLAUDE_PROVIDER"
+)
+
+// Info contains resolved provider information
+type Info struct {
+	Type       state.ProviderType
+	BinaryPath string
+}
+
+// Resolve resolves the binary path for a given provider type.
+// It checks the MULTICLAUDE_PROVIDER environment override first, then uses the provided type.
+// For happy provider, it also validates that authentication is configured.
+func Resolve(providerType state.ProviderType) (*Info, error) {
+	// Check environment override
+	if envProvider := os.Getenv(EnvProvider); envProvider != "" {
+		providerType = state.ProviderType(envProvider)
+	}
+
+	// Default to claude if empty
+	if providerType == "" {
+		providerType = state.ProviderClaude
+	}
+
+	// Validate provider type
+	if providerType != state.ProviderClaude && providerType != state.ProviderHappy {
+		return nil, &InvalidProviderError{Provider: string(providerType)}
+	}
+
+	binaryName := string(providerType)
+
+	// Resolve binary path
+	binaryPath, err := exec.LookPath(binaryName)
+	if err != nil {
+		return nil, &NotFoundError{Provider: providerType, Cause: err}
+	}
+
+	// For happy, verify auth exists
+	if providerType == state.ProviderHappy {
+		if err := ValidateHappyAuth(); err != nil {
+			return nil, err
+		}
+	}
+
+	return &Info{
+		Type:       providerType,
+		BinaryPath: binaryPath,
+	}, nil
+}
+
+// ValidateHappyAuth checks if happy authentication is configured.
+// Returns nil if auth is configured, error otherwise.
+func ValidateHappyAuth() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	authPath := filepath.Join(home, HappyAuthFile)
+	if _, err := os.Stat(authPath); os.IsNotExist(err) {
+		return &AuthNotConfiguredError{Provider: state.ProviderHappy}
+	}
+
+	return nil
+}
+
+// NotFoundError indicates the provider binary was not found in PATH
+type NotFoundError struct {
+	Provider state.ProviderType
+	Cause    error
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("%s binary not found in PATH", e.Provider)
+}
+
+func (e *NotFoundError) Unwrap() error {
+	return e.Cause
+}
+
+// AuthNotConfiguredError indicates the provider auth is not configured
+type AuthNotConfiguredError struct {
+	Provider state.ProviderType
+}
+
+func (e *AuthNotConfiguredError) Error() string {
+	return fmt.Sprintf("%s authentication not configured", e.Provider)
+}
+
+// InvalidProviderError indicates an invalid provider type was specified
+type InvalidProviderError struct {
+	Provider string
+}
+
+func (e *InvalidProviderError) Error() string {
+	return fmt.Sprintf("invalid provider: %s (must be 'claude' or 'happy')", e.Provider)
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,174 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dlorenc/multiclaude/internal/state"
+)
+
+func TestResolve_DefaultClaude(t *testing.T) {
+	// Empty provider should default to claude
+	info, err := Resolve("")
+	if err != nil {
+		// Skip if claude not installed
+		if _, ok := err.(*NotFoundError); ok {
+			t.Skip("claude binary not installed")
+		}
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.Type != state.ProviderClaude {
+		t.Errorf("expected provider type %q, got %q", state.ProviderClaude, info.Type)
+	}
+	if info.BinaryPath == "" {
+		t.Error("expected non-empty binary path")
+	}
+}
+
+func TestResolve_ExplicitClaude(t *testing.T) {
+	info, err := Resolve(state.ProviderClaude)
+	if err != nil {
+		if _, ok := err.(*NotFoundError); ok {
+			t.Skip("claude binary not installed")
+		}
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.Type != state.ProviderClaude {
+		t.Errorf("expected provider type %q, got %q", state.ProviderClaude, info.Type)
+	}
+}
+
+func TestResolve_Happy(t *testing.T) {
+	info, err := Resolve(state.ProviderHappy)
+	if err != nil {
+		// Could be not found or auth not configured
+		if _, ok := err.(*NotFoundError); ok {
+			t.Skip("happy binary not installed")
+		}
+		if _, ok := err.(*AuthNotConfiguredError); ok {
+			t.Skip("happy auth not configured")
+		}
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.Type != state.ProviderHappy {
+		t.Errorf("expected provider type %q, got %q", state.ProviderHappy, info.Type)
+	}
+}
+
+func TestResolve_EnvOverride(t *testing.T) {
+	// Set env var to override
+	os.Setenv(EnvProvider, "claude")
+	defer os.Unsetenv(EnvProvider)
+
+	// Even if we pass happy, env should override to claude
+	info, err := Resolve(state.ProviderHappy)
+	if err != nil {
+		if _, ok := err.(*NotFoundError); ok {
+			t.Skip("claude binary not installed")
+		}
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.Type != state.ProviderClaude {
+		t.Errorf("expected provider type %q (from env), got %q", state.ProviderClaude, info.Type)
+	}
+}
+
+func TestResolve_InvalidProvider(t *testing.T) {
+	_, err := Resolve("invalid-provider")
+	if err == nil {
+		t.Fatal("expected error for invalid provider")
+	}
+
+	if _, ok := err.(*InvalidProviderError); !ok {
+		t.Errorf("expected InvalidProviderError, got %T: %v", err, err)
+	}
+}
+
+func TestValidateHappyAuth_Missing(t *testing.T) {
+	// Create a temp home directory without auth file
+	tmpHome, err := os.MkdirTemp("", "happy-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpHome)
+
+	// Save and restore HOME
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	err = ValidateHappyAuth()
+	if err == nil {
+		t.Fatal("expected error for missing auth file")
+	}
+
+	if _, ok := err.(*AuthNotConfiguredError); !ok {
+		t.Errorf("expected AuthNotConfiguredError, got %T: %v", err, err)
+	}
+}
+
+func TestValidateHappyAuth_Present(t *testing.T) {
+	// Create a temp home directory with auth file
+	tmpHome, err := os.MkdirTemp("", "happy-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpHome)
+
+	// Create .happy/access.key
+	happyDir := filepath.Join(tmpHome, ".happy")
+	if err := os.MkdirAll(happyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	authFile := filepath.Join(happyDir, "access.key")
+	if err := os.WriteFile(authFile, []byte("test-key"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save and restore HOME
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	err = ValidateHappyAuth()
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestErrorMessages(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "NotFoundError",
+			err:      &NotFoundError{Provider: state.ProviderHappy},
+			expected: "happy binary not found in PATH",
+		},
+		{
+			name:     "AuthNotConfiguredError",
+			err:      &AuthNotConfiguredError{Provider: state.ProviderHappy},
+			expected: "happy authentication not configured",
+		},
+		{
+			name:     "InvalidProviderError",
+			err:      &InvalidProviderError{Provider: "foobar"},
+			expected: "invalid provider: foobar (must be 'claude' or 'happy')",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -31,6 +31,29 @@ const (
 	TrackModeAssigned TrackMode = "assigned"
 )
 
+// ProviderType defines which CLI backend to use
+type ProviderType string
+
+const (
+	// ProviderClaude uses the claude CLI (default)
+	ProviderClaude ProviderType = "claude"
+	// ProviderHappy uses the happy CLI from happy.engineering
+	ProviderHappy ProviderType = "happy"
+)
+
+// ProviderConfig holds configuration for the CLI provider
+type ProviderConfig struct {
+	// Provider is the CLI backend to use: "claude" or "happy" (default: "claude")
+	Provider ProviderType `json:"provider"`
+}
+
+// DefaultProviderConfig returns the default provider configuration
+func DefaultProviderConfig() ProviderConfig {
+	return ProviderConfig{
+		Provider: ProviderClaude,
+	}
+}
+
 // MergeQueueConfig holds configuration for the merge queue agent
 type MergeQueueConfig struct {
 	// Enabled determines whether the merge queue agent should run (default: true)
@@ -66,6 +89,7 @@ type Repository struct {
 	TmuxSession      string           `json:"tmux_session"`
 	Agents           map[string]Agent `json:"agents"`
 	MergeQueueConfig MergeQueueConfig `json:"merge_queue_config,omitempty"`
+	ProviderConfig   ProviderConfig   `json:"provider_config,omitempty"`
 }
 
 // State represents the entire daemon state
@@ -198,6 +222,7 @@ func (s *State) GetAllRepos() map[string]*Repository {
 			TmuxSession:      repo.TmuxSession,
 			Agents:           make(map[string]Agent, len(repo.Agents)),
 			MergeQueueConfig: repo.MergeQueueConfig,
+			ProviderConfig:   repo.ProviderConfig,
 		}
 		// Copy agents
 		for agentName, agent := range repo.Agents {
@@ -317,6 +342,37 @@ func (s *State) UpdateMergeQueueConfig(repoName string, config MergeQueueConfig)
 	}
 
 	repo.MergeQueueConfig = config
+	return s.saveUnlocked()
+}
+
+// GetProviderConfig returns the provider config for a repository
+func (s *State) GetProviderConfig(repoName string) (ProviderConfig, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	repo, exists := s.Repos[repoName]
+	if !exists {
+		return ProviderConfig{}, fmt.Errorf("repository %q not found", repoName)
+	}
+
+	// Return default config if not set (for backward compatibility)
+	if repo.ProviderConfig.Provider == "" {
+		return DefaultProviderConfig(), nil
+	}
+	return repo.ProviderConfig, nil
+}
+
+// UpdateProviderConfig updates the provider config for a repository
+func (s *State) UpdateProviderConfig(repoName string, config ProviderConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	repo, exists := s.Repos[repoName]
+	if !exists {
+		return fmt.Errorf("repository %q not found", repoName)
+	}
+
+	repo.ProviderConfig = config
 	return s.saveUnlocked()
 }
 


### PR DESCRIPTION
## Summary

Closes #85

Adds support for Happy.engineering CLI as an alternative provider to native Claude CLI. This is a per-repository configuration feature that defaults to Claude for full backward compatibility.

## Changes

- **New `internal/provider/` package**: Provider resolution logic with binary lookup and auth validation
- **State updates**: Added `ProviderType` and `ProviderConfig` types to support per-repo configuration
- **Error handling**: New provider-specific error constructors for clear user feedback
- **Daemon updates**: Provider resolution moved from startup to per-repo runtime
- **CLI updates**: Added `--provider` flag to config command, provider display in config output

## Features

- Per-repo provider configuration stored in `state.json`
- Environment variable override (`MULTICLAUDE_PROVIDER`)
- Happy auth validation (checks `~/.happy/access.key`)
- Clear error messages for missing binaries or unconfigured auth

## Usage

```bash
# View current provider (defaults to claude)
multiclaude config <repo>

# Switch to Happy
multiclaude config <repo> --provider=happy

# Switch back to Claude
multiclaude config <repo> --provider=claude

# Override via environment
MULTICLAUDE_PROVIDER=happy multiclaude work "task"
```

## Test plan

- [x] Unit tests pass for all modified packages
- [x] Build succeeds
- [ ] E2E test with claude (default behavior unchanged)
- [ ] E2E test with happy provider configured

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)