### PR TITLE
Fix E2E test failures: update bare repo HEAD after push

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -319,6 +319,13 @@ func TestRepoInitializationIntegration(t *testing.T) {
 		}
 	}
 
+	// Update bare repo HEAD to point to main (git init --bare defaults to master/main based on config)
+	cmd := exec.Command("git", "symbolic-ref", "HEAD", "refs/heads/main")
+	cmd.Dir = remoteRepoPath
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to update bare repo HEAD: %v", err)
+	}
+
 	// Create and start daemon
 	d, err := daemon.New(paths)
 	if err != nil {
@@ -446,13 +453,26 @@ func TestRepoInitializationWithMergeQueueDisabled(t *testing.T) {
 	setupTestGitRepo(t, sourceRepo)
 	cmd := exec.Command("git", "remote", "add", "origin", remoteRepoPath)
 	cmd.Dir = sourceRepo
-	cmd.Run()
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to add remote: %v", err)
+	}
 	cmd = exec.Command("git", "branch", "-M", "main")
 	cmd.Dir = sourceRepo
-	cmd.Run()
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to rename branch: %v", err)
+	}
 	cmd = exec.Command("git", "push", "-u", "origin", "main")
 	cmd.Dir = sourceRepo
-	cmd.Run()
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to push: %v", err)
+	}
+
+	// Update bare repo HEAD to point to main (git init --bare defaults to master/main based on config)
+	cmd = exec.Command("git", "symbolic-ref", "HEAD", "refs/heads/main")
+	cmd.Dir = remoteRepoPath
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to update bare repo HEAD: %v", err)
+	}
 
 	d, _ := daemon.New(paths)
 	d.Start()


### PR DESCRIPTION
## Summary

- Fix `TestRepoInitializationIntegration` and `TestRepoInitializationWithMergeQueueDisabled` test failures
- Root cause: After `git init --bare`, the bare repo's HEAD points to the default branch (e.g., `refs/heads/master`). When we push the `main` branch, HEAD still points to a non-existent ref, causing clone and worktree operations to fail with 'remote HEAD refers to nonexistent ref'
- Fix: Add `git symbolic-ref HEAD refs/heads/main` after pushing to ensure the bare repo's HEAD points to the actual branch that exists
- Also added error checking to git commands in `TestRepoInitializationWithMergeQueueDisabled` that were silently ignoring failures

## Test plan

- [x] Run `go test -v ./test/... -run "TestRepoInitialization"` - both tests pass
- [x] Run `go test ./...` - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)