### PR TITLE
ci: Add gofmt check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,31 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+  gofmt-check:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Check gofmt
+        run: |
+          unformatted=$(gofmt -s -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files need formatting:"
+            echo "$unformatted"
+            echo ""
+            echo "Run 'gofmt -s -w .' to fix formatting."
+            exit 1
+          fi
+          echo "All files are properly formatted."
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/internal/cli/selector_test.go
+++ b/internal/cli/selector_test.go
@@ -363,8 +363,8 @@ func TestFormatAgentStatusCell(t *testing.T) {
 		{"completed", "completed"},
 		{"stopped", "stopped"},
 		{"idle", "idle"},
-		{"", "idle"},            // Default case
-		{"unknown", "idle"},    // Unknown status defaults to idle
+		{"", "idle"},        // Default case
+		{"unknown", "idle"}, // Unknown status defaults to idle
 	}
 
 	for _, tt := range tests {

--- a/internal/daemon/handlers_test.go
+++ b/internal/daemon/handlers_test.go
@@ -1228,8 +1228,8 @@ func TestHandleSetCurrentRepo(t *testing.T) {
 		wantError   string
 	}{
 		{
-			name: "missing name",
-			args: map[string]interface{}{},
+			name:        "missing name",
+			args:        map[string]interface{}{},
 			wantSuccess: false,
 			wantError:   "missing 'name'",
 		},

--- a/pkg/claude/runner_test.go
+++ b/pkg/claude/runner_test.go
@@ -372,7 +372,7 @@ func TestStartContextCancellation(t *testing.T) {
 
 	runner := NewRunner(
 		WithTerminal(terminal),
-		WithStartupDelay(100 * time.Millisecond),
+		WithStartupDelay(100*time.Millisecond),
 	)
 
 	// Create a context that will be cancelled


### PR DESCRIPTION
## Summary

- Add a new `gofmt-check` CI job that runs `gofmt -s -l .` and fails if any Go files need formatting
- Fix formatting in 3 existing test files that had minor whitespace alignment issues
- Provides clear error message showing which files need formatting and how to fix them

## Changes

**New CI job (`gofmt-check`):**
- Runs `gofmt -s -l .` to check all Go files
- Uses `-s` flag to apply simplification rules
- Fails with helpful message if any files need formatting

**Formatting fixes:**
- `internal/cli/selector_test.go`: Align struct field comments
- `internal/daemon/handlers_test.go`: Align struct field values  
- `pkg/claude/runner_test.go`: Remove space in duration expression

## Test plan

- [ ] CI job passes on this PR (validates the check works)
- [ ] Intentionally commit poorly formatted Go code to verify the check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)