### PR TITLE
Fix get_repo_config request using wrong argument key

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -93,7 +93,7 @@ func (c *CLI) getProviderForRepo(repoName string) (*provider.Info, error) {
 	client := socket.NewClient(c.paths.DaemonSock)
 	resp, err := client.Send(socket.Request{
 		Command: "get_repo_config",
-		Args:    map[string]interface{}{"repo": repoName},
+		Args:    map[string]interface{}{"name": repoName},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repo config: %w", err)


### PR DESCRIPTION
## Summary
- Fixes bug where `getProviderForRepo` sent repo name with key "repo" but the daemon handler expected key "name"
- This caused `"failed to resolve provider: missing or invalid 'name' argument"` errors during repository initialization

## Root Cause
In `internal/cli/cli.go:96`, the socket request was:
```go
Args: map[string]interface{}{"repo": repoName}
```

But `handleGetRepoConfig` in `internal/daemon/daemon.go:963` expects:
```go
name, ok := req.Args["name"].(string)
```

## Fix
Changed the argument key from "repo" to "name" to match the daemon handler's expectation.

## Test plan
- [x] Build succeeds
- [x] Unit tests pass
- [ ] Manual verification that `multiclaude init` now works without the provider resolution error

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)