### PR TITLE
Refactor: Extract claude.Runner and GenerateSessionID to pkg/claude

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -221,36 +221,7 @@ func TestTruncateString(t *testing.T) {
 	}
 }
 
-func TestGenerateSessionID(t *testing.T) {
-	// Generate multiple session IDs and verify uniqueness
-	ids := make(map[string]bool)
-	for i := 0; i < 100; i++ {
-		id, err := generateSessionID()
-		if err != nil {
-			t.Fatalf("generateSessionID() error = %v", err)
-		}
-
-		// Check format: UUID v4 format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-		parts := strings.Split(id, "-")
-		if len(parts) != 5 {
-			t.Errorf("generateSessionID() = %q, expected 5 parts separated by dashes", id)
-		}
-
-		// Check part lengths: 8-4-4-4-12
-		expectedLens := []int{8, 4, 4, 4, 12}
-		for j, part := range parts {
-			if len(part) != expectedLens[j] {
-				t.Errorf("generateSessionID() part %d len = %d, want %d", j, len(part), expectedLens[j])
-			}
-		}
-
-		// Check uniqueness
-		if ids[id] {
-			t.Errorf("generateSessionID() generated duplicate ID: %q", id)
-		}
-		ids[id] = true
-	}
-}
+// TestGenerateSessionID is now in pkg/claude/claude_test.go
 
 func TestGenerateDocumentation(t *testing.T) {
 	// Create a minimal CLI with commands registered


### PR DESCRIPTION
## Summary

- Create new `pkg/claude` package with shared Claude instance management functionality
- Extract `GenerateSessionID()` function to eliminate duplicate UUID generation in cli.go and daemon.go
- Extract `Runner` struct to provide unified API for starting Claude instances in tmux sessions
- Migrate `cli.go` and `daemon.go` to use the new package

## Changes

### New Files
- `pkg/claude/claude.go`: Contains `Runner` struct with `Start()` method and `GenerateSessionID()` function
- `pkg/claude/claude_test.go`: Tests for session ID generation and runner creation

### Modified Files
- `internal/cli/cli.go`: Use `claude.Runner` and `claude.GenerateSessionID()`, remove duplicate code
- `internal/cli/cli_test.go`: Remove duplicate test (now in pkg/claude)
- `internal/daemon/daemon.go`: Use `claude.Runner` and `claude.GenerateSessionID()`, remove duplicate code

## Test plan
- [x] All existing tests pass
- [x] New pkg/claude tests pass
- [x] Build succeeds

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)