### PR TITLE
Add multiclaude claude command and auto-restart for managed agents

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -300,6 +300,26 @@ func (s *State) UpdateAgent(repoName, agentName string, agent Agent) error {
 	return s.saveUnlocked()
 }
 
+// UpdateAgentPID updates just the PID of an agent
+func (s *State) UpdateAgentPID(repoName, agentName string, pid int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	repo, exists := s.Repos[repoName]
+	if !exists {
+		return fmt.Errorf("repository %q not found", repoName)
+	}
+
+	agent, exists := repo.Agents[agentName]
+	if !exists {
+		return fmt.Errorf("agent %q not found in repository %q", agentName, repoName)
+	}
+
+	agent.PID = pid
+	repo.Agents[agentName] = agent
+	return s.saveUnlocked()
+}
+
 // RemoveAgent removes an agent from a repository
 func (s *State) RemoveAgent(repoName, agentName string) error {
 	s.mu.Lock()


### PR DESCRIPTION
## Summary

- Add `multiclaude claude` command for manual session restart in any agent tmux window
- Add auto-restart for supervisor/merge-queue when their Claude process exits
- Print MOTD when agents start showing how to restart if Claude exits
- Add `Resume` support to the Claude runner for `--resume` flag

## Background

When Claude exits in a tmux window (user exits, crash, etc.), restarting requires knowing the correct flags and session ID. The `--session-id` flag only works for new sessions - existing sessions need `--resume` to preserve context.

## Changes

| File | Change |
|------|--------|
| `pkg/claude/runner.go` | Add `Resume` field to Config, print MOTD before starting |
| `internal/daemon/daemon.go` | Add `restartManagedAgent()`, health check auto-restart |
| `internal/cli/cli.go` | Add `restartClaude()` command |
| `internal/state/state.go` | Add `UpdateAgentPID()` helper |
| `docs/CRASH_RECOVERY.md` | Update recovery documentation |

## Test plan

- [x] All package tests pass
- [ ] Manual test: exit Claude in a workspace, run `multiclaude claude` to restart
- [ ] Manual test: exit Claude in supervisor/merge-queue, verify auto-restart within 2 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)