### PR TITLE
docs: fix incorrect line number reference in SOCKET_API.md

### DIFF
--- a/docs/extending/SOCKET_API.md
+++ b/docs/extending/SOCKET_API.md
@@ -1140,7 +1140,7 @@ client.setTimeout(60000);
 - **[`EXTENSIBILITY.md`](../EXTENSIBILITY.md)** - Overview of extension points
 - **[`STATE_FILE_INTEGRATION.md`](STATE_FILE_INTEGRATION.md)** - For read-only monitoring
 - `internal/socket/socket.go` - Socket implementation
-- `internal/daemon/daemon.go` - Request handlers (lines 607-685)
+- `internal/daemon/daemon.go` - Request handlers (lines 574-653)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Full documentation accuracy review as requested in PR #295 (README overhaul). This PR addresses issues found during the review.

### Changes
- Fixed incorrect line number reference in `docs/extending/SOCKET_API.md`: changed "lines 607-685" to "lines 574-653" for request handlers in `internal/daemon/daemon.go`

### Documentation Review Findings

**Verified as Accurate:**
- README.md - All CLI commands and prompt file links verified
- CLAUDE.md - Key files and line references approximately correct (~5500 lines for cli.go which has 5543)
- docs/AGENTS.md - Template references point to correct files
- docs/COMMANDS.md - CLI command documentation matches implementation  
- docs/DIRECTORY_STRUCTURE.md - Runtime directory structure accurate
- docs/WORKFLOWS.md - Workflow descriptions accurate
- docs/CRASH_RECOVERY.md - Recovery procedures accurate
- docs/EXTENSIBILITY.md - Extension point documentation accurate
- docs/extending/STATE_FILE_INTEGRATION.md - State schema matches implementation
- docs/extending/EVENT_HOOKS.md - Already has "NOT IMPLEMENTED" warning
- docs/extending/WEB_UI_DEVELOPMENT.md - Already has "FOR FORKS ONLY" warning

**Historical Documents (point-in-time snapshots, not updated):**
- AUDIT_REPORT.md - Previous audit documenting issues that have been addressed
- ARCHITECTURAL_REVIEW.md - Architectural review with line numbers from when review was conducted
- docs/cli-refactoring-analysis.md - Analysis with line counts from when analysis was done

### Verification Method
For each document:
1. Verified CLI commands exist using grep on `internal/cli/cli.go` registerCommands()
2. Verified file paths using `Glob` tool
3. Verified line numbers using grep/read on actual source files
4. Verified code patterns match documentation examples
5. Ran `go test ./...` to ensure no regressions

## Test plan
- [x] All tests pass (`go test ./...`)
- [x] Line number reference verified against actual `internal/daemon/daemon.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)