### PR TITLE
fix: Standardize worker branch naming to multiclaude/ prefix

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1943,7 +1943,7 @@ func (c *CLI) createWorker(args []string) error {
 	if hasPushTo {
 		// --push-to requires --branch to specify the remote branch to start from
 		if _, hasBranch := flags["branch"]; !hasBranch {
-			return errors.InvalidUsage("--push-to requires --branch to specify the remote branch (e.g., --branch origin/work/jolly-hawk --push-to work/jolly-hawk)")
+			return errors.InvalidUsage("--push-to requires --branch to specify the remote branch (e.g., --branch origin/multiclaude/jolly-hawk --push-to multiclaude/jolly-hawk)")
 		}
 	}
 
@@ -2014,7 +2014,7 @@ func (c *CLI) createWorker(args []string) error {
 		}
 	} else {
 		// Normal case: create a new branch for this worker
-		branchName = fmt.Sprintf("work/%s", workerName)
+		branchName = fmt.Sprintf("multiclaude/%s", workerName)
 		fmt.Printf("Creating worktree at: %s\n", wtPath)
 		if err := wt.CreateNewBranch(wtPath, branchName, startBranch); err != nil {
 			return errors.WorktreeCreationFailed(err)
@@ -4740,8 +4740,12 @@ func (c *CLI) localCleanup(dryRun bool, verbose bool) error {
 				}
 			}
 
-			// Clean up orphaned work/* and workspace/* branches
-			removed, issues := c.cleanupOrphanedBranchesWithPrefix(wt, "work/", repoName, dryRun, verbose)
+			// Clean up orphaned multiclaude/*, work/* (legacy), and workspace/* branches
+			removed, issues := c.cleanupOrphanedBranchesWithPrefix(wt, "multiclaude/", repoName, dryRun, verbose)
+			totalRemoved += removed
+			totalIssues += issues
+
+			removed, issues = c.cleanupOrphanedBranchesWithPrefix(wt, "work/", repoName, dryRun, verbose)
 			totalRemoved += removed
 			totalIssues += issues
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1432,7 +1432,7 @@ func (d *Daemon) recordTaskHistory(repoName, agentName string, agent state.Agent
 			branch = b
 		} else {
 			// Fallback: construct expected branch name
-			branch = "work/" + agentName
+			branch = "multiclaude/" + agentName
 		}
 	}
 
@@ -1582,7 +1582,7 @@ func (d *Daemon) handleSpawnAgent(req socket.Request) socket.Response {
 		worktreePath = repoPath
 	} else {
 		// Ephemeral agents get their own worktree with a new branch
-		branchName := fmt.Sprintf("work/%s", agentName)
+		branchName := fmt.Sprintf("multiclaude/%s", agentName)
 		if err := wt.CreateNewBranch(worktreePath, branchName, "HEAD"); err != nil {
 			return socket.Response{Success: false, Error: fmt.Sprintf("failed to create worktree: %v", err)}
 		}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -294,8 +294,8 @@ func TestWorktreeCreationFailed_SpecificSuggestions(t *testing.T) {
 	}{
 		{
 			name:         "branch already exists with name",
-			causeMsg:     "failed to create worktree: exit status 128\nOutput: fatal: a branch named 'work/nice-owl' already exists",
-			wantContains: []string{"work/nice-owl", "multiclaude cleanup", "git branch -D work/nice-owl"},
+			causeMsg:     "failed to create worktree: exit status 128\nOutput: fatal: a branch named 'multiclaude/nice-owl' already exists",
+			wantContains: []string{"multiclaude/nice-owl", "multiclaude cleanup", "git branch -D multiclaude/nice-owl"},
 		},
 		{
 			name:         "generic branch already exists",
@@ -363,7 +363,7 @@ func TestExtractQuotedValue(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"fatal: a branch named 'work/nice-owl' already exists", "work/nice-owl"},
+		{"fatal: a branch named 'multiclaude/nice-owl' already exists", "multiclaude/nice-owl"},
 		{"some error 'value' here", "value"},
 		{"no quotes here", ""},
 		{"'only-one-quote", ""},

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1109,7 +1109,7 @@ func TestTaskHistory(t *testing.T) {
 	entry1 := TaskHistoryEntry{
 		Name:        "worker-1",
 		Task:        "Implement feature A",
-		Branch:      "work/worker-1",
+		Branch:      "multiclaude/worker-1",
 		Status:      TaskStatusUnknown,
 		CreatedAt:   time.Now().Add(-2 * time.Hour),
 		CompletedAt: time.Now().Add(-1 * time.Hour),
@@ -1117,7 +1117,7 @@ func TestTaskHistory(t *testing.T) {
 	entry2 := TaskHistoryEntry{
 		Name:        "worker-2",
 		Task:        "Fix bug B",
-		Branch:      "work/worker-2",
+		Branch:      "multiclaude/worker-2",
 		PRURL:       "https://github.com/test/repo/pull/123",
 		PRNumber:    123,
 		Status:      TaskStatusMerged,
@@ -1226,7 +1226,7 @@ func TestUpdateTaskHistoryStatus(t *testing.T) {
 	entry := TaskHistoryEntry{
 		Name:        "worker-1",
 		Task:        "Implement feature A",
-		Branch:      "work/worker-1",
+		Branch:      "multiclaude/worker-1",
 		Status:      TaskStatusUnknown,
 		CreatedAt:   time.Now().Add(-1 * time.Hour),
 		CompletedAt: time.Now(),
@@ -1281,7 +1281,7 @@ func TestTaskHistoryPersistence(t *testing.T) {
 	entry := TaskHistoryEntry{
 		Name:        "worker-1",
 		Task:        "Implement feature A",
-		Branch:      "work/worker-1",
+		Branch:      "multiclaude/worker-1",
 		PRURL:       "https://github.com/test/repo/pull/789",
 		PRNumber:    789,
 		Status:      TaskStatusMerged,

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -425,7 +425,7 @@ func (m *Manager) FetchRemote(remote string) error {
 
 // FindMergedUpstreamBranches finds local branches that have been merged into the upstream default branch.
 // It fetches from the upstream remote first to ensure we have the latest state.
-// The branchPrefix filters which branches to check (e.g., "multiclaude/" or "work/").
+// The branchPrefix filters which branches to check (e.g., "multiclaude/" or "workspace/").
 // Returns a list of branch names that can be safely deleted.
 func (m *Manager) FindMergedUpstreamBranches(branchPrefix string) ([]string, error) {
 	// Get the upstream remote name

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1194,7 +1194,7 @@ func TestFindMergedUpstreamBranches(t *testing.T) {
 		manager := NewManager(repoPath)
 
 		// Create a branch that is already merged (same as main)
-		createBranch(t, repoPath, "work/test-feature")
+		createBranch(t, repoPath, "multiclaude/test-feature")
 
 		// Add origin remote
 		cmd := exec.Command("git", "remote", "add", "origin", repoPath)
@@ -1206,7 +1206,7 @@ func TestFindMergedUpstreamBranches(t *testing.T) {
 		cmd.Run()
 
 		// Find merged branches
-		merged, err := manager.FindMergedUpstreamBranches("work/")
+		merged, err := manager.FindMergedUpstreamBranches("multiclaude/")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1214,7 +1214,7 @@ func TestFindMergedUpstreamBranches(t *testing.T) {
 		// The branch should be found since it's at the same commit as main
 		found := false
 		for _, b := range merged {
-			if b == "work/test-feature" {
+			if b == "multiclaude/test-feature" {
 				found = true
 				break
 			}
@@ -1231,7 +1231,7 @@ func TestFindMergedUpstreamBranches(t *testing.T) {
 		manager := NewManager(repoPath)
 
 		// Create a branch and add a commit to it
-		cmd := exec.Command("git", "checkout", "-b", "work/unmerged-feature")
+		cmd := exec.Command("git", "checkout", "-b", "multiclaude/unmerged-feature")
 		cmd.Dir = repoPath
 		cmd.Run()
 
@@ -1262,14 +1262,14 @@ func TestFindMergedUpstreamBranches(t *testing.T) {
 		cmd.Run()
 
 		// Find merged branches
-		merged, err := manager.FindMergedUpstreamBranches("work/")
+		merged, err := manager.FindMergedUpstreamBranches("multiclaude/")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
 		// The unmerged branch should NOT be found
 		for _, b := range merged {
-			if b == "work/unmerged-feature" {
+			if b == "multiclaude/unmerged-feature" {
 				t.Error("Unmerged branch should not be in the merged list")
 			}
 		}
@@ -1282,8 +1282,8 @@ func TestFindMergedUpstreamBranches(t *testing.T) {
 		manager := NewManager(repoPath)
 
 		// Create branches with different prefixes
-		createBranch(t, repoPath, "work/test")
 		createBranch(t, repoPath, "multiclaude/test")
+		createBranch(t, repoPath, "workspace/test")
 		createBranch(t, repoPath, "feature/test")
 
 		// Add origin remote
@@ -1295,15 +1295,15 @@ func TestFindMergedUpstreamBranches(t *testing.T) {
 		cmd.Dir = repoPath
 		cmd.Run()
 
-		// Find merged branches with work/ prefix
-		merged, err := manager.FindMergedUpstreamBranches("work/")
+		// Find merged branches with multiclaude/ prefix
+		merged, err := manager.FindMergedUpstreamBranches("multiclaude/")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
-		// Should only find work/test
+		// Should only find multiclaude/test
 		for _, b := range merged {
-			if !strings.HasPrefix(b, "work/") {
+			if !strings.HasPrefix(b, "multiclaude/") {
 				t.Errorf("Branch %s should not be included (wrong prefix)", b)
 			}
 		}
@@ -1484,13 +1484,13 @@ func TestListBranchesWithPrefix(t *testing.T) {
 		manager := NewManager(repoPath)
 
 		// Create branches with different prefixes
-		createBranch(t, repoPath, "work/feature-1")
-		createBranch(t, repoPath, "work/feature-2")
-		createBranch(t, repoPath, "multiclaude/agent-1")
+		createBranch(t, repoPath, "multiclaude/feature-1")
+		createBranch(t, repoPath, "multiclaude/feature-2")
+		createBranch(t, repoPath, "workspace/agent-1")
 		createBranch(t, repoPath, "other/branch")
 
-		// List work/ branches
-		branches, err := manager.ListBranchesWithPrefix("work/")
+		// List multiclaude/ branches
+		branches, err := manager.ListBranchesWithPrefix("multiclaude/")
 		if err != nil {
 			t.Fatalf("Failed to list branches: %v", err)
 		}
@@ -1499,19 +1499,19 @@ func TestListBranchesWithPrefix(t *testing.T) {
 			t.Errorf("Expected 2 branches, got %d: %v", len(branches), branches)
 		}
 
-		// Verify both work/ branches are in the list
+		// Verify both multiclaude/ branches are in the list
 		foundFeature1 := false
 		foundFeature2 := false
 		for _, b := range branches {
-			if b == "work/feature-1" {
+			if b == "multiclaude/feature-1" {
 				foundFeature1 = true
 			}
-			if b == "work/feature-2" {
+			if b == "multiclaude/feature-2" {
 				foundFeature2 = true
 			}
 		}
 		if !foundFeature1 || !foundFeature2 {
-			t.Errorf("Expected to find work/feature-1 and work/feature-2, got: %v", branches)
+			t.Errorf("Expected to find multiclaude/feature-1 and multiclaude/feature-2, got: %v", branches)
 		}
 	})
 
@@ -1557,19 +1557,19 @@ func TestFindOrphanedBranches(t *testing.T) {
 		manager := NewManager(repoPath)
 
 		// Create branches
-		createBranch(t, repoPath, "work/orphan-1")
-		createBranch(t, repoPath, "work/orphan-2")
-		createBranch(t, repoPath, "work/active")
+		createBranch(t, repoPath, "multiclaude/orphan-1")
+		createBranch(t, repoPath, "multiclaude/orphan-2")
+		createBranch(t, repoPath, "multiclaude/active")
 
 		// Create a worktree for one branch
 		wtPath := filepath.Join(repoPath, "wt-active")
-		if err := manager.Create(wtPath, "work/active"); err != nil {
+		if err := manager.Create(wtPath, "multiclaude/active"); err != nil {
 			t.Fatalf("Failed to create worktree: %v", err)
 		}
 		defer manager.Remove(wtPath, true)
 
 		// Find orphaned branches
-		orphaned, err := manager.FindOrphanedBranches("work/")
+		orphaned, err := manager.FindOrphanedBranches("multiclaude/")
 		if err != nil {
 			t.Fatalf("Failed to find orphaned branches: %v", err)
 		}
@@ -1580,7 +1580,7 @@ func TestFindOrphanedBranches(t *testing.T) {
 		}
 
 		for _, b := range orphaned {
-			if b == "work/active" {
+			if b == "multiclaude/active" {
 				t.Error("Active branch should not be in orphaned list")
 			}
 		}
@@ -1593,15 +1593,15 @@ func TestFindOrphanedBranches(t *testing.T) {
 		manager := NewManager(repoPath)
 
 		// Create a branch and a worktree for it
-		createBranch(t, repoPath, "work/active")
+		createBranch(t, repoPath, "multiclaude/active")
 
 		wtPath := filepath.Join(repoPath, "wt-active")
-		if err := manager.Create(wtPath, "work/active"); err != nil {
+		if err := manager.Create(wtPath, "multiclaude/active"); err != nil {
 			t.Fatalf("Failed to create worktree: %v", err)
 		}
 		defer manager.Remove(wtPath, true)
 
-		orphaned, err := manager.FindOrphanedBranches("work/")
+		orphaned, err := manager.FindOrphanedBranches("multiclaude/")
 		if err != nil {
 			t.Fatalf("Failed to find orphaned branches: %v", err)
 		}
@@ -1618,21 +1618,21 @@ func TestFindOrphanedBranches(t *testing.T) {
 		manager := NewManager(repoPath)
 
 		// Create branches with different prefixes
-		createBranch(t, repoPath, "work/orphan")
 		createBranch(t, repoPath, "multiclaude/orphan")
+		createBranch(t, repoPath, "workspace/orphan")
 
-		// Find orphaned branches with work/ prefix
-		orphaned, err := manager.FindOrphanedBranches("work/")
+		// Find orphaned branches with multiclaude/ prefix
+		orphaned, err := manager.FindOrphanedBranches("multiclaude/")
 		if err != nil {
 			t.Fatalf("Failed to find orphaned branches: %v", err)
 		}
 
-		// Should only find work/orphan
+		// Should only find multiclaude/orphan
 		if len(orphaned) != 1 {
 			t.Errorf("Expected 1 orphaned branch, got %d: %v", len(orphaned), orphaned)
 		}
-		if len(orphaned) > 0 && orphaned[0] != "work/orphan" {
-			t.Errorf("Expected work/orphan, got: %s", orphaned[0])
+		if len(orphaned) > 0 && orphaned[0] != "multiclaude/orphan" {
+			t.Errorf("Expected multiclaude/orphan, got: %s", orphaned[0])
 		}
 	})
 }
@@ -1765,10 +1765,10 @@ func TestCleanupMergedBranches(t *testing.T) {
 		manager := NewManager(repoPath)
 
 		// Create a merged branch
-		createBranch(t, repoPath, "work/merged-test")
+		createBranch(t, repoPath, "multiclaude/merged-test")
 
 		// Verify branch exists
-		exists, _ := manager.BranchExists("work/merged-test")
+		exists, _ := manager.BranchExists("multiclaude/merged-test")
 		if !exists {
 			t.Fatal("Branch should exist before cleanup")
 		}
@@ -1783,7 +1783,7 @@ func TestCleanupMergedBranches(t *testing.T) {
 		cmd.Run()
 
 		// Clean up merged branches
-		deleted, err := manager.CleanupMergedBranches("work/", false)
+		deleted, err := manager.CleanupMergedBranches("multiclaude/", false)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1793,7 +1793,7 @@ func TestCleanupMergedBranches(t *testing.T) {
 		}
 
 		// Verify branch is deleted
-		exists, _ = manager.BranchExists("work/merged-test")
+		exists, _ = manager.BranchExists("multiclaude/merged-test")
 		if exists {
 			t.Error("Branch should be deleted after cleanup")
 		}
@@ -1806,12 +1806,12 @@ func TestCleanupMergedBranches(t *testing.T) {
 		manager := NewManager(repoPath)
 
 		// Create a branch and a worktree for it
-		createBranch(t, repoPath, "work/active-branch")
+		createBranch(t, repoPath, "multiclaude/active-branch")
 
 		wtPath := filepath.Join(repoPath, "worktrees", "active")
 		os.MkdirAll(filepath.Dir(wtPath), 0755)
 
-		err := manager.Create(wtPath, "work/active-branch")
+		err := manager.Create(wtPath, "multiclaude/active-branch")
 		if err != nil {
 			t.Fatalf("Failed to create worktree: %v", err)
 		}
@@ -1827,20 +1827,20 @@ func TestCleanupMergedBranches(t *testing.T) {
 		cmd.Run()
 
 		// Clean up merged branches
-		deleted, err := manager.CleanupMergedBranches("work/", false)
+		deleted, err := manager.CleanupMergedBranches("multiclaude/", false)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
 		// The active branch should NOT be deleted
 		for _, b := range deleted {
-			if b == "work/active-branch" {
+			if b == "multiclaude/active-branch" {
 				t.Error("Active branch should not be deleted")
 			}
 		}
 
 		// Verify branch still exists
-		exists, _ := manager.BranchExists("work/active-branch")
+		exists, _ := manager.BranchExists("multiclaude/active-branch")
 		if !exists {
 			t.Error("Active branch should still exist")
 		}
@@ -2845,21 +2845,21 @@ func TestDeleteRemoteBranch(t *testing.T) {
 		}
 
 		// Create and push a branch
-		createBranch(t, repoPath, "work/to-delete")
-		cmd = exec.Command("git", "push", "-u", "origin", "work/to-delete")
+		createBranch(t, repoPath, "multiclaude/to-delete")
+		cmd = exec.Command("git", "push", "-u", "origin", "multiclaude/to-delete")
 		cmd.Dir = repoPath
 		if err := cmd.Run(); err != nil {
 			t.Fatalf("Failed to push branch: %v", err)
 		}
 
 		// Delete the remote branch
-		err = manager.DeleteRemoteBranch("origin", "work/to-delete")
+		err = manager.DeleteRemoteBranch("origin", "multiclaude/to-delete")
 		if err != nil {
 			t.Fatalf("DeleteRemoteBranch failed: %v", err)
 		}
 
 		// Verify branch was deleted from remote
-		cmd = exec.Command("git", "ls-remote", "--heads", "origin", "work/to-delete")
+		cmd = exec.Command("git", "ls-remote", "--heads", "origin", "multiclaude/to-delete")
 		cmd.Dir = repoPath
 		output, _ := cmd.Output()
 		if len(output) > 0 {
@@ -2948,10 +2948,10 @@ func TestCleanupMergedBranchesWithRemoteDeletion(t *testing.T) {
 		}
 
 		// Create a merged branch
-		createBranch(t, repoPath, "work/merged-remote")
+		createBranch(t, repoPath, "multiclaude/merged-remote")
 
 		// Push the branch
-		cmd = exec.Command("git", "push", "-u", "origin", "work/merged-remote")
+		cmd = exec.Command("git", "push", "-u", "origin", "multiclaude/merged-remote")
 		cmd.Dir = repoPath
 		if err := cmd.Run(); err != nil {
 			t.Fatalf("Failed to push branch: %v", err)
@@ -2965,7 +2965,7 @@ func TestCleanupMergedBranchesWithRemoteDeletion(t *testing.T) {
 		}
 
 		// Clean up merged branches with remote deletion
-		deleted, err := manager.CleanupMergedBranches("work/", true)
+		deleted, err := manager.CleanupMergedBranches("multiclaude/", true)
 		if err != nil {
 			t.Fatalf("CleanupMergedBranches failed: %v", err)
 		}
@@ -2975,13 +2975,13 @@ func TestCleanupMergedBranchesWithRemoteDeletion(t *testing.T) {
 		}
 
 		// Verify local branch is deleted
-		exists, _ := manager.BranchExists("work/merged-remote")
+		exists, _ := manager.BranchExists("multiclaude/merged-remote")
 		if exists {
 			t.Error("Local branch should be deleted")
 		}
 
 		// Verify remote branch is deleted
-		cmd = exec.Command("git", "ls-remote", "--heads", "origin", "work/merged-remote")
+		cmd = exec.Command("git", "ls-remote", "--heads", "origin", "multiclaude/merged-remote")
 		cmd.Dir = repoPath
 		output, _ := cmd.Output()
 		if len(output) > 0 {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -169,7 +169,7 @@ func TestPhase2Integration(t *testing.T) {
 
 		// Create worktree
 		wt := worktree.NewManager(repoPath)
-		if err := wt.CreateNewBranch(workerPath, "work/test-worker", "HEAD"); err != nil {
+		if err := wt.CreateNewBranch(workerPath, "multiclaude/test-worker", "HEAD"); err != nil {
 			t.Fatalf("Failed to create worktree: %v", err)
 		}
 


### PR DESCRIPTION
## Summary

Standardizes worker branch naming from `work/` to `multiclaude/` prefix for better namespace clarity and consistency.

## Changes

- Updated branch prefix from `work/` to `multiclaude/` across codebase
- Maintains backward compatibility for cleanup of legacy `work/` branches
- Updated all related tests

## Files Changed

- `internal/cli/cli.go` - Branch creation logic
- `internal/daemon/daemon.go` - Daemon branch handling
- `internal/worktree/worktree.go` - Worktree branch naming
- Tests updated accordingly

## Test Plan

- [x] Build succeeds: `go build ./...`
- [x] Worktree tests pass: `go test ./internal/worktree/...`
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)