### PR TITLE
fix: Link global OAuth credentials to worktrees for Claude Max users

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1630,6 +1630,11 @@ func (c *CLI) createWorker(args []string) error {
 		fmt.Printf("Warning: failed to copy hooks config: %v\n", err)
 	}
 
+	// Link global credentials to worktree
+	if err := c.linkGlobalCredentials(wtPath); err != nil {
+		fmt.Printf("Warning: failed to link credentials: %v\n", err)
+	}
+
 	// Start Claude in worker window with initial task (skip in test mode)
 	var workerPID int
 	if os.Getenv("MULTICLAUDE_TEST_MODE") != "1" {
@@ -2232,6 +2237,11 @@ func (c *CLI) addWorkspace(args []string) error {
 	// Copy hooks configuration if it exists
 	if err := hooks.CopyConfig(repoPath, wtPath); err != nil {
 		fmt.Printf("Warning: failed to copy hooks config: %v\n", err)
+	}
+
+	// Link global credentials to worktree
+	if err := c.linkGlobalCredentials(wtPath); err != nil {
+		fmt.Printf("Warning: failed to link credentials: %v\n", err)
 	}
 
 	// Start Claude in workspace window (skip in test mode)
@@ -3105,6 +3115,11 @@ func (c *CLI) reviewPR(args []string) error {
 	// Copy hooks configuration if it exists
 	if err := hooks.CopyConfig(repoPath, wtPath); err != nil {
 		fmt.Printf("Warning: failed to copy hooks config: %v\n", err)
+	}
+
+	// Link global credentials to worktree
+	if err := c.linkGlobalCredentials(wtPath); err != nil {
+		fmt.Printf("Warning: failed to link credentials: %v\n", err)
 	}
 
 	// Start Claude in reviewer window with initial task (skip in test mode)
@@ -4131,6 +4146,18 @@ func (c *CLI) localRepair(verbose bool) error {
 		}
 	}
 
+	// Repair missing credential symlinks
+	if credFixed, err := c.repairCredentials(verbose); err != nil {
+		if verbose {
+			fmt.Printf("  Warning: credential repair failed: %v\n", err)
+		}
+	} else if credFixed > 0 {
+		if verbose {
+			fmt.Printf("  Repaired credentials in %d worktree(s)\n", credFixed)
+		}
+		issuesFixed += credFixed
+	}
+
 	// Report orphaned tmux sessions
 	if len(orphanedSessions) > 0 {
 		fmt.Printf("\nFound %d orphaned tmux session(s) not in state:\n", len(orphanedSessions))
@@ -4536,4 +4563,138 @@ func (c *CLI) bugReport(args []string) error {
 	// Print to stdout
 	fmt.Print(markdown)
 	return nil
+}
+
+// linkGlobalCredentials creates a symlink from the worktree's .claude/.credentials.json
+// to the global ~/.claude/.credentials.json. This ensures workers can access OAuth
+// credentials without duplicating sensitive files.
+func (c *CLI) linkGlobalCredentials(worktreePath string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	globalCredFile := filepath.Join(home, ".claude", ".credentials.json")
+	localClaudeDir := filepath.Join(worktreePath, ".claude")
+	localCredFile := filepath.Join(localClaudeDir, ".credentials.json")
+
+	// Check if global credentials exist
+	if _, err := os.Stat(globalCredFile); os.IsNotExist(err) {
+		// No global credentials - user might be using API key
+		return nil
+	}
+
+	// Check if symlink already exists and is valid
+	if linkTarget, err := os.Readlink(localCredFile); err == nil {
+		if linkTarget == globalCredFile {
+			// Already correctly linked
+			return nil
+		}
+		// Invalid link, remove it
+		os.Remove(localCredFile)
+	} else if _, err := os.Stat(localCredFile); err == nil {
+		// File exists but is not a symlink, remove it
+		os.Remove(localCredFile)
+	}
+
+	// Create symlink
+	if err := os.Symlink(globalCredFile, localCredFile); err != nil {
+		return fmt.Errorf("failed to create credentials symlink: %w", err)
+	}
+
+	return nil
+}
+
+// repairCredentials fixes worktrees that are missing credential symlinks
+func (c *CLI) repairCredentials(verbose bool) (int, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	globalCredFile := filepath.Join(home, ".claude", ".credentials.json")
+
+	// Check if global credentials exist
+	if _, err := os.Stat(globalCredFile); os.IsNotExist(err) {
+		if verbose {
+			fmt.Println("  No global credentials found - skipping credential repair")
+		}
+		return 0, nil
+	}
+
+	// Load state to get all repos
+	st, err := state.Load(c.paths.StateFile)
+	if err != nil {
+		return 0, fmt.Errorf("failed to load state: %w", err)
+	}
+
+	fixed := 0
+	for _, repoName := range st.ListRepos() {
+		wtRootDir := c.paths.WorktreeDir(repoName)
+
+		// Skip if worktree directory doesn't exist
+		if _, err := os.Stat(wtRootDir); os.IsNotExist(err) {
+			continue
+		}
+
+		// Walk all worktrees
+		entries, err := os.ReadDir(wtRootDir)
+		if err != nil {
+			if verbose {
+				fmt.Printf("  Warning: failed to read worktree dir for %s: %v\n", repoName, err)
+			}
+			continue
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+
+			worktreePath := filepath.Join(wtRootDir, entry.Name())
+			claudeDir := filepath.Join(worktreePath, ".claude")
+
+			// Skip if .claude doesn't exist
+			if _, err := os.Stat(claudeDir); os.IsNotExist(err) {
+				continue
+			}
+
+			localCredFile := filepath.Join(claudeDir, ".credentials.json")
+
+			// Check if credentials already exist and are a valid symlink
+			if linkTarget, err := os.Readlink(localCredFile); err == nil {
+				if linkTarget == globalCredFile {
+					// Already correctly linked
+					continue
+				}
+				// Invalid symlink, will be recreated below
+			} else if _, err := os.Stat(localCredFile); err == nil {
+				// File exists but is not a symlink, remove it
+				if verbose {
+					fmt.Printf("  Removing non-symlink credential file in %s/%s\n", repoName, entry.Name())
+				}
+				os.Remove(localCredFile)
+			} else if !os.IsNotExist(err) {
+				// Some other error
+				if verbose {
+					fmt.Printf("  Warning: failed to check credentials in %s/%s: %v\n", repoName, entry.Name(), err)
+				}
+				continue
+			}
+
+			// Create or recreate symlink
+			if err := os.Symlink(globalCredFile, localCredFile); err != nil {
+				if verbose {
+					fmt.Printf("  Warning: failed to link credentials in %s/%s: %v\n", repoName, entry.Name(), err)
+				}
+			} else {
+				if verbose {
+					fmt.Printf("  Linked credentials in %s/%s\n", repoName, entry.Name())
+				}
+				fixed++
+			}
+		}
+	}
+
+	return fixed, nil
 }


### PR DESCRIPTION
## Summary
- Fixes OAuth authentication issue where new worker agents prompt for login instead of using existing credentials
- Adds symlink from worktree `.claude/.credentials.json` to global `~/.claude/.credentials.json`
- Includes repair functionality to fix existing worktrees

## Root Cause
multiclaude creates a local `.claude` directory in each git worktree for settings, which causes the Claude CLI to search for credentials in the worktree instead of the global `~/.claude/.credentials.json` where OAuth tokens are stored.

## Solution
Create symbolic links from worktree `.claude/.credentials.json` to the global credentials file. This ensures:
- Workers can access OAuth credentials
- Settings remain local to worktrees
- No credential duplication (security benefit)
- Changes to global credentials automatically propagate

## Changes
- **CLI** (`internal/cli/cli.go`):
  - Add `linkGlobalCredentials()` method
  - Integrate into worker/workspace/reviewer creation
  - Add `repairCredentials()` for existing worktrees
  - Integrate repair into `localRepair()` command

- **Daemon** (`internal/daemon/daemon.go`):
  - Add `linkGlobalCredentials()` method
  - Integrate into supervisor and merge-queue creation

- **Tests** (`internal/cli/cli_test.go`):
  - Add `TestLinkGlobalCredentials` - verifies symlink creation, idempotency, and edge cases
  - Add `TestRepairCredentials` - verifies repair functionality for existing worktrees

## Test Plan
- [x] All existing tests pass
- [x] New unit tests validate credential linking
- [x] Handles edge cases:
  - No global credentials (API key users)
  - Symlink already exists
  - File exists instead of symlink
  - Invalid symlinks

## Verification Steps
1. Ensure `~/.claude/.credentials.json` exists with OAuth tokens
2. Create a new worker: `multiclaude work "Test task"`
3. Verify symlink: `ls -la ~/.multiclaude/wts/<repo>/<worker>/.claude/.credentials.json`
4. Attach to worker: `multiclaude attach <worker>`
5. Confirm no OAuth login prompt appears

To repair existing worktrees:
```bash
multiclaude repair --verbose
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)