### PR TITLE
docs: Add Operational Principles section to ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,16 @@ Key constraints:
 - **Simple**: Prefer deleting code over adding complexity
 - **Terminal-native**: No web dashboards, GUIs, or browser-based interfaces
 
+## Operational Principles
+
+These principles guide how multiclaude interacts with the user's environment:
+
+1. **Zero Repo Requirements**: Users can use multiclaude without adding anything to their repository. Repo-level customization via `.multiclaude/` is optional.
+
+2. **Self-Contained State**: All multiclaude state lives in `$HOME/.multiclaude/`. Never modify global Claude state (`~/.claude/`) or other global configs.
+
+3. **Optional Repo Config**: If users want repo-specific behavior, they can add a `.multiclaude/` directory to their repo.
+
 ## Current Phase: Stabilization
 
 Focus: Make the core experience rock-solid before adding features.


### PR DESCRIPTION
## Summary

- Adds a new "Operational Principles" section to ROADMAP.md with three key principles:
  1. **Zero Repo Requirements**: Users can use multiclaude without adding anything to their repo
  2. **Self-Contained State**: All state lives in `$HOME/.multiclaude/`, never modifying global Claude state
  3. **Optional Repo Config**: Repo-specific behavior via `.multiclaude/` directory is optional
- Section is placed after the Mission section and before the prioritized items (P0/P1/P2)

## Rationale

These principles ensure reviewer and merge-queue agents see them early when checking PRs for roadmap alignment. They clarify how multiclaude should interact with user environments:
- Don't require users to modify their repositories
- Keep all state self-contained in `$HOME/.multiclaude/`
- Don't touch global Claude configuration

## Test plan

- [x] Verify ROADMAP.md renders correctly with the new section
- [x] Confirm section placement is after Mission but before Current Phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)