### PR TITLE
feat: Add GitHub CLI authentication verification

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -337,3 +337,50 @@ func UnknownCommand(cmd string) *CLIError {
 		Suggestion: "multiclaude --help",
 	}
 }
+
+// GitHubCLINotFound creates an error for when the gh CLI is not installed
+func GitHubCLINotFound() *CLIError {
+	return &CLIError{
+		Category:   CategoryConfig,
+		Message:    "GitHub CLI (gh) not found",
+		Suggestion: "install gh CLI: https://cli.github.com",
+	}
+}
+
+// GitHubNotAuthenticated creates an error for when the user is not authenticated with gh
+func GitHubNotAuthenticated() *CLIError {
+	return &CLIError{
+		Category:   CategoryConfig,
+		Message:    "not authenticated with GitHub CLI",
+		Suggestion: "gh auth login",
+	}
+}
+
+// GitHubAuthScopesMissing creates an error for when required scopes are not granted
+func GitHubAuthScopesMissing(missing []string) *CLIError {
+	scopeList := strings.Join(missing, ", ")
+	return &CLIError{
+		Category:   CategoryConfig,
+		Message:    fmt.Sprintf("missing required GitHub token scopes: %s", scopeList),
+		Suggestion: "gh auth refresh --scopes repo,read:org",
+	}
+}
+
+// GitHubRepoAccessDenied creates an error for when the user lacks repo permissions
+func GitHubRepoAccessDenied(owner, repo, requiredPerm string) *CLIError {
+	return &CLIError{
+		Category:   CategoryConfig,
+		Message:    fmt.Sprintf("insufficient permissions on %s/%s (need %s access)", owner, repo, requiredPerm),
+		Suggestion: "contact the repository admin to grant write access",
+	}
+}
+
+// GitHubAPIFailed creates an error for GitHub API failures
+func GitHubAPIFailed(operation string, cause error) *CLIError {
+	return &CLIError{
+		Category:   CategoryRuntime,
+		Message:    fmt.Sprintf("GitHub API call failed: %s", operation),
+		Cause:      cause,
+		Suggestion: "check your network connection and GitHub status",
+	}
+}

--- a/internal/github/auth.go
+++ b/internal/github/auth.go
@@ -1,0 +1,165 @@
+// Package github provides GitHub CLI authentication verification.
+package github
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+
+	"github.com/dlorenc/multiclaude/internal/errors"
+)
+
+// AuthStatus represents the result of an authentication check.
+type AuthStatus struct {
+	// Authenticated indicates whether the user is logged in to GitHub
+	Authenticated bool
+	// Username is the GitHub username if authenticated
+	Username string
+	// Scopes contains the OAuth scopes granted to the token
+	Scopes []string
+}
+
+// RepoPermissions represents the user's permissions on a repository.
+type RepoPermissions struct {
+	Admin    bool `json:"admin"`
+	Maintain bool `json:"maintain"`
+	Push     bool `json:"push"`
+	Pull     bool `json:"pull"`
+	Triage   bool `json:"triage"`
+}
+
+// requiredScopes lists the minimum OAuth scopes needed for multiclaude operations.
+var requiredScopes = []string{"repo"}
+
+// CheckAuth verifies that the GitHub CLI is installed and the user is authenticated.
+// Returns an AuthStatus with details, or an error if verification fails.
+func CheckAuth() (*AuthStatus, error) {
+	// Check if gh CLI is installed
+	if _, err := exec.LookPath("gh"); err != nil {
+		return nil, errors.GitHubCLINotFound()
+	}
+
+	// Run gh auth status to check authentication
+	cmd := exec.Command("gh", "auth", "status")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Exit code 1 means not authenticated
+		return nil, errors.GitHubNotAuthenticated()
+	}
+
+	// Parse the output to extract details
+	status := &AuthStatus{Authenticated: true}
+	outputStr := string(output)
+
+	// Extract username (looks for "Logged in to github.com account <username>")
+	for _, line := range strings.Split(outputStr, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "Logged in to") && strings.Contains(line, "account") {
+			parts := strings.Fields(line)
+			for i, p := range parts {
+				if p == "account" && i+1 < len(parts) {
+					// Remove any trailing characters like "(keyring)"
+					username := strings.TrimSuffix(parts[i+1], "(keyring)")
+					username = strings.TrimSuffix(username, "(environment)")
+					status.Username = strings.TrimSpace(username)
+					break
+				}
+			}
+		}
+
+		// Extract scopes (looks for "Token scopes: 'scope1', 'scope2'")
+		if strings.Contains(line, "Token scopes:") {
+			scopeStr := strings.TrimPrefix(line, "- Token scopes:")
+			scopeStr = strings.TrimSpace(scopeStr)
+			// Parse 'scope1', 'scope2' format
+			for _, s := range strings.Split(scopeStr, ",") {
+				s = strings.TrimSpace(s)
+				s = strings.Trim(s, "'\"")
+				if s != "" {
+					status.Scopes = append(status.Scopes, s)
+				}
+			}
+		}
+	}
+
+	return status, nil
+}
+
+// CheckRequiredScopes verifies that the current auth token has the required scopes.
+// Returns an error listing missing scopes if any are not present.
+func CheckRequiredScopes(status *AuthStatus) error {
+	if status == nil {
+		return errors.GitHubNotAuthenticated()
+	}
+
+	var missing []string
+	for _, required := range requiredScopes {
+		found := false
+		for _, scope := range status.Scopes {
+			if scope == required {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, required)
+		}
+	}
+
+	if len(missing) > 0 {
+		return errors.GitHubAuthScopesMissing(missing)
+	}
+
+	return nil
+}
+
+// CheckRepoPermissions checks the user's permissions on a specific repository.
+// Returns an error if the user lacks the required permission level.
+func CheckRepoPermissions(owner, repo string, requirePush bool) (*RepoPermissions, error) {
+	// Check if gh CLI is installed
+	if _, err := exec.LookPath("gh"); err != nil {
+		return nil, errors.GitHubCLINotFound()
+	}
+
+	// Use gh api to get repository permissions
+	cmd := exec.Command("gh", "api", "repos/"+owner+"/"+repo, "--jq", ".permissions")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.GitHubAPIFailed("get repo permissions", err)
+	}
+
+	var perms RepoPermissions
+	if err := json.Unmarshal(output, &perms); err != nil {
+		return nil, errors.GitHubAPIFailed("parse permissions response", err)
+	}
+
+	if requirePush && !perms.Push {
+		return &perms, errors.GitHubRepoAccessDenied(owner, repo, "push")
+	}
+
+	return &perms, nil
+}
+
+// VerifyAuthForRepo performs a complete authentication and permissions check
+// for operations on a specific repository. This is the main entry point for
+// pre-operation verification.
+func VerifyAuthForRepo(owner, repo string, requirePush bool) error {
+	// Step 1: Check basic auth
+	status, err := CheckAuth()
+	if err != nil {
+		return err
+	}
+
+	// Step 2: Check scopes
+	if err := CheckRequiredScopes(status); err != nil {
+		return err
+	}
+
+	// Step 3: Check repo permissions
+	_, err = CheckRepoPermissions(owner, repo, requirePush)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/github/auth_test.go
+++ b/internal/github/auth_test.go
@@ -1,0 +1,118 @@
+package github
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestCheckAuth_GHInstalled(t *testing.T) {
+	// Skip if gh is not installed
+	if _, err := exec.LookPath("gh"); err != nil {
+		t.Skip("gh CLI not installed, skipping auth tests")
+	}
+
+	// This test runs against the real gh CLI
+	// It verifies our parsing works with actual output
+	status, err := CheckAuth()
+	if err != nil {
+		// If not authenticated, that's fine - we're testing the code path
+		t.Logf("Not authenticated (expected in CI): %v", err)
+		return
+	}
+
+	// If we got here, we're authenticated
+	if !status.Authenticated {
+		t.Error("expected Authenticated to be true")
+	}
+}
+
+func TestCheckRequiredScopes_NilStatus(t *testing.T) {
+	err := CheckRequiredScopes(nil)
+	if err == nil {
+		t.Error("expected error for nil status")
+	}
+}
+
+func TestCheckRequiredScopes_MissingScopes(t *testing.T) {
+	status := &AuthStatus{
+		Authenticated: true,
+		Username:      "testuser",
+		Scopes:        []string{"gist"}, // Missing 'repo' scope
+	}
+
+	err := CheckRequiredScopes(status)
+	if err == nil {
+		t.Error("expected error for missing scopes")
+	}
+}
+
+func TestCheckRequiredScopes_HasRequiredScopes(t *testing.T) {
+	status := &AuthStatus{
+		Authenticated: true,
+		Username:      "testuser",
+		Scopes:        []string{"repo", "gist", "read:org"},
+	}
+
+	err := CheckRequiredScopes(status)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRepoPermissions_StructFields(t *testing.T) {
+	// Test that the struct can be instantiated correctly
+	perms := RepoPermissions{
+		Admin:    true,
+		Maintain: false,
+		Push:     true,
+		Pull:     true,
+		Triage:   false,
+	}
+
+	if !perms.Admin {
+		t.Error("expected Admin to be true")
+	}
+	if perms.Maintain {
+		t.Error("expected Maintain to be false")
+	}
+	if !perms.Push {
+		t.Error("expected Push to be true")
+	}
+	if !perms.Pull {
+		t.Error("expected Pull to be true")
+	}
+	if perms.Triage {
+		t.Error("expected Triage to be false")
+	}
+}
+
+func TestAuthStatus_StructFields(t *testing.T) {
+	status := AuthStatus{
+		Authenticated: true,
+		Username:      "testuser",
+		Scopes:        []string{"repo", "read:org"},
+	}
+
+	if !status.Authenticated {
+		t.Error("expected Authenticated to be true")
+	}
+	if status.Username != "testuser" {
+		t.Errorf("expected username 'testuser', got %s", status.Username)
+	}
+	if len(status.Scopes) != 2 {
+		t.Errorf("expected 2 scopes, got %d", len(status.Scopes))
+	}
+}
+
+func TestCheckRepoPermissions_InvalidRepo(t *testing.T) {
+	// Skip if gh is not installed
+	if _, err := exec.LookPath("gh"); err != nil {
+		t.Skip("gh CLI not installed, skipping")
+	}
+
+	// Test with a non-existent repo
+	_, err := CheckRepoPermissions("nonexistent-owner-xyz", "nonexistent-repo-xyz", false)
+	if err == nil {
+		t.Error("expected error for non-existent repo")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `multiclaude auth-check` command to verify GitHub CLI authentication and repository permissions
- Add `internal/github` package with auth verification logic
- Add 5 new error constructors in `internal/errors` for auth-related errors

This helps diagnose permission issues early, like the one currently blocking the merge queue.

## Changes

### New `internal/github` package
- `CheckAuth()` - verifies gh CLI is installed and user is authenticated
- `CheckRequiredScopes()` - ensures token has required OAuth scopes (e.g., `repo`)
- `CheckRepoPermissions()` - checks user's permissions on a specific repository
- `VerifyAuthForRepo()` - combines all checks for pre-operation verification

### New `auth-check` CLI command
```bash
# Check basic auth status
multiclaude auth-check

# Also check repo permissions
multiclaude auth-check owner/repo
```

Example output:
```
Checking GitHub CLI authentication...

  Authenticated: yes
  Username: example
  Token scopes: gist, read:org, repo
  Required scopes: present

Checking permissions on owner/repo...
  Pull: true
  Push: false
  Maintain: false
  Admin: false

Warning: You don't have push access to this repository.
Merge queue operations will fail without push permissions.
```

### New error constructors
- `GitHubCLINotFound()` - gh CLI not installed
- `GitHubNotAuthenticated()` - user not logged in
- `GitHubAuthScopesMissing()` - required OAuth scopes not granted
- `GitHubRepoAccessDenied()` - insufficient repo permissions
- `GitHubAPIFailed()` - GitHub API call failed

## Test plan
- [x] All 23 test packages pass
- [x] New tests for error constructors
- [x] New tests for github package
- [x] Manual testing of auth-check command

🤖 Generated with [Claude Code](https://claude.com/claude-code)