### PR TITLE
refactor(fork): simplify API and improve test coverage

### DIFF
--- a/internal/fork/fork.go
+++ b/internal/fork/fork.go
@@ -48,7 +48,7 @@ func DetectFork(repoPath string) (*ForkInfo, error) {
 	}
 
 	// Parse origin URL
-	originOwner, originRepo, err := parseGitHubURL(originURL)
+	originOwner, originRepo, err := ParseGitHubURL(originURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse origin URL: %w", err)
 	}
@@ -64,7 +64,7 @@ func DetectFork(repoPath string) (*ForkInfo, error) {
 	upstreamURL, err := getRemoteURL(repoPath, "upstream")
 	if err == nil && upstreamURL != "" {
 		// Upstream remote exists - this is a fork
-		upstreamOwner, upstreamRepo, err := parseGitHubURL(upstreamURL)
+		upstreamOwner, upstreamRepo, err := ParseGitHubURL(upstreamURL)
 		if err == nil {
 			info.IsFork = true
 			info.UpstreamURL = upstreamURL
@@ -96,13 +96,13 @@ func getRemoteURL(repoPath, remoteName string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// parseGitHubURL extracts owner and repo from a GitHub URL.
+// ParseGitHubURL extracts owner and repo from a GitHub URL.
 // Supports both HTTPS and SSH formats:
 // - https://github.com/owner/repo.git
 // - https://github.com/owner/repo
 // - git@github.com:owner/repo.git
 // - git@github.com:owner/repo
-func parseGitHubURL(url string) (owner, repo string, err error) {
+func ParseGitHubURL(url string) (owner, repo string, err error) {
 	// HTTPS format: https://github.com/owner/repo(.git)?
 	httpsRegex := regexp.MustCompile(`^https://github\.com/([^/]+)/([^/.]+)(?:\.git)?$`)
 	if matches := httpsRegex.FindStringSubmatch(url); matches != nil {
@@ -171,9 +171,4 @@ func AddUpstreamRemote(repoPath, upstreamURL string) error {
 func HasUpstreamRemote(repoPath string) bool {
 	_, err := getRemoteURL(repoPath, "upstream")
 	return err == nil
-}
-
-// ParseGitHubURL is an exported version of parseGitHubURL for testing and external use.
-func ParseGitHubURL(url string) (owner, repo string, err error) {
-	return parseGitHubURL(url)
 }

--- a/internal/fork/fork_test.go
+++ b/internal/fork/fork_test.go
@@ -1,6 +1,9 @@
 package fork
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
@@ -110,5 +113,206 @@ func TestForkInfo(t *testing.T) {
 	}
 	if info.UpstreamOwner != "upstream" {
 		t.Errorf("Expected UpstreamOwner to be 'upstream', got %s", info.UpstreamOwner)
+	}
+}
+
+// setupTestRepo creates a temporary git repository for testing.
+func setupTestRepo(t *testing.T) string {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "fork-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	// Initialize git repo
+	cmd := exec.Command("git", "init")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		os.RemoveAll(tmpDir)
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+
+	// Configure git user for commits
+	cmd = exec.Command("git", "config", "user.email", "test@example.com")
+	cmd.Dir = tmpDir
+	cmd.Run()
+	cmd = exec.Command("git", "config", "user.name", "Test User")
+	cmd.Dir = tmpDir
+	cmd.Run()
+
+	return tmpDir
+}
+
+func TestHasUpstreamRemote(t *testing.T) {
+	tmpDir := setupTestRepo(t)
+	defer os.RemoveAll(tmpDir)
+
+	// Initially no upstream
+	if HasUpstreamRemote(tmpDir) {
+		t.Error("expected no upstream remote initially")
+	}
+
+	// Add upstream remote
+	cmd := exec.Command("git", "remote", "add", "upstream", "https://github.com/upstream/repo")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to add upstream: %v", err)
+	}
+
+	// Now should have upstream
+	if !HasUpstreamRemote(tmpDir) {
+		t.Error("expected upstream remote after adding")
+	}
+}
+
+func TestAddUpstreamRemote(t *testing.T) {
+	tmpDir := setupTestRepo(t)
+	defer os.RemoveAll(tmpDir)
+
+	upstreamURL := "https://github.com/upstream/repo"
+
+	// Add upstream to repo without one
+	if err := AddUpstreamRemote(tmpDir, upstreamURL); err != nil {
+		t.Fatalf("AddUpstreamRemote() failed: %v", err)
+	}
+
+	// Verify it was added
+	if !HasUpstreamRemote(tmpDir) {
+		t.Error("upstream remote not added")
+	}
+
+	// Verify URL
+	cmd := exec.Command("git", "remote", "get-url", "upstream")
+	cmd.Dir = tmpDir
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("failed to get upstream url: %v", err)
+	}
+	got := string(output)
+	if got != upstreamURL+"\n" {
+		t.Errorf("upstream URL = %q, want %q", got, upstreamURL)
+	}
+
+	// Update existing upstream
+	newURL := "https://github.com/other/repo"
+	if err := AddUpstreamRemote(tmpDir, newURL); err != nil {
+		t.Fatalf("AddUpstreamRemote() update failed: %v", err)
+	}
+
+	cmd = exec.Command("git", "remote", "get-url", "upstream")
+	cmd.Dir = tmpDir
+	output, err = cmd.Output()
+	if err != nil {
+		t.Fatalf("failed to get upstream url after update: %v", err)
+	}
+	got = string(output)
+	if got != newURL+"\n" {
+		t.Errorf("upstream URL after update = %q, want %q", got, newURL)
+	}
+}
+
+func TestDetectFork_NoOrigin(t *testing.T) {
+	tmpDir := setupTestRepo(t)
+	defer os.RemoveAll(tmpDir)
+
+	// DetectFork should fail without origin
+	_, err := DetectFork(tmpDir)
+	if err == nil {
+		t.Error("expected error when no origin remote")
+	}
+}
+
+func TestDetectFork_WithOrigin(t *testing.T) {
+	tmpDir := setupTestRepo(t)
+	defer os.RemoveAll(tmpDir)
+
+	// Add origin
+	cmd := exec.Command("git", "remote", "add", "origin", "https://github.com/myuser/myrepo")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to add origin: %v", err)
+	}
+
+	// DetectFork should succeed and detect non-fork
+	info, err := DetectFork(tmpDir)
+	if err != nil {
+		t.Fatalf("DetectFork() failed: %v", err)
+	}
+
+	if info.OriginOwner != "myuser" {
+		t.Errorf("OriginOwner = %q, want %q", info.OriginOwner, "myuser")
+	}
+	if info.OriginRepo != "myrepo" {
+		t.Errorf("OriginRepo = %q, want %q", info.OriginRepo, "myrepo")
+	}
+}
+
+func TestDetectFork_WithUpstream(t *testing.T) {
+	tmpDir := setupTestRepo(t)
+	defer os.RemoveAll(tmpDir)
+
+	// Add origin
+	cmd := exec.Command("git", "remote", "add", "origin", "https://github.com/myuser/myrepo")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to add origin: %v", err)
+	}
+
+	// Add upstream (simulating a fork)
+	cmd = exec.Command("git", "remote", "add", "upstream", "https://github.com/original/repo")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to add upstream: %v", err)
+	}
+
+	// DetectFork should detect fork
+	info, err := DetectFork(tmpDir)
+	if err != nil {
+		t.Fatalf("DetectFork() failed: %v", err)
+	}
+
+	if !info.IsFork {
+		t.Error("expected IsFork to be true with upstream remote")
+	}
+	if info.UpstreamOwner != "original" {
+		t.Errorf("UpstreamOwner = %q, want %q", info.UpstreamOwner, "original")
+	}
+	if info.UpstreamRepo != "repo" {
+		t.Errorf("UpstreamRepo = %q, want %q", info.UpstreamRepo, "repo")
+	}
+}
+
+func TestGetRemoteURL(t *testing.T) {
+	tmpDir := setupTestRepo(t)
+	defer os.RemoveAll(tmpDir)
+
+	// No remote should return error
+	_, err := getRemoteURL(tmpDir, "origin")
+	if err == nil {
+		t.Error("expected error for non-existent remote")
+	}
+
+	// Add origin
+	cmd := exec.Command("git", "remote", "add", "origin", "https://github.com/test/repo")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to add origin: %v", err)
+	}
+
+	// Now should work
+	url, err := getRemoteURL(tmpDir, "origin")
+	if err != nil {
+		t.Fatalf("getRemoteURL() failed: %v", err)
+	}
+	if url != "https://github.com/test/repo" {
+		t.Errorf("url = %q, want %q", url, "https://github.com/test/repo")
+	}
+}
+
+func TestDetectFork_InvalidPath(t *testing.T) {
+	// Test with non-existent path
+	_, err := DetectFork(filepath.Join(os.TempDir(), "nonexistent-fork-test"))
+	if err == nil {
+		t.Error("expected error for non-existent path")
 	}
 }


### PR DESCRIPTION
## Summary

- Removed duplicate `parseGitHubURL`/`ParseGitHubURL` wrapper pattern by directly exporting `ParseGitHubURL`
- Added comprehensive tests for `HasUpstreamRemote`, `AddUpstreamRemote`, `DetectFork`, and `getRemoteURL` functions
- Improved test coverage from **14% to 75%**

## Changes

### Code Simplification
The fork package had an anti-pattern where `parseGitHubURL` was unexported, and `ParseGitHubURL` was just a thin wrapper that called it. Since `ParseGitHubURL` is used externally and in tests, I simplified by directly exporting the function and removing the redundant wrapper.

### Test Coverage
Added tests for all core functions in the fork package:
- `TestHasUpstreamRemote` - verifies detection of upstream remotes
- `TestAddUpstreamRemote` - tests adding and updating upstream remotes  
- `TestDetectFork_*` - tests fork detection with various remote configurations
- `TestGetRemoteURL` - tests remote URL retrieval

The only uncovered code is `detectForkViaGitHubAPI` which requires the `gh` CLI and live GitHub API access.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New tests pass (`go test -v ./internal/fork/...`)
- [x] Code passes `go vet` and `gofmt` checks
- [x] Coverage improved from 14% to 75%

🤖 Generated with [Claude Code](https://claude.com/claude-code)