### PR TITLE
fix: Remove duplicate GetSlashCommandsPrompt function declaration

### DIFF
--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -112,58 +112,12 @@ func GetPrompt(repoPath string, agentType AgentType, cliDocs string) (string, er
 		result += fmt.Sprintf("\n\n---\n\n%s", cliDocs)
 	}
 
-	// Add slash commands section
-	slashCommands := GetSlashCommandsPrompt()
-	if slashCommands != "" {
-		result += fmt.Sprintf("\n\n---\n\n%s", slashCommands)
-	}
-
 	// Add custom prompt if it exists
 	if customPrompt != "" {
 		result += fmt.Sprintf("\n\n---\n\nRepository-specific instructions:\n\n%s", customPrompt)
 	}
 
 	return result, nil
-}
-
-// GetSlashCommandsPrompt returns documentation for multiclaude slash commands
-// These are embedded in the prompt so agents can respond to /command requests
-func GetSlashCommandsPrompt() string {
-	return `## Multiclaude Slash Commands
-
-When the user types one of these commands, execute the corresponding actions:
-
-### /status - Show system status
-Run these commands and summarize the results:
-` + "```bash" + `
-multiclaude list              # Show tracked repos and agents
-git status                    # Show git status
-git log --oneline -5          # Show recent commits
-multiclaude agent list-messages  # Check for messages
-` + "```" + `
-
-### /refresh - Sync worktree with main branch
-` + "```bash" + `
-git fetch origin main
-git stash push -m "refresh-$(date +%s)" 2>/dev/null || true
-git rebase origin/main
-git stash pop 2>/dev/null || true
-` + "```" + `
-Report any conflicts if they occur.
-
-### /workers - List active workers
-` + "```bash" + `
-multiclaude work list
-` + "```" + `
-Show worker names, status, and current tasks.
-
-### /messages - Check inter-agent messages
-` + "```bash" + `
-multiclaude agent list-messages
-` + "```" + `
-If messages exist, offer to read or acknowledge them using:
-- ` + "`multiclaude agent read-message <id>`" + `
-- ` + "`multiclaude agent ack-message <id>`" + ``
 }
 
 // GenerateTrackingModePrompt generates prompt text explaining which PRs to track


### PR DESCRIPTION
## Summary
- Removed duplicate `GetSlashCommandsPrompt()` function that was declared twice in `internal/prompts/prompts.go`
- Kept the dynamic version (using `commands.AvailableCommands`) which is the correct architecture per the slash commands embedding design
- Also removed a redundant second call to `GetSlashCommandsPrompt()` in `GetPrompt()` that was adding slash commands twice to the prompt

## Context
This fixes the main branch CI failure caused by the compiler rejecting the duplicate function declaration.

The first version (removed) was a hardcoded inline version with specific bash commands.
The second version (kept) dynamically loads commands from the `internal/prompts/commands` package, which is the intended modular architecture.

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./internal/prompts/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)