### PR TITLE
fix: Remove duplicate GetSlashCommandsPrompt declaration

### DIFF
--- a/internal/prompts/commands/status.md
+++ b/internal/prompts/commands/status.md
@@ -6,27 +6,33 @@ Display the current multiclaude system status including agent information.
 
 Run the following commands and summarize the results:
 
-1. Check daemon status:
+1. List tracked repos and agents:
+   ```bash
+   multiclaude list
+   ```
+
+2. Check daemon status:
    ```bash
    multiclaude daemon status
    ```
 
-2. Show git status of the current worktree:
+3. Show git status of the current worktree:
    ```bash
    git status
    ```
 
-3. Show the current branch and recent commits:
+4. Show the current branch and recent commits:
    ```bash
    git log --oneline -5
    ```
 
-4. Check for any pending messages:
+5. Check for any pending messages:
    ```bash
    multiclaude agent list-messages
    ```
 
 Present the results in a clear, organized format with sections for:
+- Tracked repositories and agents
 - Daemon status
 - Current branch and git status
 - Recent commits

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -104,9 +104,6 @@ func GetPrompt(repoPath string, agentType AgentType, cliDocs string) (string, er
 	var result string
 	result = defaultPrompt
 
-	// Add slash commands documentation (embedded in prompt, not external files)
-	result += "\n\n" + GetSlashCommandsPrompt()
-
 	// Add CLI documentation
 	if cliDocs != "" {
 		result += fmt.Sprintf("\n\n---\n\n%s", cliDocs)
@@ -124,46 +121,6 @@ func GetPrompt(repoPath string, agentType AgentType, cliDocs string) (string, er
 	}
 
 	return result, nil
-}
-
-// GetSlashCommandsPrompt returns documentation for multiclaude slash commands
-// These are embedded in the prompt so agents can respond to /command requests
-func GetSlashCommandsPrompt() string {
-	return `## Multiclaude Slash Commands
-
-When the user types one of these commands, execute the corresponding actions:
-
-### /status - Show system status
-Run these commands and summarize the results:
-` + "```bash" + `
-multiclaude list              # Show tracked repos and agents
-git status                    # Show git status
-git log --oneline -5          # Show recent commits
-multiclaude agent list-messages  # Check for messages
-` + "```" + `
-
-### /refresh - Sync worktree with main branch
-` + "```bash" + `
-git fetch origin main
-git stash push -m "refresh-$(date +%s)" 2>/dev/null || true
-git rebase origin/main
-git stash pop 2>/dev/null || true
-` + "```" + `
-Report any conflicts if they occur.
-
-### /workers - List active workers
-` + "```bash" + `
-multiclaude work list
-` + "```" + `
-Show worker names, status, and current tasks.
-
-### /messages - Check inter-agent messages
-` + "```bash" + `
-multiclaude agent list-messages
-` + "```" + `
-If messages exist, offer to read or acknowledge them using:
-- ` + "`multiclaude agent read-message <id>`" + `
-- ` + "`multiclaude agent ack-message <id>`" + ``
 }
 
 // GenerateTrackingModePrompt generates prompt text explaining which PRs to track


### PR DESCRIPTION
## Summary
- Fixed critical CI failure caused by duplicate `GetSlashCommandsPrompt` function declarations in `internal/prompts/prompts.go`
- Removed the first hardcoded implementation (lines 131-167) and kept the dynamic implementation (lines 214-230) that loads from the commands package
- Fixed duplicate call to `GetSlashCommandsPrompt()` in the `GetPrompt()` function
- Updated `internal/prompts/commands/status.md` to include both `multiclaude list` and `multiclaude daemon status` commands to satisfy all test expectations

## Changes
1. **internal/prompts/prompts.go**: Removed duplicate function declaration and redundant function call
2. **internal/prompts/commands/status.md**: Added `multiclaude list` command back to /status documentation

## Test Results
✅ All tests passing:
- `go test ./...` - All packages pass
- `go build ./cmd/multiclaude` - Builds successfully
- `internal/prompts` tests pass
- `test/recovery_test.go::TestSlashCommandsEmbeddedInPrompts` passes

## Resolution
The duplicate declaration was causing a compilation error. The fix:
1. Kept the dynamic implementation that uses the commands package (more maintainable)
2. Removed the hardcoded implementation
3. Ensured all test expectations are met by updating status.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)