### PR TITLE
refactor: Improve pkg/tmux and pkg/claude public APIs for quality and idiomaticity

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -889,10 +890,10 @@ func TestCLIWorkCreateWithRealTmux(t *testing.T) {
 
 	// Create tmux session
 	tmuxSession := "mc-test-repo"
-	if err := tmuxClient.CreateSession(tmuxSession, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), tmuxSession, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(tmuxSession)
+	defer tmuxClient.KillSession(context.Background(), tmuxSession)
 
 	// Add repo to daemon
 	repo := &state.Repository{
@@ -931,7 +932,7 @@ func TestCLIWorkCreateWithRealTmux(t *testing.T) {
 	}
 
 	// Verify tmux window was created
-	hasWindow, err := tmuxClient.HasWindow(tmuxSession, "test-worker")
+	hasWindow, err := tmuxClient.HasWindow(context.Background(), tmuxSession, "test-worker")
 	if err != nil {
 		t.Fatalf("Failed to check window: %v", err)
 	}
@@ -1822,13 +1823,13 @@ func TestCLIRemoveWorkerWithRealTmux(t *testing.T) {
 
 	// Create tmux session
 	tmuxSession := "mc-test-rm"
-	if err := tmuxClient.CreateSession(tmuxSession, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), tmuxSession, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(tmuxSession)
+	defer tmuxClient.KillSession(context.Background(), tmuxSession)
 
 	// Create worker window
-	if err := tmuxClient.CreateWindow(tmuxSession, "test-worker"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), tmuxSession, "test-worker"); err != nil {
 		t.Fatalf("Failed to create window: %v", err)
 	}
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -875,13 +876,13 @@ func TestHealthCheckLoopWithRealTmux(t *testing.T) {
 
 	// Create a real tmux session
 	sessionName := "mc-test-healthcheck"
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create a window for the agent
-	if err := tmuxClient.CreateWindow(sessionName, "test-agent"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "test-agent"); err != nil {
 		t.Fatalf("Failed to create window: %v", err)
 	}
 
@@ -914,7 +915,7 @@ func TestHealthCheckLoopWithRealTmux(t *testing.T) {
 	}
 
 	// Kill the window
-	if err := tmuxClient.KillWindow(sessionName, "test-agent"); err != nil {
+	if err := tmuxClient.KillWindow(context.Background(), sessionName, "test-agent"); err != nil {
 		t.Fatalf("Failed to kill window: %v", err)
 	}
 
@@ -939,13 +940,13 @@ func TestHealthCheckCleansUpMarkedAgents(t *testing.T) {
 
 	// Create a real tmux session
 	sessionName := "mc-test-cleanup"
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create a window for the agent
-	if err := tmuxClient.CreateWindow(sessionName, "to-cleanup"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "to-cleanup"); err != nil {
 		t.Fatalf("Failed to create window: %v", err)
 	}
 
@@ -985,7 +986,7 @@ func TestHealthCheckCleansUpMarkedAgents(t *testing.T) {
 	}
 
 	// Verify window is killed
-	hasWindow, _ := tmuxClient.HasWindow(sessionName, "to-cleanup")
+	hasWindow, _ := tmuxClient.HasWindow(context.Background(), sessionName, "to-cleanup")
 	if hasWindow {
 		t.Error("Window should be killed when agent is cleaned up")
 	}
@@ -1003,16 +1004,16 @@ func TestMessageRoutingWithRealTmux(t *testing.T) {
 	// Create a real tmux session
 	// Note: In CI environments, tmux may be installed but unable to create sessions (no TTY)
 	sessionName := "mc-test-routing"
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Skipf("tmux cannot create sessions in this environment: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create windows for agents
-	if err := tmuxClient.CreateWindow(sessionName, "supervisor"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "supervisor"); err != nil {
 		t.Fatalf("Failed to create supervisor window: %v", err)
 	}
-	if err := tmuxClient.CreateWindow(sessionName, "worker1"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "worker1"); err != nil {
 		t.Fatalf("Failed to create worker window: %v", err)
 	}
 
@@ -1081,13 +1082,13 @@ func TestWakeLoopUpdatesNudgeTime(t *testing.T) {
 
 	// Create a real tmux session
 	sessionName := "mc-test-wake"
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create window for agent
-	if err := tmuxClient.CreateWindow(sessionName, "supervisor"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "supervisor"); err != nil {
 		t.Fatalf("Failed to create supervisor window: %v", err)
 	}
 
@@ -1140,13 +1141,13 @@ func TestWakeLoopSkipsRecentlyNudgedAgents(t *testing.T) {
 
 	// Create a real tmux session
 	sessionName := "mc-test-wake-skip"
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create window for agent
-	if err := tmuxClient.CreateWindow(sessionName, "worker"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "worker"); err != nil {
 		t.Fatalf("Failed to create worker window: %v", err)
 	}
 
@@ -1788,10 +1789,10 @@ func TestRestoreTrackedReposExistingSession(t *testing.T) {
 
 	// Create a tmux session
 	sessionName := "mc-test-restore-existing"
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Add repo with existing session
 	repo := &state.Repository{
@@ -1808,7 +1809,7 @@ func TestRestoreTrackedReposExistingSession(t *testing.T) {
 
 	// Session should still exist and no agents should be created
 	// (agents would only be created during actual init)
-	hasSession, _ := tmuxClient.HasSession(sessionName)
+	hasSession, _ := tmuxClient.HasSession(context.Background(), sessionName)
 	if !hasSession {
 		t.Error("Session should still exist after restore check")
 	}
@@ -1847,13 +1848,13 @@ func TestRestoreDeadAgentsWithExistingSession(t *testing.T) {
 
 	// Create a tmux session
 	sessionName := "mc-test-restore-dead"
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create a window for the supervisor agent
-	if err := tmuxClient.CreateWindow(sessionName, "supervisor"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "supervisor"); err != nil {
 		t.Fatalf("Failed to create window: %v", err)
 	}
 
@@ -1881,7 +1882,7 @@ func TestRestoreDeadAgentsWithExistingSession(t *testing.T) {
 	d.restoreDeadAgents("test-repo", repo)
 
 	// Session and window should still exist
-	hasSession, _ := tmuxClient.HasSession(sessionName)
+	hasSession, _ := tmuxClient.HasSession(context.Background(), sessionName)
 	if !hasSession {
 		t.Error("Session should still exist after restore attempt")
 	}
@@ -1898,13 +1899,13 @@ func TestRestoreDeadAgentsSkipsAliveProcesses(t *testing.T) {
 
 	// Create a tmux session
 	sessionName := "mc-test-restore-alive"
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create a window for the supervisor agent
-	if err := tmuxClient.CreateWindow(sessionName, "supervisor"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "supervisor"); err != nil {
 		t.Fatalf("Failed to create window: %v", err)
 	}
 
@@ -1953,13 +1954,13 @@ func TestRestoreDeadAgentsSkipsTransientAgents(t *testing.T) {
 
 	// Create a tmux session
 	sessionName := "mc-test-restore-transient"
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create a window for a worker agent
-	if err := tmuxClient.CreateWindow(sessionName, "test-worker"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "test-worker"); err != nil {
 		t.Fatalf("Failed to create window: %v", err)
 	}
 
@@ -2006,13 +2007,13 @@ func TestRestoreDeadAgentsIncludesWorkspace(t *testing.T) {
 
 	// Create a tmux session
 	sessionName := "mc-test-restore-workspace"
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create a window for the workspace agent
-	if err := tmuxClient.CreateWindow(sessionName, "workspace"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "workspace"); err != nil {
 		t.Fatalf("Failed to create window: %v", err)
 	}
 
@@ -2040,7 +2041,7 @@ func TestRestoreDeadAgentsIncludesWorkspace(t *testing.T) {
 	d.restoreDeadAgents("test-repo", repo)
 
 	// Session and window should still exist
-	hasSession, _ := tmuxClient.HasSession(sessionName)
+	hasSession, _ := tmuxClient.HasSession(context.Background(), sessionName)
 	if !hasSession {
 		t.Error("Session should still exist after restore attempt")
 	}
@@ -2204,9 +2205,9 @@ func TestHandleListReposRichFormat(t *testing.T) {
 	sessionName := "mc-test-rich"
 	sessionExists := false
 	if tmuxClient.IsTmuxAvailable() {
-		if err := tmuxClient.CreateSession(sessionName, true); err == nil {
+		if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err == nil {
 			sessionExists = true
-			defer tmuxClient.KillSession(sessionName)
+			defer tmuxClient.KillSession(context.Background(), sessionName)
 		}
 	}
 
@@ -2280,7 +2281,7 @@ func TestHealthCheckAttemptsRestorationBeforeCleanup(t *testing.T) {
 	sessionName := "mc-test-selfheal"
 
 	// Ensure the session doesn't exist at the start
-	tmuxClient.KillSession(sessionName)
+	tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create the repo directory on disk (required for restoration to succeed)
 	repoPath := d.paths.RepoDir("test-repo")
@@ -2331,13 +2332,13 @@ func TestHealthCheckAttemptsRestorationBeforeCleanup(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Verify a tmux session was created (restoration was attempted)
-	hasSession, err := tmuxClient.HasSession(sessionName)
+	hasSession, err := tmuxClient.HasSession(context.Background(), sessionName)
 	if err != nil {
 		t.Fatalf("Failed to check session: %v", err)
 	}
 
 	// Clean up the session we created
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	if hasSession {
 		t.Log("Self-healing succeeded: tmux session was restored")

--- a/pkg/claude/README.md
+++ b/pkg/claude/README.md
@@ -14,12 +14,15 @@ go get github.com/dlorenc/multiclaude/pkg/claude
 package main
 
 import (
+    "context"
     "log"
     "github.com/dlorenc/multiclaude/pkg/claude"
     "github.com/dlorenc/multiclaude/pkg/tmux"
 )
 
 func main() {
+    ctx := context.Background()
+
     // Create terminal runner (tmux)
     tmuxClient := tmux.NewClient()
 
@@ -30,13 +33,14 @@ func main() {
     )
 
     // Create tmux session and window
-    tmuxClient.CreateSession("my-session", true)
-    defer tmuxClient.KillSession("my-session")
-    tmuxClient.CreateWindow("my-session", "claude")
+    tmuxClient.CreateSession(ctx, "my-session", true)
+    defer tmuxClient.KillSession(ctx, "my-session")
+    tmuxClient.CreateWindow(ctx, "my-session", "claude")
 
     // Start Claude
-    result, err := runner.Start("my-session", "claude", claude.Config{
+    result, err := runner.Start(ctx, "my-session", "claude", claude.Config{
         SystemPromptFile: "/path/to/prompt.md",
+        WorkDir:          "/path/to/workspace",
     })
     if err != nil {
         log.Fatal(err)
@@ -45,7 +49,7 @@ func main() {
     log.Printf("Claude started: session=%s, pid=%d", result.SessionID, result.PID)
 
     // Send a message
-    if err := runner.SendMessage("my-session", "claude", "Hello, Claude!"); err != nil {
+    if err := runner.SendMessage(ctx, "my-session", "claude", "Hello, Claude!"); err != nil {
         log.Fatal(err)
     }
 }
@@ -53,22 +57,61 @@ func main() {
 
 ## Key Features
 
+### Context Support
+
+All I/O methods accept a `context.Context` as the first parameter, enabling:
+
+- Request cancellation
+- Timeouts
+- Graceful shutdown
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+result, err := runner.Start(ctx, "session", "window", claude.Config{})
+if errors.Is(err, context.DeadlineExceeded) {
+    log.Println("Claude startup timed out")
+}
+```
+
 ### TerminalRunner Interface
 
 The package uses the `TerminalRunner` interface to abstract terminal operations:
 
 ```go
 type TerminalRunner interface {
-    SendKeys(session, window, text string) error
-    SendKeysLiteral(session, window, text string) error
-    SendEnter(session, window string) error
-    GetPanePID(session, window string) (int, error)
-    StartPipePane(session, window, outputFile string) error
-    StopPipePane(session, window string) error
+    SendKeys(ctx context.Context, session, window, text string) error
+    SendKeysLiteral(ctx context.Context, session, window, text string) error
+    SendEnter(ctx context.Context, session, window string) error
+    SendKeysLiteralWithEnter(ctx context.Context, session, window, text string) error
+    GetPanePID(ctx context.Context, session, window string) (int, error)
+    StartPipePane(ctx context.Context, session, window, outputFile string) error
+    StopPipePane(ctx context.Context, session, window string) error
 }
 ```
 
 The `pkg/tmux.Client` implements this interface, but you can create custom implementations for other terminal emulators.
+
+### Working Directory Support
+
+Specify the working directory where Claude should run:
+
+```go
+result, err := runner.Start(ctx, "session", "window", claude.Config{
+    WorkDir: "/path/to/project",  // Claude will cd here before starting
+})
+```
+
+### Message of the Day (MOTD)
+
+Display a custom message before Claude starts (useful for showing restart instructions or context):
+
+```go
+result, err := runner.Start(ctx, "session", "window", claude.Config{
+    MOTD: "Restarting Claude session after crash...",
+})
+```
 
 ### Session ID Management
 
@@ -79,12 +122,18 @@ Each Claude instance gets a unique UUID v4 session ID:
 sessionID, err := claude.GenerateSessionID()
 
 // Or let Start() generate one
-result, _ := runner.Start("session", "window", claude.Config{})
+result, _ := runner.Start(ctx, "session", "window", claude.Config{})
 fmt.Println(result.SessionID)
 
 // Or provide your own
-result, _ := runner.Start("session", "window", claude.Config{
+result, _ := runner.Start(ctx, "session", "window", claude.Config{
     SessionID: "my-custom-id",
+})
+
+// Resume an existing session
+result, _ := runner.Start(ctx, "session", "window", claude.Config{
+    SessionID: existingID,
+    Resume:    true,  // Uses --resume instead of --session-id
 })
 ```
 
@@ -93,14 +142,14 @@ result, _ := runner.Start("session", "window", claude.Config{
 Capture Claude's output to a file:
 
 ```go
-result, err := runner.Start("session", "window", claude.Config{
+result, err := runner.Start(ctx, "session", "window", claude.Config{
     OutputFile: "/tmp/claude-output.log",
 })
 ```
 
 ### Multiline Messages
 
-The `SendMessage` method properly handles multiline text:
+The `SendMessage` method uses atomic sends to properly handle multiline text:
 
 ```go
 message := `Please review this code:
@@ -111,7 +160,17 @@ func hello() {
 
 What improvements would you suggest?`
 
-runner.SendMessage("session", "window", message)
+runner.SendMessage(ctx, "session", "window", message)
+```
+
+### Per-Agent Configuration
+
+Set `CLAUDE_CONFIG_DIR` for per-instance settings (slash commands, etc.):
+
+```go
+result, err := runner.Start(ctx, "session", "window", claude.Config{
+    ClaudeConfigDir: "/path/to/agent/config",
+})
 ```
 
 ## Configuration Options
@@ -135,6 +194,19 @@ runner := claude.NewRunner(
 )
 ```
 
+## Config Fields
+
+| Field | Description |
+|-------|-------------|
+| `SessionID` | Unique session identifier (auto-generated if empty) |
+| `Resume` | If true, uses `--resume` instead of `--session-id` |
+| `WorkDir` | Working directory to cd into before starting |
+| `SystemPromptFile` | Path to system prompt file |
+| `InitialMessage` | Optional message to send after startup |
+| `OutputFile` | Path to capture output via pipe-pane |
+| `ClaudeConfigDir` | Path for `CLAUDE_CONFIG_DIR` env var |
+| `MOTD` | Message to display before starting Claude |
+
 ## CLI Flags
 
 The runner constructs Claude commands with these flags:
@@ -142,6 +214,7 @@ The runner constructs Claude commands with these flags:
 | Flag | Description |
 |------|-------------|
 | `--session-id <uuid>` | Unique session identifier |
+| `--resume <uuid>` | Resume existing session |
 | `--dangerously-skip-permissions` | Skip interactive permission prompts |
 | `--append-system-prompt-file <path>` | Path to system prompt file |
 

--- a/pkg/tmux/README.md
+++ b/pkg/tmux/README.md
@@ -11,6 +11,9 @@ Existing Go tmux libraries ([gotmux](https://github.com/GianlucaP106/gotmux), [g
 | Multiline text via paste-buffer | No | **Yes** |
 | Pane PID extraction | No | **Yes** |
 | pipe-pane output capture | No | **Yes** |
+| Context support for cancellation | No | **Yes** |
+| Custom error types | No | **Yes** |
+| Atomic text + Enter send | No | **Yes** |
 
 ## Installation
 
@@ -24,11 +27,13 @@ go get github.com/dlorenc/multiclaude/pkg/tmux
 package main
 
 import (
+    "context"
     "log"
     "github.com/dlorenc/multiclaude/pkg/tmux"
 )
 
 func main() {
+    ctx := context.Background()
     client := tmux.NewClient()
 
     // Check if tmux is available
@@ -37,19 +42,63 @@ func main() {
     }
 
     // Create a detached session
-    if err := client.CreateSession("my-session", true); err != nil {
+    if err := client.CreateSession(ctx, "my-session", true); err != nil {
         log.Fatal(err)
     }
-    defer client.KillSession("my-session")
+    defer client.KillSession(ctx, "my-session")
 
     // Send a command
-    if err := client.SendKeys("my-session", "0", "echo hello"); err != nil {
+    if err := client.SendKeys(ctx, "my-session", "0", "echo hello"); err != nil {
         log.Fatal(err)
     }
 }
 ```
 
 ## Key Features
+
+### Context Support
+
+All I/O methods accept a `context.Context` as the first parameter, enabling:
+
+- Request cancellation
+- Timeouts
+- Graceful shutdown
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
+// This will fail if it takes longer than 5 seconds
+if err := client.CreateSession(ctx, "my-session", true); err != nil {
+    if errors.Is(err, context.DeadlineExceeded) {
+        log.Println("Operation timed out")
+    }
+}
+```
+
+### Custom Error Types
+
+The package provides custom error types for programmatic error handling:
+
+```go
+import "errors"
+
+err := client.CreateWindow(ctx, "nonexistent", "window")
+if err != nil {
+    var cmdErr *tmux.CommandError
+    if errors.As(err, &cmdErr) {
+        log.Printf("tmux command %s failed: %v", cmdErr.Op, cmdErr.Err)
+    }
+}
+
+// Helper functions for common checks
+if tmux.IsSessionNotFound(err) {
+    // Handle missing session
+}
+if tmux.IsWindowNotFound(err) {
+    // Handle missing window
+}
+```
 
 ### Multiline Text Input
 
@@ -62,12 +111,17 @@ This is line 2
 This is line 3`
 
 // SendKeysLiteral uses tmux's paste-buffer for multiline text
-if err := client.SendKeysLiteral("session", "window", message); err != nil {
+if err := client.SendKeysLiteral(ctx, "session", "window", message); err != nil {
     log.Fatal(err)
 }
 
 // Now send Enter to submit
-if err := client.SendEnter("session", "window"); err != nil {
+if err := client.SendEnter(ctx, "session", "window"); err != nil {
+    log.Fatal(err)
+}
+
+// Or use the atomic version to avoid race conditions
+if err := client.SendKeysLiteralWithEnter(ctx, "session", "window", message); err != nil {
     log.Fatal(err)
 }
 ```
@@ -78,12 +132,23 @@ if err := client.SendEnter("session", "window"); err != nil {
 
 This ensures the application receives the complete text before any processing is triggered.
 
+### Atomic Text + Enter
+
+`SendKeysLiteralWithEnter` sends text and Enter in a single shell command, preventing race conditions where Enter might be lost between separate exec calls:
+
+```go
+// Atomic: text + Enter in one operation
+if err := client.SendKeysLiteralWithEnter(ctx, "session", "window", "echo hello"); err != nil {
+    log.Fatal(err)
+}
+```
+
 ### Process PID Extraction
 
 Monitor whether a process running in a tmux pane is still alive:
 
 ```go
-pid, err := client.GetPanePID("session", "window")
+pid, err := client.GetPanePID(ctx, "session", "window")
 if err != nil {
     log.Fatal(err)
 }
@@ -101,14 +166,14 @@ Capture all output from a tmux pane to a file:
 
 ```go
 // Start capturing output
-if err := client.StartPipePane("session", "window", "/tmp/output.log"); err != nil {
+if err := client.StartPipePane(ctx, "session", "window", "/tmp/output.log"); err != nil {
     log.Fatal(err)
 }
 
 // ... run commands in the pane ...
 
 // Stop capturing
-if err := client.StopPipePane("session", "window"); err != nil {
+if err := client.StopPipePane(ctx, "session", "window"); err != nil {
     log.Fatal(err)
 }
 ```
@@ -118,40 +183,52 @@ if err := client.StopPipePane("session", "window"); err != nil {
 ### Session Management
 
 ```go
-HasSession(name string) (bool, error)      // Check if session exists
-CreateSession(name string, detached bool) error  // Create new session
-KillSession(name string) error             // Terminate session
-ListSessions() ([]string, error)           // List all sessions
+HasSession(ctx context.Context, name string) (bool, error)      // Check if session exists
+CreateSession(ctx context.Context, name string, detached bool) error  // Create new session
+KillSession(ctx context.Context, name string) error             // Terminate session
+ListSessions(ctx context.Context) ([]string, error)           // List all sessions
 ```
 
 ### Window Management
 
 ```go
-CreateWindow(session, name string) error   // Create window in session
-HasWindow(session, name string) (bool, error)  // Check if window exists
-KillWindow(session, name string) error     // Terminate window
-ListWindows(session string) ([]string, error)  // List windows in session
+CreateWindow(ctx context.Context, session, name string) error   // Create window in session
+HasWindow(ctx context.Context, session, name string) (bool, error)  // Check if window exists (exact match)
+KillWindow(ctx context.Context, session, name string) error     // Terminate window
+ListWindows(ctx context.Context, session string) ([]string, error)  // List windows in session
 ```
 
 ### Text Input
 
 ```go
-SendKeys(session, window, text string) error     // Send text + Enter
-SendKeysLiteral(session, window, text string) error  // Send text (paste-buffer for multiline)
-SendEnter(session, window string) error          // Send just Enter
+SendKeys(ctx context.Context, session, window, text string) error     // Send text + Enter
+SendKeysLiteral(ctx context.Context, session, window, text string) error  // Send text (paste-buffer for multiline)
+SendEnter(ctx context.Context, session, window string) error          // Send just Enter
+SendKeysLiteralWithEnter(ctx context.Context, session, window, text string) error  // Atomic text + Enter
 ```
 
 ### Process Monitoring
 
 ```go
-GetPanePID(session, window string) (int, error)  // Get process PID in pane
+GetPanePID(ctx context.Context, session, window string) (int, error)  // Get process PID in pane
 ```
 
 ### Output Capture
 
 ```go
-StartPipePane(session, window, outputFile string) error  // Start capturing
-StopPipePane(session, window string) error               // Stop capturing
+StartPipePane(ctx context.Context, session, window, outputFile string) error  // Start capturing
+StopPipePane(ctx context.Context, session, window string) error               // Stop capturing
+```
+
+### Error Types
+
+```go
+type SessionNotFoundError struct { Name string }
+type WindowNotFoundError struct { Session, Window string }
+type CommandError struct { Op, Session, Window string; Err error }
+
+func IsSessionNotFound(err error) bool
+func IsWindowNotFound(err error) bool
 ```
 
 ### Configuration

--- a/pkg/tmux/errors.go
+++ b/pkg/tmux/errors.go
@@ -1,0 +1,68 @@
+package tmux
+
+import "fmt"
+
+// SessionNotFoundError indicates that a tmux session does not exist.
+type SessionNotFoundError struct {
+	Name string
+}
+
+func (e *SessionNotFoundError) Error() string {
+	return fmt.Sprintf("tmux session not found: %s", e.Name)
+}
+
+// Is returns true if target is a *SessionNotFoundError.
+func (e *SessionNotFoundError) Is(target error) bool {
+	_, ok := target.(*SessionNotFoundError)
+	return ok
+}
+
+// WindowNotFoundError indicates that a tmux window does not exist within a session.
+type WindowNotFoundError struct {
+	Session string
+	Window  string
+}
+
+func (e *WindowNotFoundError) Error() string {
+	return fmt.Sprintf("tmux window not found: %s in session %s", e.Window, e.Session)
+}
+
+// Is returns true if target is a *WindowNotFoundError.
+func (e *WindowNotFoundError) Is(target error) bool {
+	_, ok := target.(*WindowNotFoundError)
+	return ok
+}
+
+// CommandError wraps errors from tmux command execution with additional context.
+type CommandError struct {
+	Op      string // Operation that failed (e.g., "create-session", "send-keys")
+	Session string // Session name, if applicable
+	Window  string // Window name, if applicable
+	Err     error  // Underlying error
+}
+
+func (e *CommandError) Error() string {
+	if e.Window != "" {
+		return fmt.Sprintf("tmux %s failed for %s:%s: %v", e.Op, e.Session, e.Window, e.Err)
+	}
+	if e.Session != "" {
+		return fmt.Sprintf("tmux %s failed for session %s: %v", e.Op, e.Session, e.Err)
+	}
+	return fmt.Sprintf("tmux %s failed: %v", e.Op, e.Err)
+}
+
+func (e *CommandError) Unwrap() error {
+	return e.Err
+}
+
+// IsSessionNotFound returns true if the error indicates a session was not found.
+func IsSessionNotFound(err error) bool {
+	_, ok := err.(*SessionNotFoundError)
+	return ok
+}
+
+// IsWindowNotFound returns true if the error indicates a window was not found.
+func IsWindowNotFound(err error) bool {
+	_, ok := err.(*WindowNotFoundError)
+	return ok
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -108,17 +109,17 @@ func TestPhase2Integration(t *testing.T) {
 	// Test: Add repository
 	tmuxSession := "mc-test-repo"
 	// Create tmux session first (will be cleaned up at end of test)
-	if err := tmuxClient.CreateSession(tmuxSession, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), tmuxSession, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(tmuxSession)
+	defer tmuxClient.KillSession(context.Background(), tmuxSession)
 
 	t.Run("AddRepository", func(t *testing.T) {
 		// Create windows for supervisor and merge-queue
-		if err := tmuxClient.CreateWindow(tmuxSession, "supervisor"); err != nil {
+		if err := tmuxClient.CreateWindow(context.Background(), tmuxSession, "supervisor"); err != nil {
 			t.Fatalf("Failed to create supervisor window: %v", err)
 		}
-		if err := tmuxClient.CreateWindow(tmuxSession, "merge-queue"); err != nil {
+		if err := tmuxClient.CreateWindow(context.Background(), tmuxSession, "merge-queue"); err != nil {
 			t.Fatalf("Failed to create merge-queue window: %v", err)
 		}
 
@@ -173,7 +174,7 @@ func TestPhase2Integration(t *testing.T) {
 		}
 
 		// Create tmux window
-		if err := tmuxClient.CreateWindow(tmuxSession, workerName); err != nil {
+		if err := tmuxClient.CreateWindow(context.Background(), tmuxSession, workerName); err != nil {
 			t.Fatalf("Failed to create worker window: %v", err)
 		}
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -80,7 +81,7 @@ func setupIntegrationTest(t *testing.T, repoName string) (*cli.CLI, *daemon.Daem
 
 	// Create tmux session
 	tmuxSession := "mc-" + repoName
-	if err := tmuxClient.CreateSession(tmuxSession, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), tmuxSession, true); err != nil {
 		d.Stop()
 		os.RemoveAll(tmpDir)
 		t.Fatalf("Failed to create tmux session: %v", err)
@@ -90,7 +91,7 @@ func setupIntegrationTest(t *testing.T, repoName string) (*cli.CLI, *daemon.Daem
 	c := cli.NewWithPaths(paths)
 
 	cleanup := func() {
-		tmuxClient.KillSession(tmuxSession)
+		tmuxClient.KillSession(context.Background(), tmuxSession)
 		d.Stop()
 		os.RemoveAll(tmpDir)
 		os.Unsetenv("MULTICLAUDE_TEST_MODE")
@@ -198,7 +199,7 @@ func TestWorkerCreationIntegration(t *testing.T) {
 
 	// Verification 3: Tmux window was created
 	tmuxClient := tmux.NewClient()
-	hasWindow, err := tmuxClient.HasWindow(tmuxSession, workerName)
+	hasWindow, err := tmuxClient.HasWindow(context.Background(), tmuxSession, workerName)
 	if err != nil {
 		t.Fatalf("Failed to check tmux window: %v", err)
 	}
@@ -352,7 +353,7 @@ func TestRepoInitializationIntegration(t *testing.T) {
 
 	// Clean up tmux session created by init
 	tmuxSession := "mc-" + repoName
-	defer tmuxClient.KillSession(tmuxSession)
+	defer tmuxClient.KillSession(context.Background(), tmuxSession)
 
 	// Verification 1: Repo is registered with daemon
 	repo, exists := d.GetState().GetRepo(repoName)
@@ -373,7 +374,7 @@ func TestRepoInitializationIntegration(t *testing.T) {
 	}
 
 	// Verification 3: Tmux session was created
-	hasSession, err := tmuxClient.HasSession(tmuxSession)
+	hasSession, err := tmuxClient.HasSession(context.Background(), tmuxSession)
 	if err != nil {
 		t.Fatalf("Failed to check tmux session: %v", err)
 	}
@@ -401,7 +402,7 @@ func TestRepoInitializationIntegration(t *testing.T) {
 
 	// Verification 6: Check that supervisor and merge-queue windows exist
 	for _, windowName := range []string{"supervisor", "merge-queue"} {
-		hasWindow, err := tmuxClient.HasWindow(tmuxSession, windowName)
+		hasWindow, err := tmuxClient.HasWindow(context.Background(), tmuxSession, windowName)
 		if err != nil {
 			t.Fatalf("Failed to check %s window: %v", windowName, err)
 		}
@@ -491,7 +492,7 @@ func TestRepoInitializationWithMergeQueueDisabled(t *testing.T) {
 	}
 
 	tmuxSession := "mc-" + repoName
-	defer tmuxClient.KillSession(tmuxSession)
+	defer tmuxClient.KillSession(context.Background(), tmuxSession)
 
 	// Verify merge queue is disabled
 	repo, _ := d.GetState().GetRepo(repoName)

--- a/test/recovery_test.go
+++ b/test/recovery_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -120,13 +121,13 @@ func TestOrphanedTmuxSessionCleanup(t *testing.T) {
 
 	// Create an "orphaned" tmux session (not tracked in state)
 	orphanSession := "mc-orphan-test"
-	if err := tmuxClient.CreateSession(orphanSession, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), orphanSession, true); err != nil {
 		t.Fatalf("Failed to create orphan session: %v", err)
 	}
-	defer tmuxClient.KillSession(orphanSession)
+	defer tmuxClient.KillSession(context.Background(), orphanSession)
 
 	// Verify session exists
-	exists, err := tmuxClient.HasSession(orphanSession)
+	exists, err := tmuxClient.HasSession(context.Background(), orphanSession)
 	if err != nil {
 		t.Fatalf("Failed to check session: %v", err)
 	}
@@ -135,7 +136,7 @@ func TestOrphanedTmuxSessionCleanup(t *testing.T) {
 	}
 
 	// List sessions - should see our orphan
-	sessions, err := tmuxClient.ListSessions()
+	sessions, err := tmuxClient.ListSessions(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to list sessions: %v", err)
 	}
@@ -389,13 +390,13 @@ func TestDaemonCrashRecovery(t *testing.T) {
 	// Create the tmux session BEFORE starting the daemon
 	// This is critical: when d2 starts, restoreTrackedRepos() will see the session
 	// exists and skip restoration, preserving the state as-is.
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create supervisor window for the agent we'll add
-	if err := tmuxClient.CreateWindow(sessionName, "supervisor"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "supervisor"); err != nil {
 		t.Fatalf("Failed to create supervisor window: %v", err)
 	}
 
@@ -606,13 +607,13 @@ func TestDaemonRestartSetsUpClaudeConfigDir(t *testing.T) {
 
 	// Create tmux session for the test
 	sessionName := "mc-config-test"
-	if err := tmuxClient.CreateSession(sessionName, true); err != nil {
+	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
-	defer tmuxClient.KillSession(sessionName)
+	defer tmuxClient.KillSession(context.Background(), sessionName)
 
 	// Create supervisor window for the agent
-	if err := tmuxClient.CreateWindow(sessionName, "supervisor"); err != nil {
+	if err := tmuxClient.CreateWindow(context.Background(), sessionName, "supervisor"); err != nil {
 		t.Fatalf("Failed to create supervisor window: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

- Add `context.Context` to all I/O methods in `pkg/tmux` and `pkg/claude` for cancellation/timeout support
- Fix `HasWindow` to use exact matching with tmux format strings instead of `strings.Contains`
- Add `SendKeysLiteralWithEnter` to `TerminalRunner` interface for atomic text+Enter sends
- Make MOTD configurable via `Config.MOTD` (removed hardcoded multiclaude-specific text)
- Implement `WorkDir` in `buildCommand` (now `cd`s to directory before launching)
- Add custom error types (`SessionNotFoundError`, `WindowNotFoundError`, `CommandError`) for programmatic error handling
- Update all internal callers to use new context-aware APIs
- Update README.md for both packages with new examples

## Breaking Changes

All I/O methods now require `context.Context` as first parameter:
```go
// Before
client.HasSession("my-session")
runner.Start("session", "window", config)

// After  
client.HasSession(ctx, "my-session")
runner.Start(ctx, "session", "window", config)
```

## Test plan

- [x] All existing tests updated to use context
- [x] New tests for `HasWindow` exact matching
- [x] New tests for custom error types
- [x] `go test ./...` passes
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)