### PR TITLE
feat: Add agent definition infrastructure for issue #233

### DIFF
--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -1,0 +1,229 @@
+// Package agents provides infrastructure for reading and managing
+// configurable agent definitions from markdown files.
+package agents
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Definition represents a parsed agent definition from a markdown file.
+type Definition struct {
+	// Name is the agent name, derived from the filename (without .md extension)
+	Name string
+
+	// Content is the full markdown content of the agent definition
+	Content string
+
+	// SourcePath is the absolute path to the source file
+	SourcePath string
+
+	// Source indicates where this definition came from
+	Source DefinitionSource
+}
+
+// DefinitionSource indicates the origin of an agent definition
+type DefinitionSource string
+
+const (
+	// SourceLocal indicates the definition came from ~/.multiclaude/repos/<repo>/agents/
+	SourceLocal DefinitionSource = "local"
+
+	// SourceRepo indicates the definition came from <repo>/.multiclaude/agents/
+	SourceRepo DefinitionSource = "repo"
+)
+
+// Reader reads agent definitions from the filesystem.
+type Reader struct {
+	// localAgentsDir is ~/.multiclaude/repos/<repo>/agents/
+	localAgentsDir string
+
+	// repoAgentsDir is <repo>/.multiclaude/agents/
+	repoAgentsDir string
+}
+
+// NewReader creates a new agent definition reader.
+// localAgentsDir is the path to ~/.multiclaude/repos/<repo>/agents/
+// repoPath is the path to the cloned repository (will look for .multiclaude/agents/ inside)
+func NewReader(localAgentsDir, repoPath string) *Reader {
+	repoAgentsDir := ""
+	if repoPath != "" {
+		repoAgentsDir = filepath.Join(repoPath, ".multiclaude", "agents")
+	}
+
+	return &Reader{
+		localAgentsDir: localAgentsDir,
+		repoAgentsDir:  repoAgentsDir,
+	}
+}
+
+// ReadLocalDefinitions reads agent definitions from ~/.multiclaude/repos/<repo>/agents/*.md
+func (r *Reader) ReadLocalDefinitions() ([]Definition, error) {
+	return readDefinitionsFromDir(r.localAgentsDir, SourceLocal)
+}
+
+// ReadRepoDefinitions reads agent definitions from <repo>/.multiclaude/agents/*.md
+// Returns an empty slice (not an error) if the directory doesn't exist.
+func (r *Reader) ReadRepoDefinitions() ([]Definition, error) {
+	if r.repoAgentsDir == "" {
+		return nil, nil
+	}
+	return readDefinitionsFromDir(r.repoAgentsDir, SourceRepo)
+}
+
+// ReadAllDefinitions reads and merges definitions from both local and repo directories.
+// Checked-in repo definitions win over local definitions on filename conflict.
+// Returns definitions sorted alphabetically by name.
+func (r *Reader) ReadAllDefinitions() ([]Definition, error) {
+	localDefs, err := r.ReadLocalDefinitions()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read local definitions: %w", err)
+	}
+
+	repoDefs, err := r.ReadRepoDefinitions()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read repo definitions: %w", err)
+	}
+
+	return MergeDefinitions(localDefs, repoDefs), nil
+}
+
+// MergeDefinitions merges local and repo definitions.
+// Repo definitions take precedence over local definitions on filename conflict.
+func MergeDefinitions(local, repo []Definition) []Definition {
+	// Build a map with local definitions first
+	merged := make(map[string]Definition, len(local)+len(repo))
+
+	for _, def := range local {
+		merged[def.Name] = def
+	}
+
+	// Repo definitions overwrite local ones
+	for _, def := range repo {
+		merged[def.Name] = def
+	}
+
+	// Convert to sorted slice
+	result := make([]Definition, 0, len(merged))
+	for _, def := range merged {
+		result = append(result, def)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result
+}
+
+// readDefinitionsFromDir reads all .md files from a directory and returns them as definitions.
+// Returns an empty slice (not an error) if the directory doesn't exist.
+func readDefinitionsFromDir(dir string, source DefinitionSource) ([]Definition, error) {
+	if dir == "" {
+		return nil, nil
+	}
+
+	// Check if directory exists
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to stat directory %s: %w", dir, err)
+	}
+
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", dir)
+	}
+
+	// Read directory entries
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %s: %w", dir, err)
+	}
+
+	var definitions []Definition
+
+	for _, entry := range entries {
+		// Skip directories and non-.md files
+		if entry.IsDir() {
+			continue
+		}
+
+		if !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		// Read file content
+		filePath := filepath.Join(dir, entry.Name())
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
+		}
+
+		// Extract name from filename (without .md extension)
+		name := strings.TrimSuffix(entry.Name(), ".md")
+
+		definitions = append(definitions, Definition{
+			Name:       name,
+			Content:    string(content),
+			SourcePath: filePath,
+			Source:     source,
+		})
+	}
+
+	return definitions, nil
+}
+
+// ParseTitle extracts the title from a markdown definition.
+// It looks for the first H1 heading (# Title) in the content.
+// Returns the name as-is if no H1 heading is found.
+func (d *Definition) ParseTitle() string {
+	lines := strings.Split(d.Content, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "# ") {
+			return strings.TrimPrefix(line, "# ")
+		}
+	}
+	return d.Name
+}
+
+// ParseDescription extracts the first paragraph after the title as a description.
+// Returns an empty string if no description is found.
+func (d *Definition) ParseDescription() string {
+	lines := strings.Split(d.Content, "\n")
+	foundTitle := false
+	var descLines []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Skip until we find the title
+		if strings.HasPrefix(trimmed, "# ") {
+			foundTitle = true
+			continue
+		}
+
+		if !foundTitle {
+			continue
+		}
+
+		// Skip empty lines before the description starts
+		if len(descLines) == 0 && trimmed == "" {
+			continue
+		}
+
+		// Stop at the next heading or empty line after content
+		if strings.HasPrefix(trimmed, "#") || (len(descLines) > 0 && trimmed == "") {
+			break
+		}
+
+		descLines = append(descLines, trimmed)
+	}
+
+	return strings.Join(descLines, " ")
+}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -1,0 +1,371 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadLocalDefinitions(t *testing.T) {
+	// Create temp directory structure
+	tmpDir, err := os.MkdirTemp("", "agents-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	localAgentsDir := filepath.Join(tmpDir, "local", "agents")
+	if err := os.MkdirAll(localAgentsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test agent definitions
+	workerContent := `# Worker Agent
+
+A task-based worker that completes assigned work.
+
+## Your Role
+
+Complete the assigned task.
+`
+	if err := os.WriteFile(filepath.Join(localAgentsDir, "worker.md"), []byte(workerContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reviewerContent := `# Code Reviewer
+
+Reviews pull requests.
+`
+	if err := os.WriteFile(filepath.Join(localAgentsDir, "reviewer.md"), []byte(reviewerContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a non-.md file that should be ignored
+	if err := os.WriteFile(filepath.Join(localAgentsDir, "readme.txt"), []byte("ignore me"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := NewReader(localAgentsDir, "")
+	defs, err := reader.ReadLocalDefinitions()
+	if err != nil {
+		t.Fatalf("ReadLocalDefinitions failed: %v", err)
+	}
+
+	if len(defs) != 2 {
+		t.Fatalf("expected 2 definitions, got %d", len(defs))
+	}
+
+	// Check that we got the expected definitions
+	defMap := make(map[string]Definition)
+	for _, def := range defs {
+		defMap[def.Name] = def
+	}
+
+	worker, ok := defMap["worker"]
+	if !ok {
+		t.Fatal("worker definition not found")
+	}
+	if worker.Source != SourceLocal {
+		t.Errorf("expected source local, got %s", worker.Source)
+	}
+	if worker.Content != workerContent {
+		t.Error("worker content mismatch")
+	}
+
+	reviewer, ok := defMap["reviewer"]
+	if !ok {
+		t.Fatal("reviewer definition not found")
+	}
+	if reviewer.Source != SourceLocal {
+		t.Errorf("expected source local, got %s", reviewer.Source)
+	}
+}
+
+func TestReadRepoDefinitions(t *testing.T) {
+	// Create temp directory structure
+	tmpDir, err := os.MkdirTemp("", "agents-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	repoPath := filepath.Join(tmpDir, "repo")
+	repoAgentsDir := filepath.Join(repoPath, ".multiclaude", "agents")
+	if err := os.MkdirAll(repoAgentsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a checked-in agent definition
+	customContent := `# Custom Bot
+
+A team-specific automation bot.
+`
+	if err := os.WriteFile(filepath.Join(repoAgentsDir, "custom-bot.md"), []byte(customContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := NewReader("", repoPath)
+	defs, err := reader.ReadRepoDefinitions()
+	if err != nil {
+		t.Fatalf("ReadRepoDefinitions failed: %v", err)
+	}
+
+	if len(defs) != 1 {
+		t.Fatalf("expected 1 definition, got %d", len(defs))
+	}
+
+	if defs[0].Name != "custom-bot" {
+		t.Errorf("expected name custom-bot, got %s", defs[0].Name)
+	}
+	if defs[0].Source != SourceRepo {
+		t.Errorf("expected source repo, got %s", defs[0].Source)
+	}
+}
+
+func TestReadRepoDefinitionsNonExistent(t *testing.T) {
+	// When the repo agents directory doesn't exist, should return empty slice, not error
+	tmpDir, err := os.MkdirTemp("", "agents-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	reader := NewReader("", tmpDir)
+	defs, err := reader.ReadRepoDefinitions()
+	if err != nil {
+		t.Fatalf("ReadRepoDefinitions should not fail for non-existent directory: %v", err)
+	}
+
+	if len(defs) != 0 {
+		t.Fatalf("expected 0 definitions, got %d", len(defs))
+	}
+}
+
+func TestMergeDefinitions(t *testing.T) {
+	local := []Definition{
+		{Name: "worker", Content: "local worker", Source: SourceLocal},
+		{Name: "reviewer", Content: "local reviewer", Source: SourceLocal},
+		{Name: "local-only", Content: "only in local", Source: SourceLocal},
+	}
+
+	repo := []Definition{
+		{Name: "worker", Content: "repo worker", Source: SourceRepo},
+		{Name: "repo-only", Content: "only in repo", Source: SourceRepo},
+	}
+
+	merged := MergeDefinitions(local, repo)
+
+	if len(merged) != 4 {
+		t.Fatalf("expected 4 definitions, got %d", len(merged))
+	}
+
+	// Convert to map for easier checking
+	defMap := make(map[string]Definition)
+	for _, def := range merged {
+		defMap[def.Name] = def
+	}
+
+	// Check that repo definition wins for worker
+	worker, ok := defMap["worker"]
+	if !ok {
+		t.Fatal("worker not found in merged")
+	}
+	if worker.Content != "repo worker" {
+		t.Errorf("expected repo worker content, got %s", worker.Content)
+	}
+	if worker.Source != SourceRepo {
+		t.Errorf("expected source repo, got %s", worker.Source)
+	}
+
+	// Check that local-only definition is preserved
+	localOnly, ok := defMap["local-only"]
+	if !ok {
+		t.Fatal("local-only not found in merged")
+	}
+	if localOnly.Source != SourceLocal {
+		t.Errorf("expected source local, got %s", localOnly.Source)
+	}
+
+	// Check that repo-only definition is included
+	repoOnly, ok := defMap["repo-only"]
+	if !ok {
+		t.Fatal("repo-only not found in merged")
+	}
+	if repoOnly.Source != SourceRepo {
+		t.Errorf("expected source repo, got %s", repoOnly.Source)
+	}
+
+	// Check that reviewer is preserved from local
+	reviewer, ok := defMap["reviewer"]
+	if !ok {
+		t.Fatal("reviewer not found in merged")
+	}
+	if reviewer.Source != SourceLocal {
+		t.Errorf("expected source local, got %s", reviewer.Source)
+	}
+}
+
+func TestReadAllDefinitions(t *testing.T) {
+	// Create temp directory structure
+	tmpDir, err := os.MkdirTemp("", "agents-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	localAgentsDir := filepath.Join(tmpDir, "local", "agents")
+	if err := os.MkdirAll(localAgentsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	repoPath := filepath.Join(tmpDir, "repo")
+	repoAgentsDir := filepath.Join(repoPath, ".multiclaude", "agents")
+	if err := os.MkdirAll(repoAgentsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Local worker
+	if err := os.WriteFile(filepath.Join(localAgentsDir, "worker.md"), []byte("local worker"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Local reviewer
+	if err := os.WriteFile(filepath.Join(localAgentsDir, "reviewer.md"), []byte("local reviewer"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Repo worker (should win)
+	if err := os.WriteFile(filepath.Join(repoAgentsDir, "worker.md"), []byte("repo worker"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Repo custom-bot (unique)
+	if err := os.WriteFile(filepath.Join(repoAgentsDir, "custom-bot.md"), []byte("repo custom"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := NewReader(localAgentsDir, repoPath)
+	defs, err := reader.ReadAllDefinitions()
+	if err != nil {
+		t.Fatalf("ReadAllDefinitions failed: %v", err)
+	}
+
+	if len(defs) != 3 {
+		t.Fatalf("expected 3 definitions, got %d", len(defs))
+	}
+
+	// Verify sorted order
+	expectedOrder := []string{"custom-bot", "reviewer", "worker"}
+	for i, def := range defs {
+		if def.Name != expectedOrder[i] {
+			t.Errorf("expected %s at position %d, got %s", expectedOrder[i], i, def.Name)
+		}
+	}
+
+	// Verify worker is from repo
+	for _, def := range defs {
+		if def.Name == "worker" && def.Source != SourceRepo {
+			t.Errorf("expected worker to be from repo, got %s", def.Source)
+		}
+	}
+}
+
+func TestParseTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "with title",
+			content:  "# Worker Agent\n\nSome description",
+			expected: "Worker Agent",
+		},
+		{
+			name:     "with leading whitespace",
+			content:  "  \n# Worker Agent\n\nSome description",
+			expected: "Worker Agent",
+		},
+		{
+			name:     "no title",
+			content:  "Some content without title",
+			expected: "fallback",
+		},
+		{
+			name:     "h2 only",
+			content:  "## Section\n\nContent",
+			expected: "fallback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := Definition{Name: "fallback", Content: tt.content}
+			title := def.ParseTitle()
+			if title != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, title)
+			}
+		})
+	}
+}
+
+func TestParseDescription(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "simple description",
+			content:  "# Worker Agent\n\nA task-based worker.\n\n## Section",
+			expected: "A task-based worker.",
+		},
+		{
+			name:     "multi-line description",
+			content:  "# Worker Agent\n\nFirst line of description.\nSecond line.\n\n## Section",
+			expected: "First line of description. Second line.",
+		},
+		{
+			name:     "no description",
+			content:  "# Worker Agent\n\n## Section",
+			expected: "",
+		},
+		{
+			name:     "description with no following section",
+			content:  "# Worker Agent\n\nJust a description.",
+			expected: "Just a description.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := Definition{Content: tt.content}
+			desc := def.ParseDescription()
+			if desc != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, desc)
+			}
+		})
+	}
+}
+
+func TestEmptyLocalDir(t *testing.T) {
+	reader := NewReader("", "")
+	defs, err := reader.ReadLocalDefinitions()
+	if err != nil {
+		t.Fatalf("ReadLocalDefinitions should not fail for empty path: %v", err)
+	}
+	if len(defs) != 0 {
+		t.Fatalf("expected 0 definitions, got %d", len(defs))
+	}
+}
+
+func TestEmptyRepoPath(t *testing.T) {
+	reader := NewReader("", "")
+	defs, err := reader.ReadRepoDefinitions()
+	if err != nil {
+		t.Fatalf("ReadRepoDefinitions should not fail for empty path: %v", err)
+	}
+	if len(defs) != 0 {
+		t.Fatalf("expected 0 definitions, got %d", len(defs))
+	}
+}


### PR DESCRIPTION
## Summary

- Add new `internal/agents` package with infrastructure to read/parse agent definitions from markdown files
- Add `multiclaude agents list` command to display available agent definitions for a repository
- Implement resolution order where checked-in repo definitions win over local on filename conflict

## Changes

### New Package: `internal/agents`

- `Reader` struct to read agent definitions from:
  - `~/.multiclaude/repos/<repo>/agents/*.md` (local user definitions)
  - `<repo>/.multiclaude/agents/*.md` (checked-in team definitions)
- `Definition` struct representing a parsed agent definition with:
  - Name (derived from filename)
  - Content (full markdown content)
  - SourcePath and Source (local vs repo)
- `MergeDefinitions()` function implementing the resolution order
- `ParseTitle()` and `ParseDescription()` helpers to extract metadata from markdown

### New CLI Command: `multiclaude agents list`

Lists available agent definitions for a repository, showing:
- Name
- Source (local or repo, with repo highlighted in green)
- Title (from H1 heading in markdown)
- Description (first paragraph after title)

### Tests

- Comprehensive unit tests for the agents package
- CLI test for the agents list command

## Related Issue

Part of #233 (PR 2 of 3)

This PR implements the infrastructure layer. Future PRs will:
- Update daemon to read definitions and send to supervisor (PR 3)

## Test Plan

- [x] Run `go test ./...` - all tests pass
- [x] Run `go build ./cmd/multiclaude` - builds successfully
- [x] Run `gofmt -l ./internal/agents/` - no formatting issues
- [x] Test `multiclaude agents list --help` - shows correct usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)