### PR TITLE
ci: Install Claude CLI before E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,14 @@ jobs:
           git config --global user.email "ci@github.com"
           git config --global user.name "GitHub CI"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Run e2e tests
         run: go test -v ./test/...
 


### PR DESCRIPTION
## Summary

- Adds Node.js 20 setup using `actions/setup-node@v4` to the e2e-tests job
- Installs Claude CLI globally via `npm install -g @anthropic-ai/claude-code`
- This enables PR #248's E2E tests to run properly instead of being skipped when the claude binary is not available

## Test plan

- [ ] CI workflow runs successfully on ubuntu-latest
- [ ] E2E tests execute instead of being skipped due to missing claude binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)