### PR TITLE
test: Replace tmux skip conditions with fatal errors

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -875,7 +875,7 @@ func TestCLISocketCommunication(t *testing.T) {
 func TestCLIWorkCreateWithRealTmux(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	cli, d, cleanup := setupTestEnvironment(t)
@@ -1821,7 +1821,7 @@ func TestCLIRemoveWorkerNonexistent(t *testing.T) {
 func TestCLIRemoveWorkerWithRealTmux(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	cli, d, cleanup := setupTestEnvironment(t)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -976,7 +976,7 @@ func TestWorkspaceAgentExcludedFromWakeLoop(t *testing.T) {
 func TestHealthCheckLoopWithRealTmux(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	d, cleanup := setupTestDaemon(t)
@@ -986,7 +986,7 @@ func TestHealthCheckLoopWithRealTmux(t *testing.T) {
 	// Note: In CI environments, tmux may be installed but unable to create sessions (no TTY)
 	sessionName := "mc-test-healthcheck"
 	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
-		t.Skipf("tmux cannot create sessions in this environment: %v", err)
+		t.Fatalf("tmux is required for this test but cannot create sessions in this environment: %v", err)
 	}
 	defer tmuxClient.KillSession(context.Background(), sessionName)
 
@@ -1041,7 +1041,7 @@ func TestHealthCheckLoopWithRealTmux(t *testing.T) {
 func TestHealthCheckCleansUpMarkedAgents(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	d, cleanup := setupTestDaemon(t)
@@ -1051,7 +1051,7 @@ func TestHealthCheckCleansUpMarkedAgents(t *testing.T) {
 	// Note: In CI environments, tmux may be installed but unable to create sessions (no TTY)
 	sessionName := "mc-test-cleanup"
 	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
-		t.Skipf("tmux cannot create sessions in this environment: %v", err)
+		t.Fatalf("tmux is required for this test but cannot create sessions in this environment: %v", err)
 	}
 	defer tmuxClient.KillSession(context.Background(), sessionName)
 
@@ -1105,7 +1105,7 @@ func TestHealthCheckCleansUpMarkedAgents(t *testing.T) {
 func TestMessageRoutingWithRealTmux(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	d, cleanup := setupTestDaemon(t)
@@ -1115,7 +1115,7 @@ func TestMessageRoutingWithRealTmux(t *testing.T) {
 	// Note: In CI environments, tmux may be installed but unable to create sessions (no TTY)
 	sessionName := "mc-test-routing"
 	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
-		t.Skipf("tmux cannot create sessions in this environment: %v", err)
+		t.Fatalf("tmux is required for this test but cannot create sessions in this environment: %v", err)
 	}
 	defer tmuxClient.KillSession(context.Background(), sessionName)
 
@@ -1184,7 +1184,7 @@ func TestMessageRoutingWithRealTmux(t *testing.T) {
 func TestWakeLoopUpdatesNudgeTime(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	d, cleanup := setupTestDaemon(t)
@@ -1194,7 +1194,7 @@ func TestWakeLoopUpdatesNudgeTime(t *testing.T) {
 	// Note: In CI environments, tmux may be installed but unable to create sessions (no TTY)
 	sessionName := "mc-test-wake"
 	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
-		t.Skipf("tmux cannot create sessions in this environment: %v", err)
+		t.Fatalf("tmux is required for this test but cannot create sessions in this environment: %v", err)
 	}
 	defer tmuxClient.KillSession(context.Background(), sessionName)
 
@@ -1244,7 +1244,7 @@ func TestWakeLoopUpdatesNudgeTime(t *testing.T) {
 func TestWakeLoopSkipsRecentlyNudgedAgents(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	d, cleanup := setupTestDaemon(t)
@@ -1254,7 +1254,7 @@ func TestWakeLoopSkipsRecentlyNudgedAgents(t *testing.T) {
 	// Note: In CI environments, tmux may be installed but unable to create sessions (no TTY)
 	sessionName := "mc-test-wake-skip"
 	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
-		t.Skipf("tmux cannot create sessions in this environment: %v", err)
+		t.Fatalf("tmux is required for this test but cannot create sessions in this environment: %v", err)
 	}
 	defer tmuxClient.KillSession(context.Background(), sessionName)
 
@@ -1893,7 +1893,7 @@ func TestRestoreTrackedReposNoRepos(t *testing.T) {
 func TestRestoreTrackedReposExistingSession(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	d, cleanup := setupTestDaemon(t)
@@ -1903,7 +1903,7 @@ func TestRestoreTrackedReposExistingSession(t *testing.T) {
 	// Note: In CI environments, tmux may be installed but unable to create sessions (no TTY)
 	sessionName := "mc-test-restore-existing"
 	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
-		t.Skipf("tmux cannot create sessions in this environment: %v", err)
+		t.Fatalf("tmux is required for this test but cannot create sessions in this environment: %v", err)
 	}
 	defer tmuxClient.KillSession(context.Background(), sessionName)
 
@@ -1953,7 +1953,7 @@ func TestRestoreRepoAgentsMissingRepoPath(t *testing.T) {
 func TestRestoreDeadAgentsWithExistingSession(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	d, cleanup := setupTestDaemon(t)
@@ -1963,7 +1963,7 @@ func TestRestoreDeadAgentsWithExistingSession(t *testing.T) {
 	// Note: In CI environments, tmux may be installed but unable to create sessions (no TTY)
 	sessionName := "mc-test-restore-dead"
 	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
-		t.Skipf("tmux cannot create sessions in this environment: %v", err)
+		t.Fatalf("tmux is required for this test but cannot create sessions in this environment: %v", err)
 	}
 	defer tmuxClient.KillSession(context.Background(), sessionName)
 
@@ -2005,7 +2005,7 @@ func TestRestoreDeadAgentsWithExistingSession(t *testing.T) {
 func TestRestoreDeadAgentsSkipsAliveProcesses(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	d, cleanup := setupTestDaemon(t)
@@ -2015,7 +2015,7 @@ func TestRestoreDeadAgentsSkipsAliveProcesses(t *testing.T) {
 	// Note: In CI environments, tmux may be installed but unable to create sessions (no TTY)
 	sessionName := "mc-test-restore-alive"
 	if err := tmuxClient.CreateSession(context.Background(), sessionName, true); err != nil {
-		t.Skipf("tmux cannot create sessions in this environment: %v", err)
+		t.Fatalf("tmux is required for this test but cannot create sessions in this environment: %v", err)
 	}
 	defer tmuxClient.KillSession(context.Background(), sessionName)
 
@@ -2061,7 +2061,7 @@ func TestRestoreDeadAgentsSkipsAliveProcesses(t *testing.T) {
 func TestRestoreDeadAgentsSkipsTransientAgents(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	d, cleanup := setupTestDaemon(t)
@@ -2111,7 +2111,7 @@ func TestRestoreDeadAgentsSkipsTransientAgents(t *testing.T) {
 func TestRestoreDeadAgentsIncludesWorkspace(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	d, cleanup := setupTestDaemon(t)
@@ -2381,7 +2381,7 @@ func TestHandleListReposRichFormat(t *testing.T) {
 func TestHealthCheckAttemptsRestorationBeforeCleanup(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	d, cleanup := setupTestDaemon(t)

--- a/pkg/tmux/client_test.go
+++ b/pkg/tmux/client_test.go
@@ -12,18 +12,18 @@ import (
 
 // TestMain ensures clean tmux environment for tests
 func TestMain(m *testing.M) {
-	// Skip tmux integration tests in CI environments unless TMUX_TESTS=1 is set
+	// Fail loudly in CI environments unless TMUX_TESTS=1 is set
 	// CI environments (like GitHub Actions) often have tmux installed but without
 	// proper terminal support, causing flaky session creation failures
 	if os.Getenv("CI") != "" && os.Getenv("TMUX_TESTS") != "1" {
-		fmt.Fprintln(os.Stderr, "Skipping tmux tests in CI (set TMUX_TESTS=1 to enable)")
-		os.Exit(0)
+		fmt.Fprintln(os.Stderr, "FAIL: tmux is required for these tests but TMUX_TESTS=1 is not set in CI")
+		os.Exit(1)
 	}
 
 	// Check if tmux is available
 	if exec.Command("tmux", "-V").Run() != nil {
-		fmt.Fprintln(os.Stderr, "Warning: tmux not available, skipping tmux tests")
-		os.Exit(0)
+		fmt.Fprintln(os.Stderr, "FAIL: tmux is required for these tests but not available")
+		os.Exit(1)
 	}
 
 	// Verify we can actually create sessions (not just that tmux is installed)
@@ -31,8 +31,8 @@ func TestMain(m *testing.M) {
 	testSession := fmt.Sprintf("test-tmux-probe-%d", time.Now().UnixNano())
 	cmd := exec.Command("tmux", "new-session", "-d", "-s", testSession)
 	if err := cmd.Run(); err != nil {
-		fmt.Fprintln(os.Stderr, "Warning: tmux cannot create sessions (no terminal?), skipping tmux tests")
-		os.Exit(0)
+		fmt.Fprintln(os.Stderr, "FAIL: tmux is required for these tests but cannot create sessions (no terminal?)")
+		os.Exit(1)
 	}
 	// Clean up probe session
 	exec.Command("tmux", "kill-session", "-t", testSession).Run()

--- a/test/agents_test.go
+++ b/test/agents_test.go
@@ -27,7 +27,7 @@ func TestAgentTemplatesCopiedOnInit(t *testing.T) {
 
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping integration test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	// Create temp directory
@@ -363,7 +363,7 @@ func TestAgentsSpawnCommand(t *testing.T) {
 
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping integration test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	// Create temp directory
@@ -487,7 +487,7 @@ func TestAgentDefinitionsSentToSupervisor(t *testing.T) {
 
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping integration test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	// Create temp directory
@@ -593,7 +593,7 @@ func TestSpawnPersistentAgent(t *testing.T) {
 
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping integration test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	tmpDir, err := os.MkdirTemp("", "persistent-agent-test-*")
@@ -681,7 +681,7 @@ func TestSpawnEphemeralAgent(t *testing.T) {
 
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping integration test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	tmpDir, err := os.MkdirTemp("", "ephemeral-agent-test-*")

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -26,7 +26,7 @@ func TestPhase2Integration(t *testing.T) {
 
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping integration test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	// Create temp directory

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -27,7 +27,7 @@ func setupIntegrationTest(t *testing.T, repoName string) (*cli.CLI, *daemon.Daem
 
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping integration test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	// Create temp directory
@@ -253,7 +253,7 @@ func TestRepoInitializationIntegration(t *testing.T) {
 
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping integration test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	// Create temp directory
@@ -419,7 +419,7 @@ func TestRepoInitializationWithMergeQueueDisabled(t *testing.T) {
 
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping integration test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	// Create temp directory

--- a/test/recovery_test.go
+++ b/test/recovery_test.go
@@ -100,7 +100,7 @@ func TestCorruptedStateFileRecovery(t *testing.T) {
 func TestOrphanedTmuxSessionCleanup(t *testing.T) {
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	tmpDir := t.TempDir()
@@ -365,7 +365,7 @@ func TestDaemonCrashRecovery(t *testing.T) {
 	// state is preserved as-is.
 	tmuxClient := tmux.NewClient()
 	if !tmuxClient.IsTmuxAvailable() {
-		t.Skip("tmux not available, skipping crash recovery test")
+		t.Fatal("tmux is required for this test but not available")
 	}
 
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary
- Replace all `t.Skip()` calls for tmux unavailability with `t.Fatal()` to ensure CI failures are obvious rather than silently passing with skipped tests
- Update `pkg/tmux/client_test.go` to use `os.Exit(1)` instead of `os.Exit(0)` when tmux is unavailable
- Ensures that if tmux is not available in an environment where these tests are expected to run, the failure is immediately apparent

## Files Modified
- `test/integration_test.go`: 3 skip conditions replaced
- `test/recovery_test.go`: 2 skip conditions replaced  
- `test/e2e_test.go`: 1 skip condition replaced
- `test/agents_test.go`: 5 skip conditions replaced
- `internal/daemon/daemon_test.go`: 11 `t.Skip` + 8 `t.Skipf` replaced with `t.Fatal`/`t.Fatalf`
- `internal/cli/cli_test.go`: 2 skip conditions replaced
- `pkg/tmux/client_test.go`: 3 `os.Exit(0)` changed to `os.Exit(1)` with clear error messages

## Test plan
- [x] All tests pass when tmux is available (`go test ./...` succeeds)
- [x] Build succeeds (`go build ./...`)
- [ ] Tests fail loudly when tmux is not available (verified by changing the error message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)