### PR TITLE
feat: Add self-update notification and multiclaude update command

### DIFF
--- a/docs/update-prd.md
+++ b/docs/update-prd.md
@@ -1,0 +1,213 @@
+# PRD: Self-Update Feature for Multiclaude
+
+## Overview
+
+This document describes the design and implementation of self-update functionality for multiclaude, enabling users to check for and install updates without manual intervention.
+
+## Goals
+
+1. **Automatic Update Notification**: Users should be informed when a new version is available
+2. **Easy Update Process**: A single command (`multiclaude update`) should handle the entire update process
+3. **Graceful Daemon Handling**: The update process should cleanly stop the daemon, install the new version, and optionally restart it
+4. **Minimal User Friction**: The update process should be as seamless as possible
+
+## Non-Goals
+
+- Auto-updating without user consent (updates are user-initiated)
+- Supporting non-`go install` installation methods (homebrew, apt, etc.) in this iteration
+- Rollback functionality (can be added later)
+
+## Design
+
+### Update Check (Daemon Loop)
+
+The daemon includes an update check loop that runs every 30 minutes:
+
+1. Uses `go list -m -u -json github.com/dlorenc/multiclaude@latest` to check for updates
+2. Compares the latest available version with the current running version
+3. Stores the result in the daemon state (`state.json`)
+4. Logs a message when an update is available
+
+### Update Status Command
+
+`multiclaude daemon status` (or a new `multiclaude update --check` flag) displays:
+- Current version
+- Latest available version
+- Whether an update is available
+- When the last check was performed
+
+### Update Command
+
+`multiclaude update` performs the following steps:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                    multiclaude update                          │
+└─────────────────────────────┬──────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 1. Check for updates                                            │
+│    - Query latest version from Go proxy                         │
+│    - Compare with current version                               │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 2. Verify installation method                                   │
+│    - Check if binary is under GOPATH/bin                        │
+│    - Fail gracefully if not go-installed                        │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 3. Stop daemon gracefully                                       │
+│    - Send stop command via socket                               │
+│    - Wait for daemon to terminate                               │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 4. Install new version                                          │
+│    - Run: go install github.com/dlorenc/multiclaude/cmd/...@latest │
+│    - Verify installation succeeded                              │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 5. (Optional) Restart daemon                                    │
+│    - If daemon was running, restart with new binary             │
+│    - New binary handles all agent restoration automatically     │
+└─────────────────────────────┴───────────────────────────────────┘
+```
+
+### Command Options
+
+```
+multiclaude update [options]
+
+Options:
+  --check           Only check for updates, don't install
+  --yes, -y         Skip confirmation prompt
+  --no-restart      Don't restart daemon after update
+  --force           Update even if already on latest version
+```
+
+### Limitations and Considerations
+
+#### Binary Replacement Challenges
+
+1. **Running Binary**: On some systems (notably Windows), a running binary cannot be replaced. On Unix systems, the binary can be replaced while running because the OS keeps the old binary in memory until the process exits.
+
+2. **Process Lifecycle**: The `multiclaude update` command itself is running the old binary. After `go install` completes, the new binary is on disk, but the current process continues with the old code in memory. This is handled by:
+   - Stopping the daemon (separate process) before update
+   - Restarting the daemon after update uses the new binary
+   - The CLI command completes using the old binary, but subsequent commands use the new one
+
+3. **Daemon Restart**: When the daemon is restarted after update, it:
+   - Loads from the new binary location
+   - Restores all tracked repositories
+   - Recreates agent windows (supervisor, merge-queue, workspace)
+   - Existing workers with active PRs remain as tmux windows but need manual restart
+
+#### Installation Method Detection
+
+The update command only works for `go install` installations:
+
+```go
+// Check if binary is under GOPATH/bin
+func (u *Updater) CanUpdate() (bool, string) {
+    currentExe, _ := os.Executable()
+    gopath := os.Getenv("GOPATH")
+    if gopath == "" {
+        gopath = filepath.Join(os.UserHomeDir(), "go")
+    }
+    goBin := filepath.Join(gopath, "bin")
+
+    if !strings.HasPrefix(currentExe, goBin) {
+        return false, "binary not installed via 'go install'"
+    }
+    return true, ""
+}
+```
+
+For other installation methods:
+- **Homebrew**: Users should use `brew upgrade multiclaude`
+- **apt/deb**: Users should use their package manager
+- **Manual download**: Users should re-download from releases
+
+### State Tracking
+
+Update status is stored in `~/.multiclaude/state.json`:
+
+```json
+{
+  "update_status": {
+    "last_checked": "2025-01-20T12:00:00Z",
+    "current_version": "v0.1.0",
+    "latest_version": "v0.2.0",
+    "update_available": true,
+    "last_error": ""
+  }
+}
+```
+
+### User Experience
+
+#### Update Available Notification
+
+When an update is available and the user runs any multiclaude command:
+
+```
+$ multiclaude list
+Notice: Update available (v0.1.0 → v0.2.0). Run 'multiclaude update' to upgrade.
+
+repo-1  Running  3 workers
+repo-2  Running  1 worker
+```
+
+#### Update Flow
+
+```
+$ multiclaude update
+Checking for updates...
+Current version: v0.1.0
+Latest version:  v0.2.0
+
+An update is available. Proceed? [Y/n] y
+
+Stopping daemon...
+Installing multiclaude v0.2.0...
+Successfully installed v0.2.0
+
+Restarting daemon...
+Daemon started successfully.
+
+Update complete! You are now running multiclaude v0.2.0
+```
+
+#### No Update Available
+
+```
+$ multiclaude update
+Checking for updates...
+You are already running the latest version (v0.2.0)
+```
+
+## Future Enhancements
+
+1. **Rollback Support**: Store the previous version and provide `multiclaude update --rollback`
+2. **Release Notes**: Fetch and display release notes for the new version
+3. **Scheduled Updates**: Allow configuring automatic update installation during off-hours
+4. **Package Manager Support**: Detect and use the correct update method (brew, apt, etc.)
+5. **Binary Signature Verification**: Verify downloaded binaries are signed by Anthropic
+
+## Implementation Status
+
+- [x] Update checker package (`internal/update`)
+- [x] Daemon update check loop (30-minute interval)
+- [x] Update status in state
+- [x] Socket handlers for update status
+- [ ] `multiclaude update` CLI command
+- [ ] Update notification on CLI commands
+- [ ] Tests for update functionality

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -19,6 +21,7 @@ import (
 	"github.com/dlorenc/multiclaude/internal/provider"
 	"github.com/dlorenc/multiclaude/internal/socket"
 	"github.com/dlorenc/multiclaude/internal/state"
+	"github.com/dlorenc/multiclaude/internal/update"
 	"github.com/dlorenc/multiclaude/internal/worktree"
 	"github.com/dlorenc/multiclaude/pkg/claude"
 	"github.com/dlorenc/multiclaude/pkg/config"
@@ -524,6 +527,14 @@ func (c *CLI) registerCommands() {
 		Usage:       "multiclaude bug [--output <file>] [--verbose] [description]",
 		Run:         c.bugReport,
 	}
+
+	// Update command
+	c.rootCmd.Subcommands["update"] = &Command{
+		Name:        "update",
+		Description: "Check for and install updates",
+		Usage:       "multiclaude update [--check] [--yes] [--no-restart]",
+		Run:         c.updateCommand,
+	}
 }
 
 // Daemon command implementations
@@ -533,7 +544,7 @@ func (c *CLI) startDaemon(args []string) error {
 }
 
 func (c *CLI) runDaemon(args []string) error {
-	return daemon.Run()
+	return daemon.Run(Version)
 }
 
 func (c *CLI) stopDaemon(args []string) error {
@@ -4394,5 +4405,135 @@ func (c *CLI) bugReport(args []string) error {
 
 	// Print to stdout
 	fmt.Print(markdown)
+	return nil
+}
+
+// updateCommand handles the 'multiclaude update' command
+func (c *CLI) updateCommand(args []string) error {
+	flags, _ := ParseFlags(args)
+
+	// Check for check-only mode
+	checkOnly := flags["check"] == "true"
+	skipConfirm := flags["yes"] == "true" || flags["y"] == "true"
+	noRestart := flags["no-restart"] == "true"
+	force := flags["force"] == "true"
+
+	fmt.Println("Checking for updates...")
+
+	// Check for updates
+	checker := update.NewChecker(Version)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := checker.CheckWithFallback(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	fmt.Printf("Current version: %s\n", Version)
+	if result.LatestVersion != "" {
+		fmt.Printf("Latest version:  %s\n", result.LatestVersion)
+	}
+
+	if !result.UpdateAvailable && !force {
+		if Version == "dev" {
+			fmt.Println("\nYou are running a development version.")
+			if result.LatestVersion != "" {
+				fmt.Printf("Latest release is %s\n", result.LatestVersion)
+			}
+		} else {
+			fmt.Println("\nYou are already running the latest version.")
+		}
+		return nil
+	}
+
+	if checkOnly {
+		if result.UpdateAvailable {
+			fmt.Printf("\nAn update is available: %s -> %s\n", Version, result.LatestVersion)
+			fmt.Println("Run 'multiclaude update' to install it.")
+		}
+		return nil
+	}
+
+	// Check if we can update
+	updater := update.NewUpdater()
+	canUpdate, reason := updater.CanUpdate()
+	if !canUpdate {
+		return fmt.Errorf("cannot update: %s\n\nPlease update using your installation method (e.g., 'go install github.com/dlorenc/multiclaude/cmd/multiclaude@latest')", reason)
+	}
+
+	// Confirm update
+	if !skipConfirm {
+		fmt.Printf("\nAn update is available (%s -> %s). Proceed? [Y/n] ", Version, result.LatestVersion)
+		reader := bufio.NewReader(os.Stdin)
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("failed to read response: %w", err)
+		}
+		response = strings.TrimSpace(strings.ToLower(response))
+		if response != "" && response != "y" && response != "yes" {
+			fmt.Println("Update cancelled.")
+			return nil
+		}
+	}
+
+	// Check if daemon is running
+	daemonWasRunning := false
+	pidFile := daemon.NewPIDFile(c.paths.DaemonPID)
+	if running, _, _ := pidFile.IsRunning(); running {
+		daemonWasRunning = true
+		fmt.Println("\nStopping daemon...")
+
+		client := socket.NewClient(c.paths.DaemonSock)
+		resp, err := client.Send(socket.Request{Command: "stop"})
+		if err != nil {
+			return fmt.Errorf("failed to stop daemon: %w", err)
+		}
+		if !resp.Success {
+			return fmt.Errorf("failed to stop daemon: %s", resp.Error)
+		}
+
+		// Wait for daemon to stop
+		for i := 0; i < 30; i++ {
+			if running, _, _ := pidFile.IsRunning(); !running {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		fmt.Println("Daemon stopped.")
+	}
+
+	// Install the update
+	fmt.Printf("\nInstalling multiclaude %s...\n", result.LatestVersion)
+
+	updateResult, err := updater.Update(context.Background())
+	if err != nil {
+		// If update fails and daemon was running, try to restart it
+		if daemonWasRunning {
+			fmt.Println("\nUpdate failed, attempting to restart daemon with current version...")
+			daemon.RunDetached()
+		}
+		return fmt.Errorf("failed to install update: %w", err)
+	}
+
+	if !updateResult.Success {
+		return fmt.Errorf("update failed: %v", updateResult.Error)
+	}
+
+	fmt.Printf("Successfully installed new version at %s\n", updateResult.BinaryPath)
+
+	// Restart daemon if it was running (unless --no-restart)
+	if daemonWasRunning && !noRestart {
+		fmt.Println("\nRestarting daemon...")
+		if err := daemon.RunDetached(); err != nil {
+			return fmt.Errorf("failed to restart daemon: %w\n\nYou can manually start it with: multiclaude start", err)
+		}
+		fmt.Println("Daemon started successfully.")
+	} else if daemonWasRunning && noRestart {
+		fmt.Println("\nDaemon was stopped but not restarted (--no-restart flag).")
+		fmt.Println("You can manually start it with: multiclaude start")
+	}
+
+	fmt.Printf("\nUpdate complete! You are now running multiclaude %s\n", result.LatestVersion)
 	return nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -326,7 +326,7 @@ func setupTestEnvironment(t *testing.T) (*CLI, *daemon.Daemon, func()) {
 	}
 
 	// Create daemon
-	d, err := daemon.New(paths)
+	d, err := daemon.New(paths, "test-version")
 	if err != nil {
 		t.Fatalf("Failed to create daemon: %v", err)
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dlorenc/multiclaude/internal/provider"
 	"github.com/dlorenc/multiclaude/internal/socket"
 	"github.com/dlorenc/multiclaude/internal/state"
+	"github.com/dlorenc/multiclaude/internal/update"
 	"github.com/dlorenc/multiclaude/internal/worktree"
 	"github.com/dlorenc/multiclaude/pkg/claude"
 	"github.com/dlorenc/multiclaude/pkg/config"
@@ -33,6 +34,7 @@ type Daemon struct {
 	server       *socket.Server
 	pidFile      *PIDFile
 	claudeRunner *claude.Runner
+	version      string
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -40,7 +42,7 @@ type Daemon struct {
 }
 
 // New creates a new daemon instance
-func New(paths *config.Paths) (*Daemon, error) {
+func New(paths *config.Paths, version string) (*Daemon, error) {
 	// Ensure directories exist
 	if err := paths.EnsureDirectories(); err != nil {
 		return nil, fmt.Errorf("failed to create directories: %w", err)
@@ -68,6 +70,7 @@ func New(paths *config.Paths) (*Daemon, error) {
 		logger:       logger,
 		pidFile:      NewPIDFile(paths.DaemonPID),
 		claudeRunner: claude.NewRunner(claude.WithTerminal(tmuxClient)),
+		version:      version,
 		ctx:          ctx,
 		cancel:       cancel,
 	}
@@ -101,11 +104,12 @@ func (d *Daemon) Start() error {
 	d.restoreTrackedRepos()
 
 	// Start core loops after restore completes
-	d.wg.Add(4)
+	d.wg.Add(5)
 	go d.healthCheckLoop()
 	go d.messageRouterLoop()
 	go d.wakeLoop()
 	go d.serverLoop()
+	go d.updateCheckLoop()
 
 	return nil
 }
@@ -449,6 +453,70 @@ func (d *Daemon) wakeAgents() {
 	}
 }
 
+// updateCheckLoop periodically checks for available updates (every 30 minutes)
+func (d *Daemon) updateCheckLoop() {
+	defer d.wg.Done()
+	d.logger.Info("Starting update check loop")
+
+	ticker := time.NewTicker(30 * time.Minute)
+	defer ticker.Stop()
+
+	// Run once immediately on startup (with a small delay to let daemon stabilize)
+	time.Sleep(10 * time.Second)
+	d.checkForUpdates()
+
+	for {
+		select {
+		case <-ticker.C:
+			d.checkForUpdates()
+		case <-d.ctx.Done():
+			d.logger.Info("Update check loop stopped")
+			return
+		}
+	}
+}
+
+// checkForUpdates checks for available updates and logs/stores the result
+func (d *Daemon) checkForUpdates() {
+	d.logger.Debug("Checking for updates")
+
+	checker := update.NewChecker(d.version)
+
+	ctx, cancel := context.WithTimeout(d.ctx, 30*time.Second)
+	defer cancel()
+
+	result, err := checker.CheckWithFallback(ctx)
+
+	status := state.UpdateStatus{
+		LastChecked:    time.Now(),
+		CurrentVersion: d.version,
+	}
+
+	if err != nil {
+		d.logger.Debug("Update check failed: %v", err)
+		status.LastError = err.Error()
+	} else {
+		status.LatestVersion = result.LatestVersion
+		status.UpdateAvailable = result.UpdateAvailable
+
+		if result.UpdateAvailable {
+			d.logger.Info("Update available: %s -> %s (run 'multiclaude update' to upgrade)", d.version, result.LatestVersion)
+		} else {
+			d.logger.Debug("No update available (current: %s, latest: %s)", d.version, result.LatestVersion)
+		}
+	}
+
+	// Save update status to state
+	if err := d.state.SetUpdateStatus(status); err != nil {
+		d.logger.Error("Failed to save update status: %v", err)
+	}
+}
+
+// TriggerUpdateCheck triggers an immediate update check (for testing)
+func (d *Daemon) TriggerUpdateCheck() {
+	d.checkForUpdates()
+}
+
 // handleRequest handles incoming socket requests
 func (d *Daemon) handleRequest(req socket.Request) socket.Response {
 	d.logger.Debug("Handling request: %s", req.Command)
@@ -512,6 +580,13 @@ func (d *Daemon) handleRequest(req socket.Request) socket.Response {
 	case "route_messages":
 		go d.routeMessages()
 		return socket.Response{Success: true, Data: "Message routing triggered"}
+
+	case "get_update_status":
+		return d.handleGetUpdateStatus(req)
+
+	case "check_updates":
+		go d.checkForUpdates()
+		return socket.Response{Success: true, Data: "Update check triggered"}
 
 	default:
 		return socket.Response{
@@ -1102,6 +1177,21 @@ func (d *Daemon) handleClearCurrentRepo(req socket.Request) socket.Response {
 	return socket.Response{Success: true}
 }
 
+// handleGetUpdateStatus returns the current update status
+func (d *Daemon) handleGetUpdateStatus(req socket.Request) socket.Response {
+	status := d.state.GetUpdateStatus()
+	return socket.Response{
+		Success: true,
+		Data: map[string]interface{}{
+			"current_version":  status.CurrentVersion,
+			"latest_version":   status.LatestVersion,
+			"update_available": status.UpdateAvailable,
+			"last_checked":     status.LastChecked,
+			"last_error":       status.LastError,
+		},
+	}
+}
+
 // cleanupDeadAgents removes dead agents from state
 func (d *Daemon) cleanupDeadAgents(deadAgents map[string][]string) {
 	for repoName, agentNames := range deadAgents {
@@ -1663,13 +1753,13 @@ func isProcessAlive(pid int) bool {
 }
 
 // Run runs the daemon in the foreground
-func Run() error {
+func Run(version string) error {
 	paths, err := config.DefaultPaths()
 	if err != nil {
 		return fmt.Errorf("failed to get paths: %w", err)
 	}
 
-	d, err := New(paths)
+	d, err := New(paths, version)
 	if err != nil {
 		return fmt.Errorf("failed to create daemon: %w", err)
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -41,7 +41,7 @@ func setupTestDaemon(t *testing.T) (*Daemon, func()) {
 	}
 
 	// Create daemon
-	d, err := New(paths)
+	d, err := New(paths, "test-version")
 	if err != nil {
 		t.Fatalf("Failed to create daemon: %v", err)
 	}

--- a/internal/daemon/handlers_test.go
+++ b/internal/daemon/handlers_test.go
@@ -38,7 +38,7 @@ func setupTestDaemonWithState(t *testing.T, setupFn func(*state.State)) (*Daemon
 		t.Fatalf("Failed to create directories: %v", err)
 	}
 
-	d, err := New(paths)
+	d, err := New(paths, "test-version")
 	if err != nil {
 		t.Fatalf("Failed to create daemon: %v", err)
 	}

--- a/internal/update/checker.go
+++ b/internal/update/checker.go
@@ -1,0 +1,193 @@
+// Package update provides functionality for checking and applying updates to multiclaude.
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// ModulePath is the Go module path for multiclaude
+const ModulePath = "github.com/dlorenc/multiclaude"
+
+// ModuleInfo represents the JSON output from `go list -m -u -json`
+type ModuleInfo struct {
+	Path    string      `json:"Path"`
+	Version string      `json:"Version"`
+	Update  *UpdateInfo `json:"Update,omitempty"`
+	Error   *ModuleError `json:"Error,omitempty"`
+}
+
+// UpdateInfo contains information about an available update
+type UpdateInfo struct {
+	Path    string `json:"Path"`
+	Version string `json:"Version"`
+}
+
+// ModuleError represents an error from go list
+type ModuleError struct {
+	Err string `json:"Err"`
+}
+
+// Result represents the result of an update check
+type Result struct {
+	CurrentVersion   string
+	LatestVersion    string
+	UpdateAvailable  bool
+	LastChecked      time.Time
+	Error            error
+}
+
+// Checker checks for available updates
+type Checker struct {
+	modulePath     string
+	currentVersion string
+}
+
+// NewChecker creates a new update checker
+func NewChecker(currentVersion string) *Checker {
+	return &Checker{
+		modulePath:     ModulePath,
+		currentVersion: currentVersion,
+	}
+}
+
+// Check checks for available updates using `go list -m -u -json`
+func (c *Checker) Check(ctx context.Context) (*Result, error) {
+	result := &Result{
+		CurrentVersion: c.currentVersion,
+		LastChecked:    time.Now(),
+	}
+
+	// Run: go list -m -u -json github.com/dlorenc/multiclaude@latest
+	// The @latest suffix ensures we check the proxy for the latest version
+	cmd := exec.CommandContext(ctx, "go", "list", "-m", "-u", "-json", c.modulePath+"@latest")
+
+	output, err := cmd.Output()
+	if err != nil {
+		// If go list fails, try alternative approach
+		// This can happen if the module isn't in the local cache
+		result.Error = fmt.Errorf("failed to check for updates: %w", err)
+		return result, result.Error
+	}
+
+	var info ModuleInfo
+	if err := json.Unmarshal(output, &info); err != nil {
+		result.Error = fmt.Errorf("failed to parse update info: %w", err)
+		return result, result.Error
+	}
+
+	if info.Error != nil {
+		result.Error = fmt.Errorf("go list error: %s", info.Error.Err)
+		return result, result.Error
+	}
+
+	result.LatestVersion = info.Version
+
+	// Compare versions - if current version is "dev", always show latest as available
+	if c.currentVersion == "dev" || c.currentVersion == "" {
+		// Development version - show what's available but don't flag as update
+		result.UpdateAvailable = false
+	} else {
+		// Compare semantic versions
+		result.UpdateAvailable = isNewerVersion(info.Version, c.currentVersion)
+	}
+
+	return result, nil
+}
+
+// CheckWithFallback tries to check for updates, falling back to a simpler approach if needed
+func (c *Checker) CheckWithFallback(ctx context.Context) (*Result, error) {
+	result, err := c.Check(ctx)
+	if err == nil {
+		return result, nil
+	}
+
+	// Fallback: try using go install -n to see what would be installed
+	return c.checkViaInstallDryRun(ctx)
+}
+
+// checkViaInstallDryRun uses `go install -n` to check what version would be installed
+func (c *Checker) checkViaInstallDryRun(ctx context.Context) (*Result, error) {
+	result := &Result{
+		CurrentVersion: c.currentVersion,
+		LastChecked:    time.Now(),
+	}
+
+	// Try to get version info from proxy directly
+	cmd := exec.CommandContext(ctx, "go", "list", "-m", "-versions", c.modulePath)
+	output, err := cmd.Output()
+	if err != nil {
+		result.Error = fmt.Errorf("failed to list versions: %w", err)
+		return result, result.Error
+	}
+
+	// Output format: "github.com/dlorenc/multiclaude v0.1.0 v0.2.0 v0.3.0"
+	parts := strings.Fields(string(output))
+	if len(parts) < 2 {
+		result.Error = fmt.Errorf("no versions found for module")
+		return result, result.Error
+	}
+
+	// Last version in the list is the latest
+	result.LatestVersion = parts[len(parts)-1]
+
+	if c.currentVersion == "dev" || c.currentVersion == "" {
+		result.UpdateAvailable = false
+	} else {
+		result.UpdateAvailable = isNewerVersion(result.LatestVersion, c.currentVersion)
+	}
+
+	return result, nil
+}
+
+// isNewerVersion compares two semantic version strings
+// Returns true if latest is newer than current
+func isNewerVersion(latest, current string) bool {
+	// Strip 'v' prefix if present
+	latest = strings.TrimPrefix(latest, "v")
+	current = strings.TrimPrefix(current, "v")
+
+	// Handle special cases
+	if latest == current {
+		return false
+	}
+
+	// Parse versions
+	latestParts := parseVersion(latest)
+	currentParts := parseVersion(current)
+
+	// Compare major.minor.patch
+	for i := 0; i < 3; i++ {
+		if latestParts[i] > currentParts[i] {
+			return true
+		}
+		if latestParts[i] < currentParts[i] {
+			return false
+		}
+	}
+
+	return false
+}
+
+// parseVersion parses a semantic version string into major, minor, patch
+func parseVersion(v string) [3]int {
+	var parts [3]int
+
+	// Handle pre-release suffix (e.g., v1.2.3-beta)
+	if idx := strings.Index(v, "-"); idx > 0 {
+		v = v[:idx]
+	}
+
+	segments := strings.Split(v, ".")
+	for i := 0; i < len(segments) && i < 3; i++ {
+		var n int
+		fmt.Sscanf(segments[i], "%d", &n)
+		parts[i] = n
+	}
+
+	return parts
+}

--- a/internal/update/checker_test.go
+++ b/internal/update/checker_test.go
@@ -1,0 +1,63 @@
+package update
+
+import (
+	"testing"
+)
+
+func TestIsNewerVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		latest  string
+		current string
+		want    bool
+	}{
+		{"same version", "v1.0.0", "v1.0.0", false},
+		{"patch update", "v1.0.1", "v1.0.0", true},
+		{"minor update", "v1.1.0", "v1.0.0", true},
+		{"major update", "v2.0.0", "v1.0.0", true},
+		{"current newer patch", "v1.0.0", "v1.0.1", false},
+		{"current newer minor", "v1.0.0", "v1.1.0", false},
+		{"current newer major", "v1.0.0", "v2.0.0", false},
+		{"without v prefix", "1.0.1", "1.0.0", true},
+		{"mixed prefix", "v1.0.1", "1.0.0", true},
+		{"pre-release ignored", "v1.0.1-beta", "v1.0.0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isNewerVersion(tt.latest, tt.current)
+			if got != tt.want {
+				t.Errorf("isNewerVersion(%q, %q) = %v, want %v", tt.latest, tt.current, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    [3]int
+	}{
+		{"full version", "1.2.3", [3]int{1, 2, 3}},
+		{"major only", "1", [3]int{1, 0, 0}},
+		{"major.minor", "1.2", [3]int{1, 2, 0}},
+		{"with v prefix", "v1.2.3", [3]int{1, 2, 3}},
+		{"with pre-release", "1.2.3-beta", [3]int{1, 2, 3}},
+		{"with build metadata", "1.2.3+build", [3]int{1, 2, 3}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Strip v prefix as parseVersion expects
+			v := tt.version
+			if len(v) > 0 && v[0] == 'v' {
+				v = v[1:]
+			}
+			got := parseVersion(v)
+			if got != tt.want {
+				t.Errorf("parseVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/update/updater.go
+++ b/internal/update/updater.go
@@ -1,0 +1,119 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Updater handles the update process
+type Updater struct {
+	modulePath string
+}
+
+// NewUpdater creates a new updater
+func NewUpdater() *Updater {
+	return &Updater{
+		modulePath: ModulePath,
+	}
+}
+
+// UpdateResult contains the result of an update operation
+type UpdateResult struct {
+	PreviousVersion string
+	NewVersion      string
+	BinaryPath      string
+	Success         bool
+	Error           error
+}
+
+// Update installs the latest version of multiclaude using `go install`
+func (u *Updater) Update(ctx context.Context) (*UpdateResult, error) {
+	result := &UpdateResult{}
+
+	// Get current executable path
+	currentExe, err := os.Executable()
+	if err != nil {
+		result.Error = fmt.Errorf("failed to get current executable: %w", err)
+		return result, result.Error
+	}
+	currentExe, _ = filepath.EvalSymlinks(currentExe)
+
+	// Check if this looks like a go-installed binary
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		home, _ := os.UserHomeDir()
+		gopath = filepath.Join(home, "go")
+	}
+	goBin := filepath.Join(gopath, "bin")
+
+	if !strings.HasPrefix(currentExe, goBin) {
+		result.Error = fmt.Errorf("multiclaude does not appear to be installed via 'go install' (binary at %s, expected under %s). Please update using your package manager or installation method", currentExe, goBin)
+		return result, result.Error
+	}
+
+	// Run go install to update
+	installCmd := exec.CommandContext(ctx, "go", "install", u.modulePath+"/cmd/multiclaude@latest")
+	installCmd.Stdout = os.Stdout
+	installCmd.Stderr = os.Stderr
+
+	if err := installCmd.Run(); err != nil {
+		result.Error = fmt.Errorf("failed to install update: %w", err)
+		return result, result.Error
+	}
+
+	result.Success = true
+	result.BinaryPath = filepath.Join(goBin, "multiclaude")
+
+	return result, nil
+}
+
+// UpdateWithRetry attempts the update with retries
+func (u *Updater) UpdateWithRetry(ctx context.Context, maxRetries int) (*UpdateResult, error) {
+	var lastErr error
+
+	for i := 0; i < maxRetries; i++ {
+		result, err := u.Update(ctx)
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+
+		// Wait before retry (exponential backoff)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(time.Duration(1<<uint(i)) * time.Second):
+			// Continue to retry
+		}
+	}
+
+	return nil, fmt.Errorf("update failed after %d attempts: %w", maxRetries, lastErr)
+}
+
+// CanUpdate checks if we can perform an update (i.e., installed via go install)
+func (u *Updater) CanUpdate() (bool, string) {
+	currentExe, err := os.Executable()
+	if err != nil {
+		return false, "cannot determine executable path"
+	}
+	currentExe, _ = filepath.EvalSymlinks(currentExe)
+
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		home, _ := os.UserHomeDir()
+		gopath = filepath.Join(home, "go")
+	}
+	goBin := filepath.Join(gopath, "bin")
+
+	if strings.HasPrefix(currentExe, goBin) {
+		return true, ""
+	}
+
+	return false, fmt.Sprintf("binary at %s is not under GOPATH/bin (%s)", currentExe, goBin)
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -76,7 +76,7 @@ func TestPhase2Integration(t *testing.T) {
 	}
 
 	// Create daemon
-	d, err := daemon.New(paths)
+	d, err := daemon.New(paths, "test-version")
 	if err != nil {
 		t.Fatalf("Failed to create daemon: %v", err)
 	}

--- a/test/recovery_test.go
+++ b/test/recovery_test.go
@@ -151,7 +151,7 @@ func TestOrphanedTmuxSessionCleanup(t *testing.T) {
 	}
 
 	// Create daemon and state (without the orphan)
-	d, err := daemon.New(paths)
+	d, err := daemon.New(paths, "test-version")
 	if err != nil {
 		t.Fatalf("Failed to create daemon: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestStaleSocketCleanup(t *testing.T) {
 	}
 
 	// Try to start a new daemon - it should handle the stale files
-	d, err := daemon.New(paths)
+	d, err := daemon.New(paths, "test-version")
 	if err != nil {
 		t.Fatalf("Failed to create daemon: %v", err)
 	}
@@ -397,7 +397,7 @@ func TestDaemonCrashRecovery(t *testing.T) {
 	}
 
 	// Start daemon, add state, then simulate crash
-	d1, err := daemon.New(paths)
+	d1, err := daemon.New(paths, "test-version")
 	if err != nil {
 		t.Fatalf("Failed to create first daemon: %v", err)
 	}
@@ -440,7 +440,7 @@ func TestDaemonCrashRecovery(t *testing.T) {
 	// Start new daemon - should recover state from disk
 	// Because the tmux session exists, restoreTrackedRepos() will skip restoration
 	// and the state will be preserved.
-	d2, err := daemon.New(paths)
+	d2, err := daemon.New(paths, "test-version")
 	if err != nil {
 		t.Fatalf("Failed to create second daemon: %v", err)
 	}


### PR DESCRIPTION
## Summary

This PR adds self-update functionality to multiclaude:

- **Update check loop**: The daemon checks for updates every 30 minutes and logs when a new version is available
- **Update status tracking**: Update check results are persisted in state.json
- **`multiclaude update` command**: One-command update process that stops daemon, installs new version, and restarts

## Key Changes

- `internal/update/checker.go` - Checks for updates using `go list -m -u -json`
- `internal/update/updater.go` - Handles installation via `go install`
- `internal/state/state.go` - Added `UpdateStatus` struct for tracking
- `internal/daemon/daemon.go` - Added 30-minute update check loop
- `internal/cli/cli.go` - Added `multiclaude update` command

## How It Works

1. **Automatic notification**: Daemon checks for updates every 30 minutes and logs:
   ```
   Update available: v0.1.0 -> v0.2.0 (run 'multiclaude update' to upgrade)
   ```

2. **Manual update**: Run `multiclaude update` which:
   - Checks for available updates
   - Stops the daemon gracefully
   - Runs `go install github.com/dlorenc/multiclaude/cmd/multiclaude@latest`
   - Restarts the daemon with the new binary

## Command Options

```
multiclaude update [options]

Options:
  --check       Only check for updates, don't install
  --yes, -y     Skip confirmation prompt
  --no-restart  Don't restart daemon after update
  --force       Update even if already on latest version
```

## Test plan

- [x] Run unit tests for update package: `go test ./internal/update/...`
- [x] Run daemon tests: `go test ./internal/daemon/...`
- [x] Build successfully: `go build ./cmd/multiclaude`
- [ ] Manual test: Run `multiclaude update --check` to verify update checking
- [ ] Manual test: Run full update cycle on test system

## PRD

See `docs/update-prd.md` for the full product requirements document including limitations and future enhancements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)