### PR TITLE
fix(init): use default provider for new repository initialization

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -889,8 +889,8 @@ func (c *CLI) initRepo(args []string) error {
 	// Start Claude in supervisor window (skip in test mode)
 	var supervisorPID, mergeQueuePID int
 	if os.Getenv("MULTICLAUDE_TEST_MODE") != "1" {
-		// Resolve provider for this repository
-		providerInfo, err := c.getProviderForRepo(repoName)
+		// Resolve provider directly for new repos (can't query daemon - repo not registered yet)
+		providerInfo, err := provider.Resolve(state.ProviderClaude)
 		if err != nil {
 			return fmt.Errorf("failed to resolve provider: %w", err)
 		}


### PR DESCRIPTION
## Summary

Fixes `multiclaude init` failing with "repository not found" error for new repositories.

## Problem

The `initRepo` function calls `getProviderForRepo()` which queries the daemon for provider config. However, during init the repository hasn't been registered with the daemon yet, causing the error:

```
Error: failed to resolve provider: repository "mhl" not found
```

## Solution

Use `provider.Resolve()` directly with the default provider (`claude`) for new repository initialization, since we can't query config for a repo that doesn't exist yet.

## Test plan

- [x] Tested locally - `multiclaude init` now completes successfully for new repos

Fixes #128

🤖 Generated with [Claude Code](https://claude.ai/code)