### PR TITLE
feat(errors): Add structured error constructors for common 'not found' cases

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1151,7 +1151,7 @@ func (c *CLI) removeRepo(args []string) error {
 		repos, _ := resp.Data.([]interface{})
 		items := reposToSelectableItems(repos)
 		if len(items) == 0 {
-			return fmt.Errorf("no repositories found")
+			return errors.NoRepositoriesFound()
 		}
 		selected, err := SelectFromList("Select repository to remove:", items)
 		if err != nil {
@@ -2004,7 +2004,7 @@ func (c *CLI) removeWorker(args []string) error {
 		// Interactive selection
 		items := agentsToSelectableItems(agents, []string{"worker"})
 		if len(items) == 0 {
-			return fmt.Errorf("no workers found in repo '%s'", repoName)
+			return errors.NoWorkersFound(repoName)
 		}
 		selected, err := SelectFromList("Select worker to remove:", items)
 		if err != nil {
@@ -2322,7 +2322,7 @@ func (c *CLI) removeWorkspace(args []string) error {
 		// Interactive selection
 		items := agentsToSelectableItems(agents, []string{"workspace"})
 		if len(items) == 0 {
-			return fmt.Errorf("no workspaces found in repo '%s'", repoName)
+			return errors.NoWorkspacesFound(repoName)
 		}
 		selected, err := SelectFromList("Select workspace to remove:", items)
 		if err != nil {
@@ -2555,7 +2555,7 @@ func (c *CLI) connectWorkspace(args []string) error {
 		// Interactive selection
 		items := agentsToSelectableItems(agents, []string{"workspace"})
 		if len(items) == 0 {
-			return fmt.Errorf("no workspaces found in repo '%s'", repoName)
+			return errors.NoWorkspacesFound(repoName)
 		}
 		selected, err := SelectFromList("Select workspace to connect:", items)
 		if err != nil {
@@ -2582,7 +2582,7 @@ func (c *CLI) connectWorkspace(args []string) error {
 	}
 
 	if workspaceInfo == nil {
-		return fmt.Errorf("workspace '%s' not found in repo '%s'", workspaceName, repoName)
+		return errors.WorkspaceNotFound(workspaceName, repoName)
 	}
 
 	// Get tmux session and window
@@ -3472,7 +3472,7 @@ func (c *CLI) attachAgent(args []string) error {
 		// Interactive selection - all agent types
 		items := agentsToSelectableItems(agents, nil)
 		if len(items) == 0 {
-			return fmt.Errorf("no agents found in repo '%s'", repoName)
+			return errors.NoAgentsFound(repoName)
 		}
 		selected, err := SelectFromList("Select agent to attach:", items)
 		if err != nil {
@@ -3497,7 +3497,7 @@ func (c *CLI) attachAgent(args []string) error {
 	}
 
 	if agentInfo == nil {
-		return fmt.Errorf("agent '%s' not found in repo '%s'", agentName, repoName)
+		return errors.AgentNotFound("agent", agentName, repoName)
 	}
 
 	// Get tmux session and window

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -337,3 +337,48 @@ func UnknownCommand(cmd string) *CLIError {
 		Suggestion: "multiclaude --help",
 	}
 }
+
+// NoRepositoriesFound creates an error for when no repositories are tracked
+func NoRepositoriesFound() *CLIError {
+	return &CLIError{
+		Category:   CategoryNotFound,
+		Message:    "no repositories found",
+		Suggestion: "multiclaude init <github-url>",
+	}
+}
+
+// NoWorkersFound creates an error for when no workers exist in a repository
+func NoWorkersFound(repo string) *CLIError {
+	return &CLIError{
+		Category:   CategoryNotFound,
+		Message:    fmt.Sprintf("no workers found in repo '%s'", repo),
+		Suggestion: fmt.Sprintf("multiclaude work \"<task>\" --repo %s", repo),
+	}
+}
+
+// NoWorkspacesFound creates an error for when no workspaces exist in a repository
+func NoWorkspacesFound(repo string) *CLIError {
+	return &CLIError{
+		Category:   CategoryNotFound,
+		Message:    fmt.Sprintf("no workspaces found in repo '%s'", repo),
+		Suggestion: fmt.Sprintf("multiclaude workspace add <name> --repo %s", repo),
+	}
+}
+
+// NoAgentsFound creates an error for when no agents exist in a repository
+func NoAgentsFound(repo string) *CLIError {
+	return &CLIError{
+		Category:   CategoryNotFound,
+		Message:    fmt.Sprintf("no agents found in repo '%s'", repo),
+		Suggestion: fmt.Sprintf("multiclaude work list --repo %s", repo),
+	}
+}
+
+// WorkspaceNotFound creates an error for when a workspace is not found
+func WorkspaceNotFound(name, repo string) *CLIError {
+	return &CLIError{
+		Category:   CategoryNotFound,
+		Message:    fmt.Sprintf("workspace '%s' not found in repo '%s'", name, repo),
+		Suggestion: fmt.Sprintf("multiclaude workspace list --repo %s", repo),
+	}
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -470,3 +470,110 @@ func TestCategoryPrefix_DefaultCase(t *testing.T) {
 		t.Errorf("expected default 'Error:' prefix for unknown category, got: %s", formatted)
 	}
 }
+
+func TestNoRepositoriesFound(t *testing.T) {
+	err := NoRepositoriesFound()
+
+	if err.Category != CategoryNotFound {
+		t.Errorf("expected CategoryNotFound, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "no repositories found") {
+		t.Errorf("expected 'no repositories found' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "multiclaude init") {
+		t.Errorf("expected init suggestion, got: %s", formatted)
+	}
+}
+
+func TestNoWorkersFound(t *testing.T) {
+	err := NoWorkersFound("my-repo")
+
+	if err.Category != CategoryNotFound {
+		t.Errorf("expected CategoryNotFound, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "no workers found") {
+		t.Errorf("expected 'no workers found' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "my-repo") {
+		t.Errorf("expected repo name in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "multiclaude work") {
+		t.Errorf("expected work suggestion, got: %s", formatted)
+	}
+}
+
+func TestNoWorkspacesFound(t *testing.T) {
+	err := NoWorkspacesFound("my-repo")
+
+	if err.Category != CategoryNotFound {
+		t.Errorf("expected CategoryNotFound, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "no workspaces found") {
+		t.Errorf("expected 'no workspaces found' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "my-repo") {
+		t.Errorf("expected repo name in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "multiclaude workspace add") {
+		t.Errorf("expected workspace add suggestion, got: %s", formatted)
+	}
+}
+
+func TestNoAgentsFound(t *testing.T) {
+	err := NoAgentsFound("my-repo")
+
+	if err.Category != CategoryNotFound {
+		t.Errorf("expected CategoryNotFound, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "no agents found") {
+		t.Errorf("expected 'no agents found' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "my-repo") {
+		t.Errorf("expected repo name in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "multiclaude work list") {
+		t.Errorf("expected work list suggestion, got: %s", formatted)
+	}
+}
+
+func TestWorkspaceNotFound(t *testing.T) {
+	err := WorkspaceNotFound("my-workspace", "my-repo")
+
+	if err.Category != CategoryNotFound {
+		t.Errorf("expected CategoryNotFound, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "my-workspace") {
+		t.Errorf("expected workspace name in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "my-repo") {
+		t.Errorf("expected repo name in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "multiclaude workspace list") {
+		t.Errorf("expected workspace list suggestion, got: %s", formatted)
+	}
+}


### PR DESCRIPTION
## Summary
- Add 5 new error constructors with helpful suggestions for common "not found" errors
- Update cli.go to use structured errors instead of raw fmt.Errorf calls
- Aligns with P0 roadmap goal for clear error messages

## Test plan
- [x] Unit tests for all new error constructors pass
- [x] All existing tests pass
- [ ] Manual verification of error messages in CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)