### PR TITLE
Sanitize tmux session names to handle dots and special characters

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2169,6 +2169,9 @@ func TestSanitizeTmuxSessionName(t *testing.T) {
 		{"repo:with:colons", "mc-repo-with-colons"},
 		{"repo with spaces", "mc-repo-with-spaces"},
 		{"simple", "mc-simple"},
+		{"repo/with/slashes", "mc-repo-with-slashes"},
+		{"path/to/repo.git", "mc-path-to-repo-git"},
+		{"repo\x00with\x1fnull", "mc-repowithnull"}, // control characters stripped
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #94

## Summary
tmux converts dots to underscores in session names, causing window creation to fail when referencing the original name with dots.

Now we sanitize repo names before using them as tmux session names:
- `demos.expanso.io` → `mc-demos-expanso-io`
- `repo:with:colons` → `mc-repo-with-colons`
- `repo with spaces` → `mc-repo-with-spaces`

## Test plan
- [x] Added `TestSanitizeTmuxSessionName` covering various special characters
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)