### PR TITLE
Fix integration test compilation after PR #136

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -86,7 +86,7 @@ func setupIntegrationTest(t *testing.T, repoName string) (*cli.CLI, *daemon.Daem
 	}
 
 	// Create CLI with test paths
-	c := cli.NewWithPaths(paths, "")
+	c := cli.NewWithPaths(paths)
 
 	cleanup := func() {
 		tmuxClient.KillSession(tmuxSession)
@@ -339,7 +339,7 @@ func TestRepoInitializationIntegration(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Create CLI
-	c := cli.NewWithPaths(paths, "")
+	c := cli.NewWithPaths(paths)
 
 	// Initialize repo using local bare repo as "GitHub URL"
 	repoName := "init-test-repo"
@@ -479,7 +479,7 @@ func TestRepoInitializationWithMergeQueueDisabled(t *testing.T) {
 	defer d.Stop()
 	time.Sleep(100 * time.Millisecond)
 
-	c := cli.NewWithPaths(paths, "")
+	c := cli.NewWithPaths(paths)
 
 	repoName := "nomq-repo"
 	err = c.Execute([]string{"init", remoteRepoPath, repoName, "--no-merge-queue"})


### PR DESCRIPTION
## Summary

- Fix compilation error in PR #137 caused by API change in PR #136
- PR #136 removed the second parameter from `cli.NewWithPaths` (provider name)
- The integration tests were still passing the old two-argument signature

**Changes:**
- Updated `cli.NewWithPaths(paths, "")` → `cli.NewWithPaths(paths)` at lines 89, 342, 482 in `test/integration_test.go`

This PR supersedes PR #137 (`multiclaude/wise-fox`) by rebasing on main and adding the necessary fix.

## Test plan

- [x] `go build ./...` - succeeds
- [x] `go test -c ./test/...` - test compilation succeeds  
- [x] `go test ./internal/... ./pkg/...` - unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)