### PR TITLE
feat: Add full cleanup with NUKE confirmation to 'stop-all --clean'

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -219,6 +219,18 @@ func (s *State) ListRepos() []string {
 	return repos
 }
 
+// ClearAllAgents removes all agents from all repositories
+// but preserves the repository entries themselves
+func (s *State) ClearAllAgents() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, repo := range s.Repos {
+		repo.Agents = make(map[string]Agent)
+	}
+	return s.saveUnlocked()
+}
+
 // SetCurrentRepo sets the current/default repository
 func (s *State) SetCurrentRepo(name string) error {
 	s.mu.Lock()


### PR DESCRIPTION
## Summary

This PR modifies the approach from PR #175. Instead of adding a separate 'nuke' command, it enhances `stop-all --clean` to provide full cleanup functionality with safety confirmation:

- When `--clean` is passed, shows warning about what will be permanently deleted
- Requires typing 'NUKE' to confirm (can skip with `--yes` flag)
- Removes: worktrees, messages, output logs, agent configs, prompts
- Cleans up local branches (`work/*`, `multiclaude/*`)
- Clears agent state while preserving repository entries
- Removes daemon files (PID, socket, log)

**What's preserved:**
- Cloned repositories (`~/.multiclaude/repos/`)
- Git credentials

## Changes

- `internal/cli/cli.go`:
  - Added `bufio` import for stdin reading
  - Updated `stop-all` usage to include `--yes` flag
  - Enhanced `stopAll()` with full cleanup logic and NUKE confirmation
  - Added `listBranchesWithPrefix()` helper function
  - Added `deleteBranch()` helper function

- `internal/state/state.go`:
  - Added `ClearAllAgents()` method to clear agents while preserving repos

- `internal/state/state_test.go`:
  - Added `TestClearAllAgents` test

## Test plan

- [x] All existing tests pass
- [x] New `TestClearAllAgents` test passes
- [ ] Manual test: `multiclaude stop-all` (without --clean) works as before
- [ ] Manual test: `multiclaude stop-all --clean` shows warning and requires NUKE confirmation
- [ ] Manual test: `multiclaude stop-all --clean --yes` skips confirmation

## Supersedes

This PR supersedes PR #175 by integrating the cleanup functionality into the existing `stop-all --clean` workflow rather than adding a new command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)