### PR TITLE
Remove remaining provider abstraction dead code

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -69,7 +69,7 @@ func New() (*CLI, error) {
 }
 
 // NewWithPaths creates a CLI with custom paths (for testing)
-func NewWithPaths(paths *config.Paths, _ string) *CLI {
+func NewWithPaths(paths *config.Paths) *CLI {
 	cli := &CLI{
 		paths: paths,
 		rootCmd: &Command{
@@ -91,7 +91,7 @@ func NewWithPaths(paths *config.Paths, _ string) *CLI {
 func (c *CLI) getClaudeBinary() (string, error) {
 	binaryPath, err := exec.LookPath("claude")
 	if err != nil {
-		return "", errors.ProviderNotFound("claude", err)
+		return "", errors.ClaudeNotFound(err)
 	}
 	return binaryPath, nil
 }
@@ -1372,9 +1372,8 @@ func (c *CLI) configRepo(args []string) error {
 	// Check if any config flags are provided
 	hasMqEnabled := flags["mq-enabled"] != ""
 	hasMqTrack := flags["mq-track"] != ""
-	hasProvider := flags["provider"] != ""
 
-	if !hasMqEnabled && !hasMqTrack && !hasProvider {
+	if !hasMqEnabled && !hasMqTrack {
 		// No flags - just show current config
 		return c.showRepoConfig(repoName)
 	}
@@ -1425,17 +1424,9 @@ func (c *CLI) showRepoConfig(repoName string) error {
 		fmt.Printf("  Enabled: false\n")
 	}
 
-	// Show provider config
-	providerStr := "claude"
-	if p, ok := configMap["provider"].(string); ok && p != "" {
-		providerStr = p
-	}
-	fmt.Printf("\nProvider: %s\n", providerStr)
-
 	fmt.Println("\nTo modify:")
 	fmt.Printf("  multiclaude config %s --mq-enabled=true|false\n", repoName)
 	fmt.Printf("  multiclaude config %s --mq-track=all|author|assigned\n", repoName)
-	fmt.Printf("  multiclaude config %s --provider=claude|happy\n", repoName)
 
 	return nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -340,7 +340,7 @@ func setupTestEnvironment(t *testing.T) (*CLI, *daemon.Daemon, func()) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Create CLI with test paths
-	cli := NewWithPaths(paths, "")
+	cli := NewWithPaths(paths)
 
 	cleanup := func() {
 		d.Stop()
@@ -685,7 +685,7 @@ func TestCLISendMessageFallbackWhenDaemonUnavailable(t *testing.T) {
 	}
 
 	// Create CLI
-	cli := NewWithPaths(paths, "")
+	cli := NewWithPaths(paths)
 
 	// Change to worktree directory
 	origDir, _ := os.Getwd()
@@ -1042,14 +1042,8 @@ func TestNewWithPaths(t *testing.T) {
 		OutputDir:    filepath.Join(tmpDir, "output"),
 	}
 
-	// Test CLI creation (second parameter is now ignored, provider resolved at runtime)
-	cli := NewWithPaths(paths, "")
-	if cli == nil {
-		t.Fatal("CLI should not be nil")
-	}
-
-	// Test with custom path (now ignored - provider resolved per-repo at runtime)
-	cli = NewWithPaths(paths, "/custom/path/claude")
+	// Test CLI creation
+	cli := NewWithPaths(paths)
 	if cli == nil {
 		t.Fatal("CLI should not be nil")
 	}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -300,38 +300,6 @@ func ClaudeNotFound(cause error) *CLIError {
 	}
 }
 
-// ProviderNotFound creates an error for when a provider binary is not found
-func ProviderNotFound(provider string, cause error) *CLIError {
-	suggestion := "install Claude Code CLI: https://docs.anthropic.com/claude-code"
-	if provider == "happy" {
-		suggestion = "install Happy CLI: https://happy.engineering/docs"
-	}
-	return &CLIError{
-		Category:   CategoryConfig,
-		Message:    fmt.Sprintf("%s binary not found in PATH", provider),
-		Cause:      cause,
-		Suggestion: suggestion,
-	}
-}
-
-// ProviderAuthNotConfigured creates an error for unconfigured provider auth
-func ProviderAuthNotConfigured(provider string) *CLIError {
-	return &CLIError{
-		Category:   CategoryConfig,
-		Message:    fmt.Sprintf("%s authentication not configured", provider),
-		Suggestion: fmt.Sprintf("run '%s auth login' to authenticate", provider),
-	}
-}
-
-// InvalidProvider creates an error for invalid provider values
-func InvalidProvider(value string) *CLIError {
-	return &CLIError{
-		Category:   CategoryUsage,
-		Message:    fmt.Sprintf("invalid provider: %s", value),
-		Suggestion: "use 'claude' or 'happy'",
-	}
-}
-
 // MissingArgument creates an error for missing required arguments
 func MissingArgument(argName, expectedType string) *CLIError {
 	msg := fmt.Sprintf("missing required argument: %s", argName)


### PR DESCRIPTION
## Summary

Follow-up cleanup after PR #132 which removed the provider abstraction. This removes the remaining dead code that was left behind:

- Remove unused error constructors: `ProviderNotFound`, `ProviderAuthNotConfigured`, `InvalidProvider`
- Replace `ProviderNotFound("claude", err)` with `ClaudeNotFound(err)`  
- Remove provider config display and `--provider` flag references from config command
- Remove unused second parameter from `NewWithPaths` function
- Clean up stale comments referring to removed provider functionality

**Changes:** 3 files changed, 7 insertions(+), 54 deletions(-)

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (all 18 packages)
- [x] No remaining references to removed provider functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)