### PR TITLE
docs: Update documentation for PRs #140-#143

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,12 @@ multiclaude workspace <name>               # Connect to workspace (shorthand)
 ```bash
 multiclaude work "task description"        # Create worker for task
 multiclaude work "task" --branch feature   # Start from specific branch
+multiclaude work "Fix tests" --branch origin/work/fox --push-to work/fox  # Iterate on existing PR
 multiclaude work list                      # List active workers
 multiclaude work rm <name>                 # Remove worker (warns if uncommitted work)
 ```
+
+The `--push-to` flag creates a worker that pushes to an existing branch instead of creating a new PR. Use this when you want to iterate on an existing PR.
 
 ### Observing
 
@@ -199,6 +202,15 @@ multiclaude agent list-messages            # List incoming messages
 multiclaude agent ack-message <id>         # Acknowledge a message
 multiclaude agent complete                 # Signal task completion (workers)
 ```
+
+### Agent Slash Commands (available within Claude sessions)
+
+Agents have access to multiclaude-specific slash commands:
+
+- `/refresh` - Sync worktree with main branch
+- `/status` - Show system status and pending messages
+- `/workers` - List active workers for the repo
+- `/messages` - Check inter-agent messages
 
 ## Working with multiclaude
 
@@ -394,7 +406,8 @@ When CI fails, the merge queue can spawn workers to fix it:
 ├── state.json          # Persisted state
 ├── repos/<repo>/       # Cloned repositories
 ├── wts/<repo>/         # Git worktrees (supervisor, merge-queue, workers)
-└── messages/<repo>/    # Inter-agent messages
+├── messages/<repo>/    # Inter-agent messages
+└── claude-config/<repo>/<agent>/  # Per-agent Claude configuration (slash commands)
 ```
 
 ### Repository Configuration


### PR DESCRIPTION
## Summary

- Updates CLAUDE.md with new packages (`internal/hooks`, `internal/prompts/commands`) and features (self-healing health checks, `NewTestPaths()`)
- Updates AGENTS.md with slash commands documentation (`/refresh`, `/status`, `/workers`, `/messages`) and self-healing health check behavior
- Updates README.md with `--push-to` flag for workers and agent slash commands section

## Changes by File

**CLAUDE.md:**
- Added `internal/hooks` and `internal/prompts/commands` to Package Responsibilities table
- Updated `internal/prompts` description to include `GenerateTrackingModePrompt()`
- Added `NewTestPaths()` to `pkg/config` description
- Updated Data Flow to mention self-healing health checks
- Added `claude-config/` directory to Runtime Directories
- Simplified test example to use `config.NewTestPaths()`

**AGENTS.md:**
- Added new "Agent Slash Commands" section with available commands and implementation details
- Updated Health Check Cycle to describe self-healing behavior (restoration before cleanup)

**README.md:**
- Added `--push-to` flag documentation with example usage
- Added new "Agent Slash Commands" section listing available commands
- Added `claude-config/` to directory structure

## PRs Documented

- #140: Self-healing health checks (restoration before cleanup)
- #141: `--push-to` flag for iterating on existing PRs
- #142: Per-agent slash commands via `CLAUDE_CONFIG_DIR`
- #143: `internal/hooks` package and `GenerateTrackingModePrompt()`

## Test plan

- [x] Build passes: `go build ./...`
- [x] Unit tests pass: `go test ./internal/... -short`
- [ ] Visual review of documentation formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)