### PR TITLE
Fix review agent failing on external PRs from forks

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1987,26 +1987,16 @@ func (c *CLI) reviewPR(args []string) error {
 	// Get repository path
 	repoPath := c.paths.RepoDir(repoName)
 
-	// Get the PR branch name using gh CLI
-	fmt.Printf("Fetching PR branch information...\n")
-	cmd := exec.Command("gh", "pr", "view", prNumber, "--repo", fmt.Sprintf("%s/%s", parts[1], parts[2]), "--json", "headRefName", "-q", ".headRefName")
+	// Fetch the PR using GitHub's PR refs - this works for both same-repo and fork PRs
+	// The refs/pull/<number>/head ref always exists and points to the PR's head commit
+	fmt.Printf("Fetching PR #%s...\n", prNumber)
+	prRef := fmt.Sprintf("refs/pull/%s/head", prNumber)
+	localRef := fmt.Sprintf("refs/multiclaude/pr-%s", prNumber)
+	cmd := exec.Command("git", "fetch", "origin", fmt.Sprintf("%s:%s", prRef, localRef))
 	cmd.Dir = repoPath
-	branchOutput, err := cmd.Output()
-	if err != nil {
-		return errors.Wrap(errors.CategoryRuntime, "failed to get PR branch info", err).WithSuggestion("ensure 'gh' CLI is installed and authenticated: gh auth login")
-	}
-	prBranch := strings.TrimSpace(string(branchOutput))
-	if prBranch == "" {
-		return errors.New(errors.CategoryRuntime, "could not determine PR branch name - the PR may not exist or be accessible")
-	}
-
-	fmt.Printf("PR branch: %s\n", prBranch)
-
-	// Fetch the PR branch
-	cmd = exec.Command("git", "fetch", "origin", prBranch)
-	cmd.Dir = repoPath
-	if err := cmd.Run(); err != nil {
-		return errors.GitOperationFailed("fetch", err)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return errors.Wrap(errors.CategoryRuntime, fmt.Sprintf("failed to fetch PR #%s: %s", prNumber, strings.TrimSpace(string(output))), err).
+			WithSuggestion("ensure the PR exists and you have access to the repository")
 	}
 
 	// Create worktree for review
@@ -2015,7 +2005,7 @@ func (c *CLI) reviewPR(args []string) error {
 	reviewBranch := fmt.Sprintf("review/%s", reviewerName)
 
 	fmt.Printf("Creating worktree at: %s\n", wtPath)
-	if err := wt.CreateNewBranch(wtPath, reviewBranch, fmt.Sprintf("origin/%s", prBranch)); err != nil {
+	if err := wt.CreateNewBranch(wtPath, reviewBranch, localRef); err != nil {
 		return fmt.Errorf("failed to create worktree: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Fixed review agent failing to checkout branches from external contributor PRs (forks)
- Changed from fetching branch by name (`git fetch origin <branch>`) to using GitHub's PR refs (`refs/pull/<number>/head`)
- PR refs always exist and work regardless of PR source (fork or same-repo)

## Problem

The review agent was unable to review PRs from external contributors because it tried to:
1. Get the PR's branch name via `gh pr view --json headRefName`
2. Fetch that branch with `git fetch origin <branch-name>`
3. Create a worktree from `origin/<branch-name>`

For external PRs from forks, the branch doesn't exist on `origin` - it exists on the contributor's fork remote. This caused the fetch to fail.

## Solution

Instead of fetching by branch name, now use GitHub's PR refs which are available for all PRs:
- Fetch `refs/pull/<number>/head` to a local ref `refs/multiclaude/pr-<number>`
- Create the worktree from this local ref

This approach:
- Works for both same-repo PRs and fork PRs
- Eliminates the need to query the branch name via `gh` CLI
- Is more reliable since it fetches exactly what GitHub sees as the PR head

## Test plan

- [x] Build passes
- [x] All existing tests pass
- [ ] Manual test: Review a PR from a fork (requires external contributor PR)
- [ ] Manual test: Review a same-repo PR (should still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)