### PR TITLE
fix: Wrap tmux tests with script command to provide PTY in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
         env:
           TMUX_TESTS: "1"
         run: |
-          go test -coverprofile=coverage.out -covermode=atomic ./internal/... ./pkg/...
+          # Use script to provide a PTY for tmux (needed in headless CI environments)
+          script -e -c "go test -coverprofile=coverage.out -covermode=atomic ./internal/... ./pkg/..."
           go tool cover -func=coverage.out
 
       - name: Upload coverage report
@@ -99,7 +100,8 @@ jobs:
         env:
           TMUX_TESTS: "1"
         run: |
-          go test -coverprofile=coverage.out -covermode=atomic ./internal/... ./pkg/...
+          # Use script to provide a PTY for tmux (needed in headless CI environments)
+          script -e -c "go test -coverprofile=coverage.out -covermode=atomic ./internal/... ./pkg/..."
 
           echo "## Coverage Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Fixes the CI failure caused by PR #260 where TMUX_TESTS=1 was enabled but tmux session creation was failing in GitHub Actions headless environment.

## Problem

PR #260 added TMUX_TESTS=1 to enable tmux tests in CI and installed tmux, but tests were still failing because:
- GitHub Actions runs in a headless environment without a proper PTY (pseudo-terminal)
- `pkg/tmux/client_test.go` includes a probe check that verifies tmux can actually create sessions
- Without a PTY, `tmux new-session` fails even when tmux is installed

## Solution

Wrap test commands with `script -e -c` which provides a PTY for tmux to function properly. This is a common pattern for running tmux in headless CI environments.

## Changes

- Wrapped `go test` command in unit-tests job with `script -e -c`
- Wrapped `go test` command in coverage-check job with `script -e -c`
- Added explanatory comments

## Test Plan

- [x] CI unit-tests job should now pass with tmux tests enabled
- [x] CI coverage-check job should now pass with tmux tests enabled
- [x] No changes to test logic or production code, only CI configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)