### PR TITLE
test: Add tests to improve coverage for config, format, and tmux packages

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -162,3 +162,110 @@ func TestOutputPaths(t *testing.T) {
 		t.Errorf("AgentLogFile(happy-eagle, true) = %q, want %q", workerLog, expected)
 	}
 }
+
+func TestAgentClaudeConfigDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	paths := &Paths{
+		Root:            tmpDir,
+		ClaudeConfigDir: filepath.Join(tmpDir, "claude-config"),
+	}
+
+	repoName := "test-repo"
+	agentName := "happy-eagle"
+
+	configDir := paths.AgentClaudeConfigDir(repoName, agentName)
+	expected := filepath.Join(tmpDir, "claude-config", repoName, agentName)
+	if configDir != expected {
+		t.Errorf("AgentClaudeConfigDir() = %q, want %q", configDir, expected)
+	}
+
+	// Test with different agent types
+	supervisorConfigDir := paths.AgentClaudeConfigDir(repoName, "supervisor")
+	expected = filepath.Join(tmpDir, "claude-config", repoName, "supervisor")
+	if supervisorConfigDir != expected {
+		t.Errorf("AgentClaudeConfigDir(supervisor) = %q, want %q", supervisorConfigDir, expected)
+	}
+}
+
+func TestAgentCommandsDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	paths := &Paths{
+		Root:            tmpDir,
+		ClaudeConfigDir: filepath.Join(tmpDir, "claude-config"),
+	}
+
+	repoName := "test-repo"
+	agentName := "happy-eagle"
+
+	commandsDir := paths.AgentCommandsDir(repoName, agentName)
+	expected := filepath.Join(tmpDir, "claude-config", repoName, agentName, "commands")
+	if commandsDir != expected {
+		t.Errorf("AgentCommandsDir() = %q, want %q", commandsDir, expected)
+	}
+
+	// Verify it builds on AgentClaudeConfigDir
+	configDir := paths.AgentClaudeConfigDir(repoName, agentName)
+	expectedFromConfig := filepath.Join(configDir, "commands")
+	if commandsDir != expectedFromConfig {
+		t.Errorf("AgentCommandsDir should be AgentClaudeConfigDir + 'commands'")
+	}
+}
+
+func TestNewTestPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	paths := NewTestPaths(tmpDir)
+
+	// Verify all paths are set correctly
+	if paths.Root != tmpDir {
+		t.Errorf("Root = %q, want %q", paths.Root, tmpDir)
+	}
+
+	expectedPaths := map[string]string{
+		"DaemonPID":       filepath.Join(tmpDir, "daemon.pid"),
+		"DaemonSock":      filepath.Join(tmpDir, "daemon.sock"),
+		"DaemonLog":       filepath.Join(tmpDir, "daemon.log"),
+		"StateFile":       filepath.Join(tmpDir, "state.json"),
+		"ReposDir":        filepath.Join(tmpDir, "repos"),
+		"WorktreesDir":    filepath.Join(tmpDir, "wts"),
+		"MessagesDir":     filepath.Join(tmpDir, "messages"),
+		"OutputDir":       filepath.Join(tmpDir, "output"),
+		"ClaudeConfigDir": filepath.Join(tmpDir, "claude-config"),
+	}
+
+	if paths.DaemonPID != expectedPaths["DaemonPID"] {
+		t.Errorf("DaemonPID = %q, want %q", paths.DaemonPID, expectedPaths["DaemonPID"])
+	}
+	if paths.DaemonSock != expectedPaths["DaemonSock"] {
+		t.Errorf("DaemonSock = %q, want %q", paths.DaemonSock, expectedPaths["DaemonSock"])
+	}
+	if paths.DaemonLog != expectedPaths["DaemonLog"] {
+		t.Errorf("DaemonLog = %q, want %q", paths.DaemonLog, expectedPaths["DaemonLog"])
+	}
+	if paths.StateFile != expectedPaths["StateFile"] {
+		t.Errorf("StateFile = %q, want %q", paths.StateFile, expectedPaths["StateFile"])
+	}
+	if paths.ReposDir != expectedPaths["ReposDir"] {
+		t.Errorf("ReposDir = %q, want %q", paths.ReposDir, expectedPaths["ReposDir"])
+	}
+	if paths.WorktreesDir != expectedPaths["WorktreesDir"] {
+		t.Errorf("WorktreesDir = %q, want %q", paths.WorktreesDir, expectedPaths["WorktreesDir"])
+	}
+	if paths.MessagesDir != expectedPaths["MessagesDir"] {
+		t.Errorf("MessagesDir = %q, want %q", paths.MessagesDir, expectedPaths["MessagesDir"])
+	}
+	if paths.OutputDir != expectedPaths["OutputDir"] {
+		t.Errorf("OutputDir = %q, want %q", paths.OutputDir, expectedPaths["OutputDir"])
+	}
+	if paths.ClaudeConfigDir != expectedPaths["ClaudeConfigDir"] {
+		t.Errorf("ClaudeConfigDir = %q, want %q", paths.ClaudeConfigDir, expectedPaths["ClaudeConfigDir"])
+	}
+
+	// Verify helper methods work correctly
+	repoDir := paths.RepoDir("test-repo")
+	if repoDir != filepath.Join(tmpDir, "repos", "test-repo") {
+		t.Errorf("RepoDir() on NewTestPaths result = %q, unexpected", repoDir)
+	}
+}

--- a/pkg/config/doc_test.go
+++ b/pkg/config/doc_test.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestDirectoryDocs(t *testing.T) {
+	docs := DirectoryDocs()
+
+	// Verify we have documentation entries
+	if len(docs) == 0 {
+		t.Fatal("DirectoryDocs() returned empty slice")
+	}
+
+	// Verify each doc has required fields
+	for i, doc := range docs {
+		if doc.Path == "" {
+			t.Errorf("DirectoryDocs()[%d].Path is empty", i)
+		}
+		if doc.Description == "" {
+			t.Errorf("DirectoryDocs()[%d].Description is empty for path %q", i, doc.Path)
+		}
+		if doc.Type != "file" && doc.Type != "directory" {
+			t.Errorf("DirectoryDocs()[%d].Type = %q, want 'file' or 'directory' for path %q", i, doc.Type, doc.Path)
+		}
+	}
+
+	// Verify key paths are documented
+	requiredPaths := []string{
+		"daemon.pid",
+		"daemon.sock",
+		"daemon.log",
+		"state.json",
+		"repos/",
+		"wts/",
+		"messages/",
+	}
+
+	pathSet := make(map[string]bool)
+	for _, doc := range docs {
+		pathSet[doc.Path] = true
+	}
+
+	for _, required := range requiredPaths {
+		if !pathSet[required] {
+			t.Errorf("DirectoryDocs() missing documentation for required path %q", required)
+		}
+	}
+}
+
+func TestStateDocs(t *testing.T) {
+	docs := StateDocs()
+
+	// Verify we have documentation entries
+	if len(docs) == 0 {
+		t.Fatal("StateDocs() returned empty slice")
+	}
+
+	// Verify each doc has required fields
+	for i, doc := range docs {
+		if doc.Field == "" {
+			t.Errorf("StateDocs()[%d].Field is empty", i)
+		}
+		if doc.Type == "" {
+			t.Errorf("StateDocs()[%d].Type is empty for field %q", i, doc.Field)
+		}
+		if doc.Description == "" {
+			t.Errorf("StateDocs()[%d].Description is empty for field %q", i, doc.Field)
+		}
+	}
+
+	// Verify key fields are documented
+	requiredFields := []string{
+		"repos",
+		"repos.<name>.github_url",
+		"repos.<name>.agents",
+	}
+
+	fieldSet := make(map[string]bool)
+	for _, doc := range docs {
+		fieldSet[doc.Field] = true
+	}
+
+	for _, required := range requiredFields {
+		if !fieldSet[required] {
+			t.Errorf("StateDocs() missing documentation for required field %q", required)
+		}
+	}
+}
+
+func TestMessageDocs(t *testing.T) {
+	docs := MessageDocs()
+
+	// Verify we have documentation entries
+	if len(docs) == 0 {
+		t.Fatal("MessageDocs() returned empty slice")
+	}
+
+	// Verify each doc has required fields
+	for i, doc := range docs {
+		if doc.Field == "" {
+			t.Errorf("MessageDocs()[%d].Field is empty", i)
+		}
+		if doc.Type == "" {
+			t.Errorf("MessageDocs()[%d].Type is empty for field %q", i, doc.Field)
+		}
+		if doc.Description == "" {
+			t.Errorf("MessageDocs()[%d].Description is empty for field %q", i, doc.Field)
+		}
+	}
+
+	// Verify key fields are documented
+	requiredFields := []string{
+		"id",
+		"from",
+		"to",
+		"timestamp",
+		"body",
+		"status",
+	}
+
+	fieldSet := make(map[string]bool)
+	for _, doc := range docs {
+		fieldSet[doc.Field] = true
+	}
+
+	for _, required := range requiredFields {
+		if !fieldSet[required] {
+			t.Errorf("MessageDocs() missing documentation for required field %q", required)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add comprehensive tests for previously uncovered code paths in `pkg/config`, `internal/format`, and `pkg/tmux`
- Improves overall test coverage:
  - `pkg/config`: 69.2% → 92.3% (+23.1%)
  - `internal/format`: 73.9% → 78.4% (+4.5%)
  - `pkg/tmux`: 70.7% → 75.0% (+4.3%)

## Test plan
- [x] All new tests pass locally
- [x] Full test suite runs without regressions (pre-existing `internal/cli` test failure not affected)
- [x] Coverage improvements verified with `go test -coverprofile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)