### PR TITLE
refactor: Add helper methods to reduce code duplication

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -308,8 +308,8 @@ func (d *Daemon) checkAgentHealth() {
 				if !isProcessAlive(agent.PID) {
 					d.logger.Warn("Agent %s process (PID %d) not running", agentName, agent.PID)
 
-					// For persistent agents (supervisor, merge-queue, workspace, generic-persistent), attempt auto-restart
-					if agent.Type == state.AgentTypeSupervisor || agent.Type == state.AgentTypeMergeQueue || agent.Type == state.AgentTypeWorkspace || agent.Type == state.AgentTypeGenericPersistent {
+					// For persistent agents, attempt auto-restart
+					if agent.Type.IsPersistent() {
 						d.logger.Info("Attempting to auto-restart agent %s", agentName)
 						if err := d.restartAgent(repoName, agentName, agent, repo); err != nil {
 							d.logger.Error("Failed to restart agent %s: %v", agentName, err)


### PR DESCRIPTION
## Summary

This PR introduces a helper function to reduce code duplication and improve maintainability:

- **`resolvePathWithSymlinks()` helper function**: Centralizes the repeated pattern of `filepath.Abs()` + `filepath.EvalSymlinks()` with fallback handling - used in 4 places in worktree.go (important for macOS where `/var` is a symlink to /private/var)
- **Uses `agent.Type.IsPersistent()` helper**: Replaces one remaining long conditional in daemon.go with the helper method that was added in PR #250

## Changes

### internal/daemon/daemon.go
- Replaced one remaining complex type conditional with `agent.Type.IsPersistent()` call (the other location was already updated in PR #250)

### internal/worktree/worktree.go
- Added `resolvePathWithSymlinks()` helper function
- Replaced 4 instances of duplicated path resolution code with helper function calls
- Simplified `Exists()` and `CleanupOrphanedWithDetails()` functions

## Test Plan

- [x] All existing unit tests pass (`go test ./internal/... ./pkg/...`)
- [x] Specific package tests verified:
  - `go test ./internal/daemon` - PASS  
  - `go test ./internal/worktree` - PASS
- [x] Code formatting checked with `gofmt -s -l`
- [x] No behavior changes - purely refactoring existing patterns

## Rebase Notes

This PR was rebased on latest main to resolve merge conflicts. PR #250 had already added `IsPersistent()` as a method on `AgentType`, so the state.go changes from this PR were dropped (they were redundant). The daemon.go changes now use `agent.Type.IsPersistent()` consistently with main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)