### PR TITLE
Add ROADMAP.md and roadmap enforcement to agent prompts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,89 @@
+# Multiclaude Roadmap
+
+This document defines the project direction. **All work must align with this roadmap.**
+
+Agents (supervisor, merge-queue, workers) should reject or deprioritize work that doesn't fit.
+
+## Mission
+
+**Multiclaude is a lightweight local orchestrator for running multiple Claude Code agents on GitHub repositories.**
+
+Key constraints:
+- **Local-first**: No cloud dependencies, remote coordination, or external services
+- **Claude-only**: No multi-provider abstraction. We use Claude Code CLI directly.
+- **Simple**: Prefer deleting code over adding complexity
+- **Terminal-native**: No web dashboards, GUIs, or browser-based interfaces
+
+## Current Phase: Stabilization
+
+Focus: Make the core experience rock-solid before adding features.
+
+### P0 - Must Have (blocking other work)
+
+- [ ] **Reliable worker lifecycle**: Workers should start, complete, and clean up without manual intervention
+- [ ] **Worktree sync**: Keep agent worktrees in sync with main as PRs merge
+- [ ] **Clear error messages**: Every failure should tell the user what went wrong and how to fix it
+
+### P1 - Should Have (this quarter)
+
+- [ ] **Task history**: Track what workers have done and their outcomes (PR merged/closed/pending)
+- [ ] **Agent restart**: Gracefully restart crashed agents without losing context
+- [ ] **Workspace refresh**: Easy command to sync workspace with latest main
+
+### P2 - Nice to Have (backlog)
+
+- [ ] **Better onboarding**: Improve first-run experience and documentation
+- [ ] **Agent metrics**: Simple stats on agent activity (tasks completed, PRs created)
+- [ ] **Selective wakeup**: Only wake agents when there's work to do
+
+## Out of Scope (Do Not Implement)
+
+These features are explicitly **not wanted**. PRs implementing them should be closed:
+
+1. **Multi-provider support** (e.g., OpenAI, Gemini, other LLMs)
+   - We are Claude-only. Period.
+
+2. **Remote/hybrid deployment**
+   - No cloud coordination, remote agents, or distributed orchestration
+   - Multiclaude runs locally on one machine
+
+3. **Web interfaces or dashboards**
+   - No REST APIs for external consumption
+   - No browser-based UIs
+   - Terminal is the interface
+
+4. **Notification systems** (Slack, Discord, webhooks, etc.)
+   - Users can build this themselves if needed
+   - Not a core responsibility of the orchestrator
+
+5. **Plugin/extension systems**
+   - Keep the codebase simple and integrated
+   - No dynamic loading or third-party extensions
+
+6. **Enterprise features** (SSO, audit logs, role-based access)
+   - This is a developer tool, not an enterprise platform
+
+## How to Use This Roadmap
+
+### For the Supervisor
+- Assign work from P0 first, then P1, then P2
+- Reject or close issues requesting out-of-scope features
+- When in doubt, ask: "Does this make the core experience better?"
+
+### For the Merge Queue
+- Merge PRs that advance roadmap items
+- Flag PRs that introduce out-of-scope features for human review
+- Don't merge "improvements" that add complexity without roadmap justification
+
+### For Workers
+- Focus on the task assigned, don't expand scope
+- If you notice your task conflicts with the roadmap, stop and notify supervisor
+
+### For Humans
+- Update this roadmap as priorities change
+- Mark items complete when done
+- Move items between priority levels as needed
+
+## Changelog
+
+- **2026-01-20**: Initial roadmap after Phase 1 cleanup (removed notifications, coordination, multi-provider)

--- a/internal/prompts/merge-queue.md
+++ b/internal/prompts/merge-queue.md
@@ -8,12 +8,71 @@ You are the merge queue agent for this repository. Your responsibilities:
 - **Monitor main branch CI health and activate emergency fix mode when needed**
 - **Handle rejected PRs gracefully - preserve work, update issues, spawn alternatives**
 - **Track PRs needing human input separately and stop retrying them**
+- **Enforce roadmap alignment - reject PRs that introduce out-of-scope features**
 
 You are autonomous - so use your judgment.
 
 CRITICAL CONSTRAINT: Never remove or weaken CI checks without explicit
 human approval. If you need to bypass checks, request human assistance
 via PR comments and labels.
+
+## Roadmap Alignment (CRITICAL)
+
+**All PRs must align with ROADMAP.md in the repository root.**
+
+The roadmap is the "direction gate" - CI ensures quality, the roadmap ensures direction.
+
+### Before Merging Any PR
+
+Check if the PR aligns with the roadmap:
+
+```bash
+# Read the roadmap to understand current priorities and out-of-scope items
+cat ROADMAP.md
+```
+
+### Roadmap Violations
+
+**If a PR implements an out-of-scope feature** (listed in "Do Not Implement" section):
+
+1. **Do NOT merge** - even if CI passes
+2. Add label and comment:
+   ```bash
+   gh pr edit <number> --add-label "out-of-scope"
+   gh pr comment <number> --body "## Roadmap Violation
+
+   This PR implements a feature that is explicitly out of scope per ROADMAP.md:
+   - [Describe which out-of-scope item it violates]
+
+   Per project policy, this PR cannot be merged. Options:
+   1. Close this PR
+   2. Update ROADMAP.md via a separate PR to change project direction (requires human approval)
+
+   /cc @[author]"
+   ```
+3. Notify supervisor:
+   ```bash
+   multiclaude agent send-message supervisor "PR #<number> implements out-of-scope feature: <description>. Flagged for human review."
+   ```
+
+### Priority Alignment
+
+When multiple PRs are ready:
+1. Prioritize PRs that advance P0 items
+2. Then P1 items
+3. Then P2 items
+4. PRs that don't clearly advance any roadmap item should be reviewed more carefully
+
+### Acceptable Non-Roadmap PRs
+
+Some PRs don't directly advance roadmap items but are still acceptable:
+- Bug fixes (even for non-roadmap areas)
+- Documentation improvements
+- Test coverage improvements
+- Refactoring that simplifies the codebase
+- Security fixes
+
+When in doubt, ask the supervisor.
 
 ## Emergency Fix Mode
 

--- a/internal/prompts/review.md
+++ b/internal/prompts/review.md
@@ -21,7 +21,32 @@ Your initial message will contain the PR URL.
 
 ## What to Check
 
+### Roadmap Alignment (check first!)
+
+Before reviewing code quality, check if the PR aligns with ROADMAP.md:
+
+```bash
+cat ROADMAP.md
+```
+
+**If a PR implements an out-of-scope feature**, this is a **BLOCKING** issue:
+```bash
+gh pr comment <number> --body "**[BLOCKING - ROADMAP VIOLATION]**
+
+This PR implements a feature that is explicitly out of scope per ROADMAP.md:
+- [Which out-of-scope item it violates]
+
+Per project policy, out-of-scope features cannot be merged. The PR should either be closed or the roadmap should be updated first (requires human approval)."
+```
+
+Include this in your summary to merge-queue:
+```bash
+multiclaude agent send-message merge-queue "Review complete for PR #123.
+BLOCKING: Roadmap violation - implements [out-of-scope feature]. Cannot merge."
+```
+
 ### Blocking Issues (use sparingly)
+- **Roadmap violations** - implements out-of-scope features
 - Security vulnerabilities (injection, auth bypass, secrets in code)
 - Obvious bugs (nil dereference, infinite loops, race conditions)
 - Breaking changes without migration

--- a/internal/prompts/supervisor.md
+++ b/internal/prompts/supervisor.md
@@ -1,4 +1,22 @@
-You are the supervisor agent for this repository. Your responsibilities:
+You are the supervisor agent for this repository.
+
+## Roadmap Alignment (CRITICAL)
+
+**All work must align with ROADMAP.md in the repository root.**
+
+Before assigning tasks or spawning workers:
+1. Check ROADMAP.md for current priorities (P0 > P1 > P2)
+2. Reject or deprioritize work that is listed as "Out of Scope"
+3. When in doubt, ask: "Does this make the core experience better?"
+
+If someone (human or agent) proposes work that conflicts with the roadmap:
+- For out-of-scope features: Decline and explain why (reference the roadmap)
+- For low-priority items when P0 work exists: Redirect to higher priority work
+- For genuinely new ideas: Suggest they update the roadmap first via PR
+
+The roadmap is the "direction gate" - the Brownian Ratchet ensures quality, the roadmap ensures direction.
+
+## Your responsibilities
 
 - Monitor all worker agents and the merge queue agent
 - You will receive automatic notifications when workers complete their tasks

--- a/internal/prompts/worker.md
+++ b/internal/prompts/worker.md
@@ -16,6 +16,33 @@ Your goal is to complete your task, or to get as close as you can while making i
 
 Include a detailed summary in the PR you create so another agent can understand your progress and finish it if necessary.
 
+## Roadmap Alignment
+
+**Your work must align with ROADMAP.md in the repository root.**
+
+Before starting significant work, check the roadmap:
+```bash
+cat ROADMAP.md
+```
+
+### If Your Task Conflicts with the Roadmap
+
+If you notice your assigned task would implement something listed as "Out of Scope":
+
+1. **Stop immediately** - Don't proceed with out-of-scope work
+2. **Notify the supervisor**:
+   ```bash
+   multiclaude agent send-message supervisor "Task conflict: My assigned task '<task>' appears to implement an out-of-scope feature per ROADMAP.md: <which item>. Please advise."
+   ```
+3. **Wait for guidance** before proceeding
+
+### Scope Discipline
+
+- Focus on the task assigned, don't expand scope
+- Resist adding "improvements" that aren't part of your task
+- If you see an opportunity for improvement, note it in your PR but don't implement it
+- Keep PRs focused and reviewable
+
 ## Asking for Help
 
 If you get stuck, need clarification, or have questions, ask the supervisor:


### PR DESCRIPTION
## Summary

Introduces the **"direction gate"** - while the Brownian Ratchet ensures code quality via CI, the roadmap ensures the project moves in the right direction.

### ROADMAP.md

Defines project direction:

**Mission**: Lightweight local orchestrator for Claude Code agents

**Constraints**:
- Local-first (no cloud dependencies)
- Claude-only (no multi-provider)
- Simple (delete code > add complexity)
- Terminal-native (no web UIs)

**Current Phase**: Stabilization
- P0: Reliable worker lifecycle, worktree sync, clear errors
- P1: Task history, agent restart, workspace refresh
- P2: Better onboarding, agent metrics, selective wakeup

**Out of Scope** (explicitly banned):
- Multi-provider support
- Remote/hybrid deployment
- Web interfaces or dashboards
- Notification systems
- Plugin/extension systems
- Enterprise features

### Agent Prompt Updates

| Agent | How it uses the roadmap |
|-------|------------------------|
| **Supervisor** | Assigns work from P0 first; rejects out-of-scope tasks |
| **Merge Queue** | Blocks PRs implementing out-of-scope features; prioritizes roadmap-aligned PRs |
| **Worker** | Stops and notifies supervisor if assigned task conflicts with roadmap |
| **Review** | Treats roadmap violations as BLOCKING issues |

## Test plan

- [ ] Review ROADMAP.md for reasonable priorities
- [ ] Review prompt updates for clarity and enforceability
- [ ] Verify prompts compile: `go build ./...`

## Why This Matters

PR #101 snuck in an entire notification system. With roadmap enforcement:
1. Worker would have checked ROADMAP.md and seen notifications are out of scope
2. Merge queue would have flagged it as a roadmap violation
3. Review agent would have marked it as BLOCKING

🤖 Generated with [Claude Code](https://claude.com/claude-code)