### PR TITLE
fix: Set CLAUDE_CONFIG_DIR for daemon-restarted agents

### DIFF
--- a/pkg/claude/runner.go
+++ b/pkg/claude/runner.go
@@ -165,6 +165,10 @@ type Config struct {
 	// OutputFile is the path to capture Claude's output.
 	// If non-empty, StartPipePane is called with this file.
 	OutputFile string
+
+	// ClaudeConfigDir is the path to set as CLAUDE_CONFIG_DIR environment variable.
+	// This enables per-agent slash commands. If empty, CLAUDE_CONFIG_DIR is not set.
+	ClaudeConfigDir string
 }
 
 // StartResult contains information about a started Claude instance.
@@ -253,7 +257,15 @@ func (r *Runner) Start(session, window string, cfg Config) (*StartResult, error)
 
 // buildCommand constructs the claude CLI command string.
 func (r *Runner) buildCommand(sessionID string, cfg Config) string {
-	cmd := r.BinaryPath
+	var cmd string
+
+	// Prepend CLAUDE_CONFIG_DIR environment variable if set
+	// This enables per-agent slash commands
+	if cfg.ClaudeConfigDir != "" {
+		cmd = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", cfg.ClaudeConfigDir)
+	}
+
+	cmd += r.BinaryPath
 
 	// Add session ID or resume
 	if cfg.Resume {

--- a/test/recovery_test.go
+++ b/test/recovery_test.go
@@ -571,3 +571,140 @@ func TestConcurrentStateAccess(t *testing.T) {
 		t.Error("Repo should still exist after concurrent access")
 	}
 }
+
+// TestDaemonRestartSetsUpClaudeConfigDir tests that daemon restart creates
+// CLAUDE_CONFIG_DIR with slash commands for agents
+func TestDaemonRestartSetsUpClaudeConfigDir(t *testing.T) {
+	tmuxClient := tmux.NewClient()
+	if !tmuxClient.IsTmuxAvailable() {
+		t.Skip("tmux not available, skipping CLAUDE_CONFIG_DIR test")
+	}
+
+	// Use os.MkdirTemp with a short prefix to avoid Unix socket path length limits
+	tmpDir, err := os.MkdirTemp("", "mc-cfg-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	paths := &config.Paths{
+		Root:            tmpDir,
+		DaemonPID:       filepath.Join(tmpDir, "daemon.pid"),
+		DaemonSock:      filepath.Join(tmpDir, "daemon.sock"),
+		DaemonLog:       filepath.Join(tmpDir, "daemon.log"),
+		StateFile:       filepath.Join(tmpDir, "state.json"),
+		ReposDir:        filepath.Join(tmpDir, "repos"),
+		WorktreesDir:    filepath.Join(tmpDir, "wts"),
+		MessagesDir:     filepath.Join(tmpDir, "messages"),
+		OutputDir:       filepath.Join(tmpDir, "output"),
+		ClaudeConfigDir: filepath.Join(tmpDir, "claude-config"),
+	}
+
+	if err := paths.EnsureDirectories(); err != nil {
+		t.Fatalf("Failed to create directories: %v", err)
+	}
+
+	// Create tmux session for the test
+	sessionName := "mc-config-test"
+	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+		t.Fatalf("Failed to create tmux session: %v", err)
+	}
+	defer tmuxClient.KillSession(sessionName)
+
+	// Create supervisor window for the agent
+	if err := tmuxClient.CreateWindow(sessionName, "supervisor"); err != nil {
+		t.Fatalf("Failed to create supervisor window: %v", err)
+	}
+
+	// Start first daemon and add state
+	d1, err := daemon.New(paths)
+	if err != nil {
+		t.Fatalf("Failed to create first daemon: %v", err)
+	}
+
+	if err := d1.Start(); err != nil {
+		t.Fatalf("Failed to start first daemon: %v", err)
+	}
+
+	// Add repo and agent to state
+	repoName := "test-repo"
+	agentName := "supervisor"
+	repo := &state.Repository{
+		GithubURL:   "https://github.com/test/repo",
+		TmuxSession: sessionName,
+		Agents:      make(map[string]state.Agent),
+	}
+	if err := d1.GetState().AddRepo(repoName, repo); err != nil {
+		t.Fatalf("Failed to add repo: %v", err)
+	}
+
+	agent := state.Agent{
+		Type:         state.AgentTypeSupervisor,
+		TmuxWindow:   agentName,
+		WorktreePath: filepath.Join(paths.WorktreesDir, repoName, agentName),
+		SessionID:    "test-session-id",
+		PID:          99999, // Dead PID to trigger restart
+		CreatedAt:    time.Now(),
+	}
+	if err := d1.GetState().AddAgent(repoName, agentName, agent); err != nil {
+		t.Fatalf("Failed to add agent: %v", err)
+	}
+
+	// Create the worktree directory so it exists
+	wtPath := filepath.Join(paths.WorktreesDir, repoName, agentName)
+	if err := os.MkdirAll(wtPath, 0755); err != nil {
+		t.Fatalf("Failed to create worktree directory: %v", err)
+	}
+
+	// Stop first daemon cleanly
+	if err := d1.Stop(); err != nil {
+		t.Fatalf("Failed to stop first daemon: %v", err)
+	}
+
+	// Clean up stale socket
+	os.Remove(paths.DaemonSock)
+	time.Sleep(100 * time.Millisecond)
+
+	// Start second daemon - this simulates daemon restart
+	d2, err := daemon.New(paths)
+	if err != nil {
+		t.Fatalf("Failed to create second daemon: %v", err)
+	}
+
+	if err := d2.Start(); err != nil {
+		t.Fatalf("Failed to start second daemon: %v", err)
+	}
+	defer d2.Stop()
+
+	// Wait for daemon to fully initialize and run health check
+	time.Sleep(200 * time.Millisecond)
+
+	// Trigger a health check which will attempt to restart dead agents
+	d2.TriggerHealthCheck()
+
+	// Give it time to process
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify CLAUDE_CONFIG_DIR structure was created
+	agentConfigDir := paths.AgentClaudeConfigDir(repoName, agentName)
+	commandsDir := filepath.Join(agentConfigDir, "commands")
+
+	// Check config directory exists
+	if _, err := os.Stat(agentConfigDir); os.IsNotExist(err) {
+		t.Errorf("Expected CLAUDE_CONFIG_DIR to exist at %s", agentConfigDir)
+	}
+
+	// Check commands directory exists
+	if _, err := os.Stat(commandsDir); os.IsNotExist(err) {
+		t.Errorf("Expected commands directory to exist at %s", commandsDir)
+	}
+
+	// Check that slash command files were created
+	expectedCommands := []string{"refresh.md", "status.md", "workers.md", "messages.md"}
+	for _, cmd := range expectedCommands {
+		cmdPath := filepath.Join(commandsDir, cmd)
+		if _, err := os.Stat(cmdPath); os.IsNotExist(err) {
+			t.Errorf("Expected command file %s to exist", cmdPath)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Added `ClaudeConfigDir` field to `claude.Config` struct in `pkg/claude/runner.go`
- Updated `buildCommand` to prepend `CLAUDE_CONFIG_DIR=<path>` environment variable when set
- Updated daemon's `restartAgent` function to set up agent commands and pass config dir to Claude runner
- Added unit tests for the new `ClaudeConfigDir` field in `pkg/claude/runner_test.go`
- Added integration test verifying CLAUDE_CONFIG_DIR is properly set after daemon restart

## Problem
When the daemon restarted agents (e.g., after detecting dead processes), it wasn't setting `CLAUDE_CONFIG_DIR`, which meant the agents lost access to their slash commands (`/refresh`, `/status`, `/workers`, `/messages`).

## Solution
The fix mirrors how the CLI sets up `CLAUDE_CONFIG_DIR`:
1. The daemon now calls `commands.SetupAgentCommands(agentConfigDir)` before restarting an agent
2. The `claude.Config` struct now has a `ClaudeConfigDir` field
3. The `buildCommand` method prepends `CLAUDE_CONFIG_DIR=<path>` when this field is set

Reference: CLI implementation at `internal/cli/cli.go:4453-4461`

## Test plan
- [x] Unit tests for `ClaudeConfigDir` field in `pkg/claude/runner_test.go`
- [x] Integration test `TestDaemonRestartSetsUpClaudeConfigDir` in `test/recovery_test.go`
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)