### PR TITLE
feat: Add Claude hook to prevent PRs against upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ Thumbs.db
 # multiclaude runtime (but allow config files)
 .multiclaude/*
 !.multiclaude/*.md
+!.multiclaude/hooks.json
+!.multiclaude/scripts/

--- a/.multiclaude/hooks.json
+++ b/.multiclaude/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.multiclaude/scripts/check-pr-target.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.multiclaude/scripts/check-pr-target.sh
+++ b/.multiclaude/scripts/check-pr-target.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# check-pr-target.sh - Prevents PRs from being created against upstream
+#
+# This script is called by Claude Code hooks (PreToolUse) to intercept
+# `gh pr create` commands and ensure they never target the upstream
+# repository (dlorenc/multiclaude).
+#
+# Exit codes:
+#   0 - Allow the command
+#   2 - Block the command (error message in stderr)
+
+set -e
+
+# Read the hook input from stdin
+INPUT=$(cat)
+
+# Extract the command from the JSON input
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# If not a bash command or empty, allow it
+if [ -z "$COMMAND" ]; then
+    exit 0
+fi
+
+# Check if this is a gh pr create command
+if ! echo "$COMMAND" | grep -qE 'gh\s+(pr\s+create|pr\s+--repo|--repo.*pr\s+create)'; then
+    exit 0
+fi
+
+# Blocked upstream repositories (case-insensitive check)
+UPSTREAM_PATTERNS=(
+    "dlorenc/multiclaude"
+    "DLORENC/MULTICLAUDE"
+    "dlorenc/Multiclaude"
+)
+
+# Check if the command explicitly targets upstream via --repo or -R
+for pattern in "${UPSTREAM_PATTERNS[@]}"; do
+    if echo "$COMMAND" | grep -qiE "(--repo[= ]|--repo$|-R[= ]|-R$).*${pattern}"; then
+        echo "ERROR: Cannot create PR against upstream repository (dlorenc/multiclaude)." >&2
+        echo "" >&2
+        echo "PRs must target the fork: aronchick/multiclaude" >&2
+        echo "" >&2
+        echo "Fix: Remove --repo flag or use: --repo aronchick/multiclaude" >&2
+        exit 2
+    fi
+done
+
+# Check for upstream in the command even without explicit --repo flag
+# (catches cases like `gh pr create -R dlorenc/multiclaude`)
+for pattern in "${UPSTREAM_PATTERNS[@]}"; do
+    if echo "$COMMAND" | grep -qi "$pattern"; then
+        echo "ERROR: Cannot create PR against upstream repository (dlorenc/multiclaude)." >&2
+        echo "" >&2
+        echo "PRs must target the fork: aronchick/multiclaude" >&2
+        exit 2
+    fi
+done
+
+# Command is allowed
+exit 0

--- a/internal/hooks/check_pr_target_test.go
+++ b/internal/hooks/check_pr_target_test.go
@@ -1,0 +1,144 @@
+package hooks
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCheckPRTargetScript tests the check-pr-target.sh script that prevents
+// PRs from being created against upstream (dlorenc/multiclaude).
+func TestCheckPRTargetScript(t *testing.T) {
+	// Find the script path relative to the repo root
+	// We need to go up from internal/hooks to find .multiclaude/scripts
+	scriptPath := filepath.Join("..", "..", ".multiclaude", "scripts", "check-pr-target.sh")
+
+	// Verify script exists
+	if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
+		t.Skipf("Script not found at %s - skipping test", scriptPath)
+	}
+
+	tests := []struct {
+		name       string
+		input      string
+		wantCode   int
+		wantStderr string // substring to check in stderr
+	}{
+		{
+			name:     "non-gh command allowed",
+			input:    `{"tool_input":{"command":"git status"}}`,
+			wantCode: 0,
+		},
+		{
+			name:     "gh pr create without repo flag allowed",
+			input:    `{"tool_input":{"command":"gh pr create --title \"test\""}}`,
+			wantCode: 0,
+		},
+		{
+			name:     "gh pr create to fork allowed",
+			input:    `{"tool_input":{"command":"gh pr create --repo aronchick/multiclaude --title \"test\""}}`,
+			wantCode: 0,
+		},
+		{
+			name:     "gh pr create to other repo allowed",
+			input:    `{"tool_input":{"command":"gh pr create --repo someuser/somerepo --title \"test\""}}`,
+			wantCode: 0,
+		},
+		{
+			name:       "gh pr create to upstream blocked",
+			input:      `{"tool_input":{"command":"gh pr create --repo dlorenc/multiclaude --title \"test\""}}`,
+			wantCode:   2,
+			wantStderr: "dlorenc/multiclaude",
+		},
+		{
+			name:       "gh pr create to upstream with -R flag blocked",
+			input:      `{"tool_input":{"command":"gh pr create -R dlorenc/multiclaude"}}`,
+			wantCode:   2,
+			wantStderr: "dlorenc/multiclaude",
+		},
+		{
+			name:       "case insensitive blocking",
+			input:      `{"tool_input":{"command":"gh pr create --repo DLORENC/MULTICLAUDE"}}`,
+			wantCode:   2,
+			wantStderr: "dlorenc/multiclaude",
+		},
+		{
+			name:     "empty command allowed",
+			input:    `{"tool_input":{}}`,
+			wantCode: 0,
+		},
+		{
+			name:     "empty input allowed",
+			input:    `{}`,
+			wantCode: 0,
+		},
+		{
+			name:       "upstream mentioned anywhere in command blocked",
+			input:      `{"tool_input":{"command":"gh pr create --body \"fix for dlorenc/multiclaude issue\""}}`,
+			wantCode:   2,
+			wantStderr: "dlorenc/multiclaude",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command("bash", scriptPath)
+			cmd.Stdin = strings.NewReader(tt.input)
+
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+
+			// Check exit code
+			exitCode := 0
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				exitCode = exitErr.ExitCode()
+			} else if err != nil {
+				t.Fatalf("Failed to run script: %v", err)
+			}
+
+			if exitCode != tt.wantCode {
+				t.Errorf("Exit code = %d, want %d. Stderr: %s", exitCode, tt.wantCode, stderr.String())
+			}
+
+			// Check stderr contains expected message if blocking
+			if tt.wantStderr != "" && !strings.Contains(stderr.String(), tt.wantStderr) {
+				t.Errorf("Stderr = %q, want to contain %q", stderr.String(), tt.wantStderr)
+			}
+		})
+	}
+}
+
+// TestHooksJSONValid verifies the hooks.json file is valid JSON with expected structure.
+func TestHooksJSONValid(t *testing.T) {
+	hooksPath := filepath.Join("..", "..", ".multiclaude", "hooks.json")
+
+	data, err := os.ReadFile(hooksPath)
+	if os.IsNotExist(err) {
+		t.Skipf("hooks.json not found at %s - skipping test", hooksPath)
+	}
+	if err != nil {
+		t.Fatalf("Failed to read hooks.json: %v", err)
+	}
+
+	// Check it contains expected keys
+	content := string(data)
+	expectedKeys := []string{
+		`"hooks"`,
+		`"PreToolUse"`,
+		`"Bash"`,
+		`"matcher"`,
+		`"command"`,
+		`check-pr-target.sh`,
+	}
+
+	for _, key := range expectedKeys {
+		if !strings.Contains(content, key) {
+			t.Errorf("hooks.json should contain %q", key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `PreToolUse` Claude Code hook that intercepts `gh pr create` commands
- Blocks any PR creation that targets the upstream repository (`dlorenc/multiclaude`)
- Ensures workers always create PRs against the fork (`aronchick/multiclaude`)

## Implementation

**New files:**
- `.multiclaude/hooks.json` - Hook configuration that triggers on Bash tool use
- `.multiclaude/scripts/check-pr-target.sh` - Validation script that checks PR target
- `internal/hooks/check_pr_target_test.go` - Comprehensive tests

**How it works:**
1. When Claude Code executes a Bash command, the `PreToolUse` hook fires
2. The hook script checks if the command contains `gh pr create`
3. If it targets upstream (`--repo dlorenc/multiclaude` or `-R dlorenc/multiclaude`), exit code 2 blocks execution
4. Clear error message guides the agent to use the correct repo

**Error output when blocked:**
```
ERROR: Cannot create PR against upstream repository (dlorenc/multiclaude).

PRs must target the fork: aronchick/multiclaude

Fix: Remove --repo flag or use: --repo aronchick/multiclaude
```

## Test plan

- [x] Script blocks `gh pr create --repo dlorenc/multiclaude`
- [x] Script blocks `gh pr create -R dlorenc/multiclaude`  
- [x] Script blocks case-insensitive variations (DLORENC/MULTICLAUDE)
- [x] Script allows `gh pr create` without repo flag
- [x] Script allows `gh pr create --repo aronchick/multiclaude`
- [x] Script allows non-gh commands
- [x] All new tests pass (`go test ./internal/hooks/...`)

🤖 Generated with [Claude Code](https://claude.ai/code)