### PR TITLE
feat: Link global credentials to agent CLAUDE_CONFIG_DIR

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -4774,6 +4774,11 @@ func (c *CLI) startClaudeInTmux(binaryPath, tmuxSession, tmuxWindow, workDir, se
 		fmt.Printf("Warning: failed to setup agent commands: %v\n", err)
 	}
 
+	// Link global credentials to agent config directory
+	if err := commands.LinkGlobalCredentials(agentConfigDir); err != nil {
+		fmt.Printf("Warning: failed to link credentials: %v\n", err)
+	}
+
 	// Build Claude command using the full path to prevent version drift
 	// Set CLAUDE_CONFIG_DIR to inject per-agent slash commands
 	claudeCmd := fmt.Sprintf("CLAUDE_CONFIG_DIR=%s %s --session-id %s --dangerously-skip-permissions", agentConfigDir, binaryPath, sessionID)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1870,6 +1870,11 @@ func (d *Daemon) restartAgent(repoName, agentName string, agent state.Agent, rep
 		d.logger.Warn("Failed to setup agent commands: %v", err)
 	}
 
+	// Link global credentials to agent config directory
+	if err := commands.LinkGlobalCredentials(agentConfigDir); err != nil {
+		d.logger.Warn("Failed to link credentials: %v", err)
+	}
+
 	// Restart Claude using the runner
 	result, err := d.claudeRunner.Start(d.ctx, repo.TmuxSession, agentName, claude.Config{
 		SessionID:        agent.SessionID,


### PR DESCRIPTION
## Summary

- Fix authentication prompts appearing on every multiclaude session
- Add `LinkGlobalCredentials()` function to symlink `~/.claude/.credentials.json` into each agent's config directory
- Automatically link credentials when agents start (both via CLI and daemon)

## Problem

When `CLAUDE_CONFIG_DIR` is set, Claude Code looks for credentials in that directory instead of `~/.claude/`. Multiclaude sets a per-agent `CLAUDE_CONFIG_DIR` to provide custom slash commands (`/refresh`, `/status`, etc.), but this caused Claude to not find the user's OAuth credentials, resulting in re-authentication prompts on every session.

## Solution

Symlink the global credentials file into each agent's config directory:

```
~/.multiclaude/claude-config/<repo>/<agent>/.credentials.json -> ~/.claude/.credentials.json
```

This allows agents to:
1. Keep their custom slash commands via `CLAUDE_CONFIG_DIR`
2. Reuse the user's existing OAuth credentials without duplication

## Verification

After the fix, all agent config directories have the credentials symlink:

```
$ ls -la ~/.multiclaude/claude-config/repo/*/.credentials.json
lrwxrwxrwx 1 user user 37 Jan 21 22:45 default/.credentials.json -> /home/user/.claude/.credentials.json
lrwxrwxrwx 1 user user 37 Jan 21 22:45 eager-bear/.credentials.json -> /home/user/.claude/.credentials.json
lrwxrwxrwx 1 user user 37 Jan 21 22:45 merge-queue/.credentials.json -> /home/user/.claude/.credentials.json
lrwxrwxrwx 1 user user 37 Jan 21 22:45 supervisor/.credentials.json -> /home/user/.claude/.credentials.json
lrwxrwxrwx 1 user user 37 Jan 21 22:45 witty-rabbit/.credentials.json -> /home/user/.claude/.credentials.json
```

## Test plan

- [x] Unit tests for `LinkGlobalCredentials()` covering:
  - Basic symlink creation
  - No-op when global credentials don't exist (API key users)
  - Idempotent behavior (safe to call multiple times)
  - Replaces invalid symlinks
  - Replaces regular files with symlinks
- [x] All existing tests pass
- [x] Manual verification: agents no longer prompt for re-authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)