### PR TITLE
feat(coordination): Add foundational types for hybrid deployment (#58)

### DIFF
--- a/internal/coordination/registry.go
+++ b/internal/coordination/registry.go
@@ -1,0 +1,221 @@
+package coordination
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Registry provides access to the agent registry.
+// It tracks all agents (local and remote) and their current state.
+type Registry interface {
+	// Register adds or updates an agent in the registry
+	Register(agent *AgentInfo) error
+	// Unregister removes an agent from the registry
+	Unregister(repoName, agentName string) error
+	// Get retrieves an agent by name
+	Get(repoName, agentName string) (*AgentInfo, error)
+	// List returns all agents for a repository
+	List(repoName string) ([]*AgentInfo, error)
+	// ListByType returns agents of a specific type
+	ListByType(repoName, agentType string) ([]*AgentInfo, error)
+	// ListByLocation returns agents at a specific location
+	ListByLocation(repoName string, location Location) ([]*AgentInfo, error)
+	// UpdateHeartbeat updates the last heartbeat time for an agent
+	UpdateHeartbeat(repoName, agentName string) error
+	// UpdateStatus updates the status of an agent
+	UpdateStatus(repoName, agentName string, status AgentStatus) error
+}
+
+// LocalRegistry implements Registry using in-memory storage.
+// This is used when hybrid mode is disabled or as a local cache.
+type LocalRegistry struct {
+	mu     sync.RWMutex
+	agents map[string]map[string]*AgentInfo // repo -> agent name -> info
+}
+
+// NewLocalRegistry creates a new local registry
+func NewLocalRegistry() *LocalRegistry {
+	return &LocalRegistry{
+		agents: make(map[string]map[string]*AgentInfo),
+	}
+}
+
+// Register adds or updates an agent in the registry
+func (r *LocalRegistry) Register(agent *AgentInfo) error {
+	if agent.Name == "" {
+		return fmt.Errorf("agent name is required")
+	}
+	if agent.RepoName == "" {
+		return fmt.Errorf("repo name is required")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.agents[agent.RepoName] == nil {
+		r.agents[agent.RepoName] = make(map[string]*AgentInfo)
+	}
+
+	// Set registration time if not already set
+	if agent.RegisteredAt.IsZero() {
+		agent.RegisteredAt = time.Now()
+	}
+	agent.LastHeartbeat = time.Now()
+
+	// Set ownership if not specified
+	if agent.Ownership == "" {
+		agent.Ownership = GetOwnershipLevel(agent.Type)
+	}
+
+	r.agents[agent.RepoName][agent.Name] = agent
+	return nil
+}
+
+// Unregister removes an agent from the registry
+func (r *LocalRegistry) Unregister(repoName, agentName string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.agents[repoName] == nil {
+		return fmt.Errorf("repository %q not found in registry", repoName)
+	}
+
+	if _, exists := r.agents[repoName][agentName]; !exists {
+		return fmt.Errorf("agent %q not found in repository %q", agentName, repoName)
+	}
+
+	delete(r.agents[repoName], agentName)
+	return nil
+}
+
+// Get retrieves an agent by name
+func (r *LocalRegistry) Get(repoName, agentName string) (*AgentInfo, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.agents[repoName] == nil {
+		return nil, fmt.Errorf("repository %q not found in registry", repoName)
+	}
+
+	agent, exists := r.agents[repoName][agentName]
+	if !exists {
+		return nil, fmt.Errorf("agent %q not found in repository %q", agentName, repoName)
+	}
+
+	// Return a copy to prevent mutation
+	copy := *agent
+	return &copy, nil
+}
+
+// List returns all agents for a repository
+func (r *LocalRegistry) List(repoName string) ([]*AgentInfo, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.agents[repoName] == nil {
+		return []*AgentInfo{}, nil
+	}
+
+	result := make([]*AgentInfo, 0, len(r.agents[repoName]))
+	for _, agent := range r.agents[repoName] {
+		copy := *agent
+		result = append(result, &copy)
+	}
+	return result, nil
+}
+
+// ListByType returns agents of a specific type
+func (r *LocalRegistry) ListByType(repoName, agentType string) ([]*AgentInfo, error) {
+	agents, err := r.List(repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*AgentInfo
+	for _, agent := range agents {
+		if agent.Type == agentType {
+			result = append(result, agent)
+		}
+	}
+	return result, nil
+}
+
+// ListByLocation returns agents at a specific location
+func (r *LocalRegistry) ListByLocation(repoName string, location Location) ([]*AgentInfo, error) {
+	agents, err := r.List(repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*AgentInfo
+	for _, agent := range agents {
+		if agent.Location == location {
+			result = append(result, agent)
+		}
+	}
+	return result, nil
+}
+
+// UpdateHeartbeat updates the last heartbeat time for an agent
+func (r *LocalRegistry) UpdateHeartbeat(repoName, agentName string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.agents[repoName] == nil {
+		return fmt.Errorf("repository %q not found in registry", repoName)
+	}
+
+	agent, exists := r.agents[repoName][agentName]
+	if !exists {
+		return fmt.Errorf("agent %q not found in repository %q", agentName, repoName)
+	}
+
+	agent.LastHeartbeat = time.Now()
+	return nil
+}
+
+// UpdateStatus updates the status of an agent
+func (r *LocalRegistry) UpdateStatus(repoName, agentName string, status AgentStatus) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.agents[repoName] == nil {
+		return fmt.Errorf("repository %q not found in registry", repoName)
+	}
+
+	agent, exists := r.agents[repoName][agentName]
+	if !exists {
+		return fmt.Errorf("agent %q not found in repository %q", agentName, repoName)
+	}
+
+	agent.Status = status
+	agent.LastHeartbeat = time.Now()
+	return nil
+}
+
+// GetStaleAgents returns agents that haven't sent a heartbeat within the threshold
+func (r *LocalRegistry) GetStaleAgents(repoName string, threshold time.Duration) ([]*AgentInfo, error) {
+	agents, err := r.List(repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	cutoff := time.Now().Add(-threshold)
+	var stale []*AgentInfo
+	for _, agent := range agents {
+		if agent.LastHeartbeat.Before(cutoff) && agent.Status != StatusTerminated {
+			result := *agent
+			result.Status = StatusUnreachable
+			stale = append(stale, &result)
+		}
+	}
+	return stale, nil
+}
+
+// Clear removes all agents for a repository
+func (r *LocalRegistry) Clear(repoName string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.agents, repoName)
+}

--- a/internal/coordination/registry_test.go
+++ b/internal/coordination/registry_test.go
@@ -1,0 +1,287 @@
+package coordination
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLocalRegistry_Register(t *testing.T) {
+	registry := NewLocalRegistry()
+
+	agent := &AgentInfo{
+		Name:     "test-worker",
+		Type:     "worker",
+		RepoName: "test-repo",
+		Location: LocationLocal,
+		Status:   StatusActive,
+	}
+
+	err := registry.Register(agent)
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	// Verify registration
+	got, err := registry.Get("test-repo", "test-worker")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if got.Name != "test-worker" {
+		t.Errorf("Name = %q, want %q", got.Name, "test-worker")
+	}
+	if got.Ownership != OwnershipTask {
+		t.Errorf("Ownership = %q, want %q", got.Ownership, OwnershipTask)
+	}
+	if got.RegisteredAt.IsZero() {
+		t.Error("RegisteredAt should be set")
+	}
+}
+
+func TestLocalRegistry_RegisterValidation(t *testing.T) {
+	registry := NewLocalRegistry()
+
+	// Missing name
+	err := registry.Register(&AgentInfo{RepoName: "repo"})
+	if err == nil {
+		t.Error("expected error for missing name")
+	}
+
+	// Missing repo
+	err = registry.Register(&AgentInfo{Name: "agent"})
+	if err == nil {
+		t.Error("expected error for missing repo")
+	}
+}
+
+func TestLocalRegistry_Unregister(t *testing.T) {
+	registry := NewLocalRegistry()
+
+	agent := &AgentInfo{
+		Name:     "test-worker",
+		Type:     "worker",
+		RepoName: "test-repo",
+		Location: LocationLocal,
+	}
+
+	registry.Register(agent)
+
+	err := registry.Unregister("test-repo", "test-worker")
+	if err != nil {
+		t.Fatalf("Unregister failed: %v", err)
+	}
+
+	// Verify removed
+	_, err = registry.Get("test-repo", "test-worker")
+	if err == nil {
+		t.Error("expected error after unregister")
+	}
+}
+
+func TestLocalRegistry_List(t *testing.T) {
+	registry := NewLocalRegistry()
+
+	// Register multiple agents
+	agents := []*AgentInfo{
+		{Name: "supervisor", Type: "supervisor", RepoName: "test-repo", Location: LocationLocal},
+		{Name: "worker-1", Type: "worker", RepoName: "test-repo", Location: LocationLocal},
+		{Name: "worker-2", Type: "worker", RepoName: "test-repo", Location: LocationRemote},
+	}
+
+	for _, a := range agents {
+		registry.Register(a)
+	}
+
+	// List all
+	result, err := registry.List("test-repo")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(result) != 3 {
+		t.Errorf("List returned %d agents, want 3", len(result))
+	}
+}
+
+func TestLocalRegistry_ListByType(t *testing.T) {
+	registry := NewLocalRegistry()
+
+	agents := []*AgentInfo{
+		{Name: "supervisor", Type: "supervisor", RepoName: "test-repo", Location: LocationLocal},
+		{Name: "worker-1", Type: "worker", RepoName: "test-repo", Location: LocationLocal},
+		{Name: "worker-2", Type: "worker", RepoName: "test-repo", Location: LocationRemote},
+	}
+
+	for _, a := range agents {
+		registry.Register(a)
+	}
+
+	// List workers only
+	workers, err := registry.ListByType("test-repo", "worker")
+	if err != nil {
+		t.Fatalf("ListByType failed: %v", err)
+	}
+	if len(workers) != 2 {
+		t.Errorf("ListByType returned %d workers, want 2", len(workers))
+	}
+}
+
+func TestLocalRegistry_ListByLocation(t *testing.T) {
+	registry := NewLocalRegistry()
+
+	agents := []*AgentInfo{
+		{Name: "supervisor", Type: "supervisor", RepoName: "test-repo", Location: LocationLocal},
+		{Name: "worker-1", Type: "worker", RepoName: "test-repo", Location: LocationLocal},
+		{Name: "worker-2", Type: "worker", RepoName: "test-repo", Location: LocationRemote},
+	}
+
+	for _, a := range agents {
+		registry.Register(a)
+	}
+
+	// List local agents
+	local, err := registry.ListByLocation("test-repo", LocationLocal)
+	if err != nil {
+		t.Fatalf("ListByLocation failed: %v", err)
+	}
+	if len(local) != 2 {
+		t.Errorf("ListByLocation returned %d local agents, want 2", len(local))
+	}
+
+	// List remote agents
+	remote, err := registry.ListByLocation("test-repo", LocationRemote)
+	if err != nil {
+		t.Fatalf("ListByLocation failed: %v", err)
+	}
+	if len(remote) != 1 {
+		t.Errorf("ListByLocation returned %d remote agents, want 1", len(remote))
+	}
+}
+
+func TestLocalRegistry_UpdateHeartbeat(t *testing.T) {
+	registry := NewLocalRegistry()
+
+	agent := &AgentInfo{
+		Name:     "test-worker",
+		Type:     "worker",
+		RepoName: "test-repo",
+		Location: LocationLocal,
+	}
+	registry.Register(agent)
+
+	// Sleep briefly to ensure time difference
+	time.Sleep(10 * time.Millisecond)
+
+	err := registry.UpdateHeartbeat("test-repo", "test-worker")
+	if err != nil {
+		t.Fatalf("UpdateHeartbeat failed: %v", err)
+	}
+
+	got, _ := registry.Get("test-repo", "test-worker")
+	if got.LastHeartbeat.Before(agent.LastHeartbeat) {
+		t.Error("LastHeartbeat should be updated")
+	}
+}
+
+func TestLocalRegistry_UpdateStatus(t *testing.T) {
+	registry := NewLocalRegistry()
+
+	agent := &AgentInfo{
+		Name:     "test-worker",
+		Type:     "worker",
+		RepoName: "test-repo",
+		Location: LocationLocal,
+		Status:   StatusActive,
+	}
+	registry.Register(agent)
+
+	err := registry.UpdateStatus("test-repo", "test-worker", StatusBusy)
+	if err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	got, _ := registry.Get("test-repo", "test-worker")
+	if got.Status != StatusBusy {
+		t.Errorf("Status = %q, want %q", got.Status, StatusBusy)
+	}
+}
+
+func TestLocalRegistry_GetStaleAgents(t *testing.T) {
+	registry := NewLocalRegistry()
+
+	// Register an agent with old heartbeat
+	agent := &AgentInfo{
+		Name:          "stale-worker",
+		Type:          "worker",
+		RepoName:      "test-repo",
+		Location:      LocationLocal,
+		Status:        StatusActive,
+		LastHeartbeat: time.Now().Add(-5 * time.Minute),
+	}
+	registry.mu.Lock()
+	if registry.agents["test-repo"] == nil {
+		registry.agents["test-repo"] = make(map[string]*AgentInfo)
+	}
+	registry.agents["test-repo"]["stale-worker"] = agent
+	registry.mu.Unlock()
+
+	// Register a fresh agent
+	fresh := &AgentInfo{
+		Name:     "fresh-worker",
+		Type:     "worker",
+		RepoName: "test-repo",
+		Location: LocationLocal,
+		Status:   StatusActive,
+	}
+	registry.Register(fresh)
+
+	// Check for stale agents (threshold 2 minutes)
+	stale, err := registry.GetStaleAgents("test-repo", 2*time.Minute)
+	if err != nil {
+		t.Fatalf("GetStaleAgents failed: %v", err)
+	}
+
+	if len(stale) != 1 {
+		t.Errorf("GetStaleAgents returned %d agents, want 1", len(stale))
+	}
+
+	if len(stale) > 0 && stale[0].Name != "stale-worker" {
+		t.Errorf("Expected stale-worker, got %s", stale[0].Name)
+	}
+}
+
+func TestLocalRegistry_Clear(t *testing.T) {
+	registry := NewLocalRegistry()
+
+	agents := []*AgentInfo{
+		{Name: "agent-1", Type: "worker", RepoName: "test-repo", Location: LocationLocal},
+		{Name: "agent-2", Type: "worker", RepoName: "test-repo", Location: LocationLocal},
+	}
+
+	for _, a := range agents {
+		registry.Register(a)
+	}
+
+	registry.Clear("test-repo")
+
+	result, _ := registry.List("test-repo")
+	if len(result) != 0 {
+		t.Errorf("Clear should remove all agents, got %d", len(result))
+	}
+}
+
+func TestLocalRegistry_GetNonExistent(t *testing.T) {
+	registry := NewLocalRegistry()
+
+	// Non-existent repo
+	_, err := registry.Get("no-repo", "agent")
+	if err == nil {
+		t.Error("expected error for non-existent repo")
+	}
+
+	// Non-existent agent
+	registry.Register(&AgentInfo{Name: "exists", Type: "worker", RepoName: "repo"})
+	_, err = registry.Get("repo", "no-agent")
+	if err == nil {
+		t.Error("expected error for non-existent agent")
+	}
+}

--- a/internal/coordination/types.go
+++ b/internal/coordination/types.go
@@ -1,0 +1,172 @@
+// Package coordination provides types and interfaces for hybrid agent deployment.
+// It enables local and remote agents to coordinate through a shared registry and
+// message routing system.
+package coordination
+
+import (
+	"time"
+)
+
+// Location represents where an agent is running
+type Location string
+
+const (
+	// LocationLocal indicates an agent running on the developer's machine
+	LocationLocal Location = "local"
+	// LocationRemote indicates an agent running on remote infrastructure
+	LocationRemote Location = "remote"
+)
+
+// OwnershipLevel defines the ownership scope of an agent
+type OwnershipLevel string
+
+const (
+	// OwnershipRepo indicates agents shared by the whole team (supervisor, merge-queue, review)
+	OwnershipRepo OwnershipLevel = "repo"
+	// OwnershipUser indicates agents owned by individual developers (workspace)
+	OwnershipUser OwnershipLevel = "user"
+	// OwnershipTask indicates ephemeral agents for specific tasks (workers)
+	OwnershipTask OwnershipLevel = "task"
+)
+
+// AgentInfo represents an agent's registration in the coordination system
+type AgentInfo struct {
+	// Name is the unique identifier for this agent within the repo
+	Name string `json:"name"`
+	// Type is the agent type (supervisor, worker, merge-queue, workspace, review)
+	Type string `json:"type"`
+	// Location indicates whether the agent runs locally or remotely
+	Location Location `json:"location"`
+	// Ownership indicates the ownership level of this agent
+	Ownership OwnershipLevel `json:"ownership"`
+	// RepoName is the repository this agent is associated with
+	RepoName string `json:"repo_name"`
+	// Owner is the user/entity that owns this agent (for user/task level)
+	Owner string `json:"owner,omitempty"`
+	// Endpoint is the API endpoint for remote agents (empty for local)
+	Endpoint string `json:"endpoint,omitempty"`
+	// RegisteredAt is when this agent was registered
+	RegisteredAt time.Time `json:"registered_at"`
+	// LastHeartbeat is the last time this agent reported healthy
+	LastHeartbeat time.Time `json:"last_heartbeat"`
+	// Status indicates the current agent status
+	Status AgentStatus `json:"status"`
+	// Metadata contains additional agent-specific data
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// AgentStatus represents the current state of an agent
+type AgentStatus string
+
+const (
+	// StatusActive indicates the agent is running and healthy
+	StatusActive AgentStatus = "active"
+	// StatusIdle indicates the agent is running but not working on anything
+	StatusIdle AgentStatus = "idle"
+	// StatusBusy indicates the agent is currently working on a task
+	StatusBusy AgentStatus = "busy"
+	// StatusUnreachable indicates the agent has not reported in recently
+	StatusUnreachable AgentStatus = "unreachable"
+	// StatusTerminated indicates the agent has been shut down
+	StatusTerminated AgentStatus = "terminated"
+)
+
+// RoutedMessage represents a message being routed through the coordination system
+type RoutedMessage struct {
+	// ID is the unique message identifier
+	ID string `json:"id"`
+	// From is the sender agent name
+	From string `json:"from"`
+	// To is the recipient agent name
+	To string `json:"to"`
+	// RepoName is the repository context
+	RepoName string `json:"repo_name"`
+	// Body is the message content
+	Body string `json:"body"`
+	// Timestamp is when the message was created
+	Timestamp time.Time `json:"timestamp"`
+	// RouteInfo contains routing metadata
+	RouteInfo *RouteInfo `json:"route_info,omitempty"`
+}
+
+// RouteInfo contains information about how a message was routed
+type RouteInfo struct {
+	// SourceLocation is where the sender is running
+	SourceLocation Location `json:"source_location"`
+	// DestLocation is where the recipient is running
+	DestLocation Location `json:"dest_location"`
+	// RoutedVia indicates if the message was routed through the API
+	RoutedVia string `json:"routed_via,omitempty"`
+	// RoutedAt is when the message was routed
+	RoutedAt time.Time `json:"routed_at"`
+}
+
+// SpawnRequest represents a request to spawn a new worker agent
+type SpawnRequest struct {
+	// RepoName is the repository to spawn the worker for
+	RepoName string `json:"repo_name"`
+	// Task is the task description for the worker
+	Task string `json:"task"`
+	// SpawnedBy is the agent or user requesting the spawn
+	SpawnedBy string `json:"spawned_by"`
+	// PreferLocation is the preferred location for the worker (optional)
+	PreferLocation Location `json:"prefer_location,omitempty"`
+	// Metadata contains additional spawn parameters
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// SpawnResponse represents the result of a spawn request
+type SpawnResponse struct {
+	// WorkerName is the assigned name for the spawned worker
+	WorkerName string `json:"worker_name"`
+	// Location is where the worker was spawned
+	Location Location `json:"location"`
+	// Endpoint is the endpoint to communicate with the worker (for remote)
+	Endpoint string `json:"endpoint,omitempty"`
+	// Error is set if the spawn failed
+	Error string `json:"error,omitempty"`
+}
+
+// HybridConfig holds configuration for hybrid deployment mode
+type HybridConfig struct {
+	// Enabled indicates whether hybrid mode is active
+	Enabled bool `json:"enabled"`
+	// CoordinationAPIURL is the URL of the coordination API service
+	CoordinationAPIURL string `json:"coordination_api_url,omitempty"`
+	// APIToken is the authentication token for the coordination API
+	APIToken string `json:"api_token,omitempty"`
+	// LocalAgentTypes specifies which agent types should run locally
+	LocalAgentTypes []string `json:"local_agent_types,omitempty"`
+	// RemoteAgentTypes specifies which agent types should run remotely
+	RemoteAgentTypes []string `json:"remote_agent_types,omitempty"`
+	// FallbackToLocal indicates whether to fall back to local if remote is unavailable
+	FallbackToLocal bool `json:"fallback_to_local"`
+}
+
+// DefaultHybridConfig returns the default hybrid configuration (disabled)
+func DefaultHybridConfig() HybridConfig {
+	return HybridConfig{
+		Enabled:         false,
+		FallbackToLocal: true,
+		LocalAgentTypes: []string{"workspace"},
+		RemoteAgentTypes: []string{
+			"supervisor",
+			"merge-queue",
+			"worker",
+		},
+	}
+}
+
+// GetOwnershipLevel returns the ownership level for a given agent type
+func GetOwnershipLevel(agentType string) OwnershipLevel {
+	switch agentType {
+	case "supervisor", "merge-queue", "review":
+		return OwnershipRepo
+	case "workspace":
+		return OwnershipUser
+	case "worker":
+		return OwnershipTask
+	default:
+		return OwnershipTask
+	}
+}

--- a/internal/coordination/types_test.go
+++ b/internal/coordination/types_test.go
@@ -1,0 +1,95 @@
+package coordination
+
+import (
+	"testing"
+)
+
+func TestGetOwnershipLevel(t *testing.T) {
+	tests := []struct {
+		agentType string
+		expected  OwnershipLevel
+	}{
+		{"supervisor", OwnershipRepo},
+		{"merge-queue", OwnershipRepo},
+		{"review", OwnershipRepo},
+		{"workspace", OwnershipUser},
+		{"worker", OwnershipTask},
+		{"unknown", OwnershipTask},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.agentType, func(t *testing.T) {
+			got := GetOwnershipLevel(tt.agentType)
+			if got != tt.expected {
+				t.Errorf("GetOwnershipLevel(%q) = %q, want %q", tt.agentType, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultHybridConfig(t *testing.T) {
+	config := DefaultHybridConfig()
+
+	if config.Enabled {
+		t.Error("default hybrid config should be disabled")
+	}
+
+	if !config.FallbackToLocal {
+		t.Error("default should fall back to local")
+	}
+
+	// Check local agent types
+	foundWorkspace := false
+	for _, at := range config.LocalAgentTypes {
+		if at == "workspace" {
+			foundWorkspace = true
+		}
+	}
+	if !foundWorkspace {
+		t.Error("workspace should be in local agent types")
+	}
+
+	// Check remote agent types
+	expectedRemote := map[string]bool{
+		"supervisor":  true,
+		"merge-queue": true,
+		"worker":      true,
+	}
+	for _, at := range config.RemoteAgentTypes {
+		if !expectedRemote[at] {
+			t.Errorf("unexpected remote agent type: %s", at)
+		}
+		delete(expectedRemote, at)
+	}
+	if len(expectedRemote) > 0 {
+		t.Errorf("missing remote agent types: %v", expectedRemote)
+	}
+}
+
+func TestLocationConstants(t *testing.T) {
+	if LocationLocal != "local" {
+		t.Errorf("LocationLocal = %q, want %q", LocationLocal, "local")
+	}
+	if LocationRemote != "remote" {
+		t.Errorf("LocationRemote = %q, want %q", LocationRemote, "remote")
+	}
+}
+
+func TestAgentStatusConstants(t *testing.T) {
+	statuses := []struct {
+		status   AgentStatus
+		expected string
+	}{
+		{StatusActive, "active"},
+		{StatusIdle, "idle"},
+		{StatusBusy, "busy"},
+		{StatusUnreachable, "unreachable"},
+		{StatusTerminated, "terminated"},
+	}
+
+	for _, tt := range statuses {
+		if string(tt.status) != tt.expected {
+			t.Errorf("status %v = %q, want %q", tt.status, tt.status, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Initial implementation of hybrid deployment types for issue #58. This is the first step toward enabling local + remote agent architectures.

**New package: `internal/coordination`**

- **Location type** (`local`/`remote`) for tracking where agents run
- **OwnershipLevel type** (`repo`/`user`/`task`) for agent ownership semantics
- **AgentInfo struct** for agent registration in coordination system
- **AgentStatus** for tracking agent state (`active`/`idle`/`busy`/`unreachable`/`terminated`)
- **RoutedMessage and RouteInfo** for cross-location message routing
- **SpawnRequest/SpawnResponse** for remote worker spawning
- **HybridConfig** for per-repo hybrid mode configuration
- **LocalRegistry** implementation with in-memory storage

## Design Decisions

1. **Location-agnostic agents**: Agents are identified by name within a repo, with location tracked separately
2. **Ownership levels**: Aligns with issue #58's identity model (repo/user/task)
3. **Local-first**: LocalRegistry serves as both standalone implementation and local cache for hybrid mode
4. **Heartbeat-based health**: Stale agent detection via configurable heartbeat threshold

## Test plan

- [x] Unit tests for all types and registry methods
- [x] Full test suite passes: `go test ./...`

## Next steps (future PRs)

1. Add coordination API client for remote registry
2. Integrate with existing daemon for message routing
3. Add CLI commands for hybrid mode configuration
4. Implement remote worker spawning

Closes #58 (partial - foundational types only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)