### PR TITLE
feat: Add supervisor orchestration for agent definitions (issue #233 PR 3)

### DIFF
--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -227,3 +227,53 @@ func (d *Definition) ParseDescription() string {
 
 	return strings.Join(descLines, " ")
 }
+
+// AgentClass represents whether an agent is persistent or ephemeral
+type AgentClass string
+
+const (
+	// ClassPersistent indicates an agent that auto-restarts on crash and is long-lived
+	ClassPersistent AgentClass = "persistent"
+
+	// ClassEphemeral indicates a task-based agent that cleans up on completion
+	ClassEphemeral AgentClass = "ephemeral"
+)
+
+// ParseClass determines the agent class (persistent or ephemeral) from the markdown content.
+// It looks for keywords like "persistent" or "ephemeral" in the description.
+// Defaults to ephemeral if not specified.
+func (d *Definition) ParseClass() AgentClass {
+	content := strings.ToLower(d.Content)
+
+	// Check for explicit class indicators
+	if strings.Contains(content, "persistent agent") ||
+		strings.Contains(content, "long-lived") ||
+		strings.Contains(content, "auto-restart") {
+		return ClassPersistent
+	}
+
+	if strings.Contains(content, "ephemeral agent") ||
+		strings.Contains(content, "task-based") ||
+		strings.Contains(content, "clean up on completion") {
+		return ClassEphemeral
+	}
+
+	// Default to ephemeral for safety (workers, reviewers, etc.)
+	return ClassEphemeral
+}
+
+// ParseSpawnOnInit determines if the agent should be spawned when the repository is initialized.
+// It looks for keywords indicating the agent should start automatically.
+func (d *Definition) ParseSpawnOnInit() bool {
+	content := strings.ToLower(d.Content)
+
+	// Check for indicators that agent should spawn on init
+	if strings.Contains(content, "spawn this agent when the repository is initialized") ||
+		strings.Contains(content, "spawn on init") ||
+		strings.Contains(content, "start on init") ||
+		strings.Contains(content, "always running") {
+		return true
+	}
+
+	return false
+}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -369,3 +369,116 @@ func TestEmptyRepoPath(t *testing.T) {
 		t.Fatalf("expected 0 definitions, got %d", len(defs))
 	}
 }
+
+func TestParseClass(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected AgentClass
+	}{
+		{
+			name:     "persistent agent keyword",
+			content:  "# Merge Queue\n\nA persistent agent that monitors PRs.",
+			expected: ClassPersistent,
+		},
+		{
+			name:     "long-lived keyword",
+			content:  "# Triage Bot\n\nA long-lived bot for handling issues.",
+			expected: ClassPersistent,
+		},
+		{
+			name:     "auto-restart keyword",
+			content:  "# Monitor\n\nThis agent should auto-restart on crash.",
+			expected: ClassPersistent,
+		},
+		{
+			name:     "ephemeral agent keyword",
+			content:  "# Worker\n\nAn ephemeral agent that completes tasks.",
+			expected: ClassEphemeral,
+		},
+		{
+			name:     "task-based keyword",
+			content:  "# Reviewer\n\nA task-based agent for code review.",
+			expected: ClassEphemeral,
+		},
+		{
+			name:     "clean up on completion",
+			content:  "# Worker\n\nThis agent should clean up on completion.",
+			expected: ClassEphemeral,
+		},
+		{
+			name:     "no keywords defaults to ephemeral",
+			content:  "# Generic Agent\n\nDoes some work.",
+			expected: ClassEphemeral,
+		},
+		{
+			name:     "case insensitive",
+			content:  "# Bot\n\nA PERSISTENT AGENT for monitoring.",
+			expected: ClassPersistent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := Definition{Content: tt.content}
+			class := def.ParseClass()
+			if class != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, class)
+			}
+		})
+	}
+}
+
+func TestParseSpawnOnInit(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "spawn when repository initialized",
+			content:  "# Merge Queue\n\nSpawn this agent when the repository is initialized.",
+			expected: true,
+		},
+		{
+			name:     "spawn on init",
+			content:  "# Monitor\n\nThis agent should spawn on init.",
+			expected: true,
+		},
+		{
+			name:     "start on init",
+			content:  "# Bot\n\nStart on init to begin monitoring.",
+			expected: true,
+		},
+		{
+			name:     "always running",
+			content:  "# Watcher\n\nThis agent is always running.",
+			expected: true,
+		},
+		{
+			name:     "no spawn on init",
+			content:  "# Worker\n\nSpawned when a task is assigned.",
+			expected: false,
+		},
+		{
+			name:     "default to false",
+			content:  "# Generic\n\nNo special instructions.",
+			expected: false,
+		},
+		{
+			name:     "case insensitive",
+			content:  "# Bot\n\nSPAWN ON INIT for immediate monitoring.",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := Definition{Content: tt.content}
+			spawnOnInit := def.ParseSpawnOnInit()
+			if spawnOnInit != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, spawnOnInit)
+			}
+		})
+	}
+}

--- a/internal/prompts/supervisor.md
+++ b/internal/prompts/supervisor.md
@@ -16,6 +16,56 @@ If someone (human or agent) proposes work that conflicts with the roadmap:
 
 The roadmap is the "direction gate" - the Brownian Ratchet ensures quality, the roadmap ensures direction.
 
+## Agent Orchestration (IMPORTANT)
+
+**You are the orchestrator.** The daemon sends you agent definitions on startup, and you decide which agents to spawn.
+
+### Receiving Agent Definitions
+
+When the daemon starts or restores this repository, you will receive a message containing available agent definitions. Each definition includes:
+
+- **Name**: The agent identifier (from the filename)
+- **Title**: Human-readable name (from the markdown heading)
+- **Class**: `persistent` (long-lived, auto-restart) or `ephemeral` (task-based, cleanup on completion)
+- **Spawn on init**: Whether this agent should start automatically
+- **Full prompt content**: The system prompt for the agent
+
+### Interpreting Definitions
+
+When you receive agent definitions, analyze each one:
+
+1. **Class determination**: Look for keywords like "persistent agent", "long-lived", "ephemeral", "task-based"
+2. **Spawn conditions**: Look for phrases like "spawn on init", "start when repository is initialized"
+3. **Purpose**: Understand what the agent does from its description and workflow sections
+
+### Spawning Agents
+
+To spawn an agent, the daemon provides a `spawn_agent` socket command. However, since you're in a Claude session, you can request the daemon to spawn agents by sending yourself a reminder or by using available tools.
+
+For now, the practical approach is:
+- Agents marked "Spawn on init: true" should be spawned by the daemon automatically
+- For workers and other ephemeral agents, use `multiclaude work "<task>"` as before
+- The daemon will evolve to accept spawn requests from you directly
+
+### Agent Lifecycle
+
+**Persistent agents** (like merge-queue):
+- Auto-restart on crash
+- Run continuously
+- Spawn them once on init, daemon handles restarts
+
+**Ephemeral agents** (like workers, reviewers):
+- Complete a specific task
+- Clean up after signaling completion
+- Spawn as needed based on work
+
+### Current Transition
+
+This orchestration system is being phased in. During the transition:
+- The daemon may still spawn some hardcoded agents (merge-queue, workspace)
+- You'll receive definitions for informational purposes
+- Future versions will give you full control over agent spawning
+
 ## Your responsibilities
 
 - Monitor all worker agents and the merge queue agent


### PR DESCRIPTION
## Summary

This PR implements the third phase of issue #233 (Configurable agents via markdown definitions), making the supervisor the orchestrator for agent spawning.

- **Add agent metadata parsing**: `ParseClass()` and `ParseSpawnOnInit()` methods to extract agent characteristics from markdown
- **Add spawn_agent daemon handler**: Accepts inline prompts (name, class, prompt text) instead of hardcoded types
- **Update daemon startup**: Reads agent definitions and sends them to supervisor on initialization  
- **Update supervisor prompt**: New "Agent Orchestration" section explaining how to interpret definitions

## Test plan

- [x] All existing tests pass
- [x] New tests added for `ParseClass` and `ParseSpawnOnInit`
- [x] Code compiles without errors
- [x] gofmt passes
- [ ] Manual testing with real daemon startup

## How it works

1. On daemon startup (per repo), it reads agent definitions from:
   - `~/.multiclaude/repos/<repo>/agents/*.md`
   - `<repo>/.multiclaude/agents/*.md`

2. The daemon sends all definitions to the supervisor as a formatted message containing:
   - Agent name, title, class (persistent/ephemeral)
   - Spawn on init flag
   - Full prompt content

3. The supervisor can now understand agent definitions and (in future PRs) request the daemon to spawn agents using the new `spawn_agent` command

## Files changed

| File | Changes |
|------|---------|
| `internal/agents/agents.go` | Add `ParseClass()` and `ParseSpawnOnInit()` methods |
| `internal/agents/agents_test.go` | Add comprehensive tests for new methods |
| `internal/daemon/daemon.go` | Add `spawn_agent` handler and `sendAgentDefinitionsToSupervisor()` |
| `internal/prompts/supervisor.md` | Add "Agent Orchestration" section |

## Related

- Closes part of #233
- Builds on PR #236 (agent-templates) and PR #237 (internal/agents package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)