### PR TITLE
fix: Handle existing local branch in --push-to flag

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1938,9 +1938,23 @@ func (c *CLI) createWorker(args []string) error {
 		// Create a worktree that checks out the remote branch into a local branch
 		branchName = pushTo
 		fmt.Printf("Creating worktree at: %s (checking out %s)\n", wtPath, startBranch)
-		// Use git worktree add with -b to create local branch tracking the remote
-		if err := wt.CreateNewBranch(wtPath, branchName, startBranch); err != nil {
+
+		// Check if the local branch already exists
+		branchExists, err := wt.BranchExists(branchName)
+		if err != nil {
 			return errors.WorktreeCreationFailed(err)
+		}
+
+		if branchExists {
+			// Branch exists locally, check it out
+			if err := wt.Create(wtPath, branchName); err != nil {
+				return errors.WorktreeCreationFailed(err)
+			}
+		} else {
+			// Branch doesn't exist, create it from the start point
+			if err := wt.CreateNewBranch(wtPath, branchName, startBranch); err != nil {
+				return errors.WorktreeCreationFailed(err)
+			}
 		}
 	} else {
 		// Normal case: create a new branch for this worker


### PR DESCRIPTION
## Summary

- Fixes the `--push-to` flag which always used `CreateNewBranch()` and failed if the local branch already exists
- Now checks with `BranchExists()` first and uses `Create()` for existing branches, `CreateNewBranch()` for new ones
- Added test case `TestCreateWorktreeForExistingBranch` validating this scenario

## Details

The bug was in `internal/cli/cli.go` around line 1936-1944. The `--push-to` flag is used to iterate on an existing PR branch, but if the local branch already existed, `CreateNewBranch()` would fail with a "branch already exists" error.

The fix:
1. Check if the local branch exists using `wt.BranchExists(branchName)`
2. If branch exists: use `wt.Create(wtPath, branchName)` to check out the existing branch
3. If branch doesn't exist: use `wt.CreateNewBranch(wtPath, branchName, startBranch)` as before

Fixes #278

## Test plan

- [x] Added `TestCreateWorktreeForExistingBranch` test case
- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)