### PR TITLE
fix: Stabilize tmux tests in CI environment

### DIFF
--- a/pkg/tmux/client.go
+++ b/pkg/tmux/client.go
@@ -136,10 +136,11 @@ func (c *Client) HasSession(ctx context.Context, name string) (bool, error) {
 // CreateSession creates a new tmux session with the given name.
 // If detached is true, creates the session in detached mode (-d).
 func (c *Client) CreateSession(ctx context.Context, name string, detached bool) error {
-	args := []string{"new-session", "-s", name}
+	args := []string{"new-session"}
 	if detached {
 		args = append(args, "-d")
 	}
+	args = append(args, "-s", name)
 
 	cmd := c.tmuxCmd(ctx, args...)
 	return c.wrapCommandError(ctx, cmd.Run(), "new-session", name, "")

--- a/pkg/tmux/client_test.go
+++ b/pkg/tmux/client_test.go
@@ -34,8 +34,8 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stderr, "FAIL: tmux is required for these tests but cannot create sessions (no terminal?)")
 		os.Exit(1)
 	}
-	// Clean up probe session
-	exec.Command("tmux", "kill-session", "-t", testSession).Run()
+	// Keep the probe session alive during tests to ensure the tmux server stays running.
+	// It will be cleaned up by cleanupTestSessions() at the end since it starts with "test-".
 
 	// Run tests
 	code := m.Run()


### PR DESCRIPTION
## Summary

- Fixed tmux `CreateSession` flag order to match the TestMain probe (`-d -s name` instead of `-s name -d`)
- Kept probe session alive during tests to ensure tmux server stays running

This fixes the CI failure introduced by PR #260 where `TestCreateSession` was failing with:
```
Failed to create session: tmux new-session failed for session test-tmux-1769174006690650596: exit status 1
```

## Root Cause

Two issues were causing flaky test failures:

1. **Inconsistent flag order**: The TestMain probe used `tmux new-session -d -s name` while `CreateSession()` used `tmux new-session -s name -d`. Some CI environments may have different behavior with different flag ordering.

2. **Tmux server lifecycle**: The probe session was killed immediately after creation. If it was the only session, the tmux server would exit. When subsequent tests tried to create sessions, timing issues with server restart could cause failures.

## Test plan

- [x] All tests pass locally: `go test ./internal/... ./pkg/...`
- [x] tmux tests pass: `go test -v ./pkg/tmux/...`
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)