### PR TITLE
feat: Add 'multiclaude nuke' command for resetting to clean state

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -213,6 +213,18 @@ func (s *State) ListRepos() []string {
 	return repos
 }
 
+// ClearAllAgents removes all agents from all repositories
+// but preserves the repository entries themselves
+func (s *State) ClearAllAgents() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, repo := range s.Repos {
+		repo.Agents = make(map[string]Agent)
+	}
+	return s.saveUnlocked()
+}
+
 // SetCurrentRepo sets the current/default repository
 func (s *State) SetCurrentRepo(name string) error {
 	s.mu.Lock()


### PR DESCRIPTION
Cherry-picked from fork. Adds 'multiclaude nuke' command that resets multiclaude to a clean state (removes agents, worktrees, messages).