### PR TITLE
fix: Prevent TestInitRepoNameParsing from hanging in CI

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1030,15 +1030,23 @@ func (c *CLI) initRepo(args []string) error {
 		return errors.DaemonNotRunning()
 	}
 
-	// Clone repository
+	// Clone repository (skip in test mode)
 	repoPath := c.paths.RepoDir(repoName)
-	fmt.Printf("Cloning to: %s\n", repoPath)
+	var cmd *exec.Cmd
+	if os.Getenv("MULTICLAUDE_TEST_MODE") != "1" {
+		fmt.Printf("Cloning to: %s\n", repoPath)
 
-	cmd := exec.Command("git", "clone", githubURL, repoPath)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return errors.GitOperationFailed("clone", err)
+		cmd = exec.Command("git", "clone", githubURL, repoPath)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return errors.GitOperationFailed("clone", err)
+		}
+	} else {
+		// In test mode, create a mock repo directory
+		if err := os.MkdirAll(repoPath, 0755); err != nil {
+			return fmt.Errorf("failed to create test repo directory: %w", err)
+		}
 	}
 
 	// Copy agent templates to per-repo agents directory


### PR DESCRIPTION
## Summary
- Fixed CLI test timeouts that were causing TestInitRepoNameParsing to hang for 11 minutes in CI
- Added 3-second timeout protection to prevent indefinite hanging
- Made git clone respect MULTICLAUDE_TEST_MODE by skipping in test environment

## Problem
PR #263 fixed tmux tests but revealed that TestInitRepoNameParsing was hanging in CI. The test was calling the full `init` command which attempted to clone non-existent GitHub repos, causing 11-minute hangs.

## Solution
1. **Test Timeout**: Added a 3-second timeout to each test case using a goroutine + select pattern
2. **Skip Git Clone in Test Mode**: Modified `initRepo()` to check `MULTICLAUDE_TEST_MODE` and skip git clone operations, creating a mock repo directory instead

## Test Results
- All test cases now complete in ~0.1s (previously hanging/timing out)
- Full test suite passes: `go test ./internal/... ./pkg/...` ✓

## Files Changed
- `internal/cli/cli.go`: Added MULTICLAUDE_TEST_MODE check to skip git operations
- `internal/cli/cli_test.go`: Added timeout protection to TestInitRepoNameParsing

🤖 Generated with multiclaude worker: calm-koala