### PR TITLE
feat: Add GitHub CLI authentication verification

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -391,3 +391,51 @@ func WorkspaceNotFound(name, repo string) *CLIError {
 		Suggestion: fmt.Sprintf("multiclaude workspace list --repo %s", repo),
 	}
 }
+
+// GitHub CLI authentication error constructors
+
+// GitHubCLINotFound creates an error for when the gh CLI is not installed
+func GitHubCLINotFound() *CLIError {
+	return &CLIError{
+		Category:   CategoryConfig,
+		Message:    "GitHub CLI (gh) not found in PATH",
+		Suggestion: "install gh CLI: https://cli.github.com/",
+	}
+}
+
+// GitHubNotAuthenticated creates an error for when the user is not logged in
+func GitHubNotAuthenticated() *CLIError {
+	return &CLIError{
+		Category:   CategoryConfig,
+		Message:    "not authenticated with GitHub",
+		Suggestion: "gh auth login",
+	}
+}
+
+// GitHubAuthScopesMissing creates an error for missing OAuth scopes
+func GitHubAuthScopesMissing(missing []string) *CLIError {
+	return &CLIError{
+		Category:   CategoryConfig,
+		Message:    fmt.Sprintf("missing required OAuth scopes: %s", strings.Join(missing, ", ")),
+		Suggestion: "gh auth refresh -s repo",
+	}
+}
+
+// GitHubRepoAccessDenied creates an error for insufficient repository permissions
+func GitHubRepoAccessDenied(owner, repo, requiredPerm string) *CLIError {
+	return &CLIError{
+		Category:   CategoryConfig,
+		Message:    fmt.Sprintf("insufficient permissions on %s/%s (requires %s)", owner, repo, requiredPerm),
+		Suggestion: "request access from repository owner or check repository visibility",
+	}
+}
+
+// GitHubAPIFailed creates an error for GitHub API failures
+func GitHubAPIFailed(operation string, cause error) *CLIError {
+	return &CLIError{
+		Category:   CategoryRuntime,
+		Message:    fmt.Sprintf("GitHub API call failed: %s", operation),
+		Cause:      cause,
+		Suggestion: "check your network connection and GitHub status",
+	}
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -577,3 +577,108 @@ func TestWorkspaceNotFound(t *testing.T) {
 		t.Errorf("expected workspace list suggestion, got: %s", formatted)
 	}
 }
+
+// GitHub CLI error constructor tests
+
+func TestGitHubCLINotFound(t *testing.T) {
+	err := GitHubCLINotFound()
+
+	if err.Category != CategoryConfig {
+		t.Errorf("expected CategoryConfig, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "gh") {
+		t.Errorf("expected 'gh' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "cli.github.com") {
+		t.Errorf("expected install URL in suggestion, got: %s", formatted)
+	}
+}
+
+func TestGitHubNotAuthenticated(t *testing.T) {
+	err := GitHubNotAuthenticated()
+
+	if err.Category != CategoryConfig {
+		t.Errorf("expected CategoryConfig, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "not authenticated") {
+		t.Errorf("expected 'not authenticated' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "gh auth login") {
+		t.Errorf("expected 'gh auth login' suggestion, got: %s", formatted)
+	}
+}
+
+func TestGitHubAuthScopesMissing(t *testing.T) {
+	missing := []string{"repo", "read:org"}
+	err := GitHubAuthScopesMissing(missing)
+
+	if err.Category != CategoryConfig {
+		t.Errorf("expected CategoryConfig, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "repo") {
+		t.Errorf("expected 'repo' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "read:org") {
+		t.Errorf("expected 'read:org' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "gh auth refresh") {
+		t.Errorf("expected 'gh auth refresh' suggestion, got: %s", formatted)
+	}
+}
+
+func TestGitHubRepoAccessDenied(t *testing.T) {
+	err := GitHubRepoAccessDenied("owner", "repo", "push")
+
+	if err.Category != CategoryConfig {
+		t.Errorf("expected CategoryConfig, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "owner/repo") {
+		t.Errorf("expected 'owner/repo' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "push") {
+		t.Errorf("expected 'push' in message, got: %s", formatted)
+	}
+}
+
+func TestGitHubAPIFailed(t *testing.T) {
+	cause := errors.New("connection refused")
+	err := GitHubAPIFailed("fetching repository", cause)
+
+	if err.Category != CategoryRuntime {
+		t.Errorf("expected CategoryRuntime, got %v", err.Category)
+	}
+	if err.Cause != cause {
+		t.Error("should wrap cause")
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "fetching repository") {
+		t.Errorf("expected operation in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "connection refused") {
+		t.Errorf("expected cause in message, got: %s", formatted)
+	}
+}

--- a/internal/github/auth.go
+++ b/internal/github/auth.go
@@ -1,0 +1,247 @@
+// Package github provides GitHub CLI authentication verification utilities.
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// AuthStatus represents the current GitHub CLI authentication status.
+type AuthStatus struct {
+	Authenticated bool
+	Username      string
+	Scopes        []string
+}
+
+// RepoPermissions represents the user's permissions on a specific repository.
+type RepoPermissions struct {
+	Owner    string
+	Repo     string
+	Pull     bool
+	Push     bool
+	Maintain bool
+	Admin    bool
+}
+
+// VerifyResult contains the combined result of all verification checks.
+type VerifyResult struct {
+	AuthStatus      *AuthStatus
+	Scopes          *ScopesResult
+	RepoPermissions *RepoPermissions
+	Errors          []error
+}
+
+// ScopesResult contains the result of scope verification.
+type ScopesResult struct {
+	HasRequired bool
+	Present     []string
+	Missing     []string
+}
+
+// RequiredScopes is the list of OAuth scopes required for full functionality.
+var RequiredScopes = []string{"repo"}
+
+// CheckAuth verifies that the gh CLI is installed and the user is authenticated.
+func CheckAuth() (*AuthStatus, error) {
+	// Check if gh CLI is installed
+	if _, err := exec.LookPath("gh"); err != nil {
+		return nil, fmt.Errorf("gh CLI not found: %w", err)
+	}
+
+	// Check authentication status
+	cmd := exec.Command("gh", "auth", "status", "--show-token")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Not authenticated or error
+		if strings.Contains(string(output), "not logged in") ||
+			strings.Contains(string(output), "authentication required") {
+			return &AuthStatus{Authenticated: false}, nil
+		}
+		return nil, fmt.Errorf("failed to check auth status: %w", err)
+	}
+
+	// Parse auth status output for username and scopes
+	status := &AuthStatus{Authenticated: true}
+	lines := strings.Split(string(output), "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		// Look for "Logged in to github.com account username (keyring)"
+		if strings.Contains(line, "Logged in to") && strings.Contains(line, "account") {
+			parts := strings.Split(line, "account")
+			if len(parts) > 1 {
+				// Extract username - format is "account username (" or similar
+				rest := strings.TrimSpace(parts[1])
+				if idx := strings.Index(rest, " "); idx > 0 {
+					status.Username = rest[:idx]
+				} else if idx := strings.Index(rest, "("); idx > 0 {
+					status.Username = strings.TrimSpace(rest[:idx])
+				} else {
+					status.Username = rest
+				}
+			}
+		}
+
+		// Look for "Token scopes:" line
+		if strings.HasPrefix(line, "- Token scopes:") || strings.HasPrefix(line, "Token scopes:") {
+			scopesPart := strings.TrimPrefix(line, "- Token scopes:")
+			scopesPart = strings.TrimPrefix(scopesPart, "Token scopes:")
+			scopesPart = strings.TrimSpace(scopesPart)
+			if scopesPart != "" && scopesPart != "''" && scopesPart != "(none)" {
+				scopes := strings.Split(scopesPart, ",")
+				for _, s := range scopes {
+					s = strings.TrimSpace(s)
+					s = strings.Trim(s, "'")
+					if s != "" {
+						status.Scopes = append(status.Scopes, s)
+					}
+				}
+			}
+		}
+	}
+
+	return status, nil
+}
+
+// CheckRequiredScopes verifies that the token has the required OAuth scopes.
+func CheckRequiredScopes(scopes []string) *ScopesResult {
+	result := &ScopesResult{
+		HasRequired: true,
+		Present:     []string{},
+		Missing:     []string{},
+	}
+
+	scopeSet := make(map[string]bool)
+	for _, s := range scopes {
+		scopeSet[s] = true
+	}
+
+	for _, required := range RequiredScopes {
+		if scopeSet[required] {
+			result.Present = append(result.Present, required)
+		} else {
+			result.Missing = append(result.Missing, required)
+			result.HasRequired = false
+		}
+	}
+
+	return result
+}
+
+// CheckRepoPermissions checks the user's permissions on a specific repository.
+func CheckRepoPermissions(owner, repo string) (*RepoPermissions, error) {
+	// Check if gh CLI is installed
+	if _, err := exec.LookPath("gh"); err != nil {
+		return nil, fmt.Errorf("gh CLI not found: %w", err)
+	}
+
+	// Use gh api to get repository permissions
+	cmd := exec.Command("gh", "api", fmt.Sprintf("repos/%s/%s", owner, repo),
+		"--jq", ".permissions")
+	output, err := cmd.Output()
+	if err != nil {
+		// Check if it's a not found error
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exitErr.Stderr)
+			if strings.Contains(stderr, "Not Found") ||
+				strings.Contains(stderr, "404") {
+				return nil, fmt.Errorf("repository %s/%s not found or not accessible", owner, repo)
+			}
+		}
+		return nil, fmt.Errorf("failed to check repository permissions: %w", err)
+	}
+
+	// Parse permissions JSON
+	var perms struct {
+		Pull     bool `json:"pull"`
+		Push     bool `json:"push"`
+		Maintain bool `json:"maintain"`
+		Admin    bool `json:"admin"`
+	}
+
+	if err := json.Unmarshal(output, &perms); err != nil {
+		return nil, fmt.Errorf("failed to parse permissions: %w", err)
+	}
+
+	return &RepoPermissions{
+		Owner:    owner,
+		Repo:     repo,
+		Pull:     perms.Pull,
+		Push:     perms.Push,
+		Maintain: perms.Maintain,
+		Admin:    perms.Admin,
+	}, nil
+}
+
+// VerifyAuthForRepo performs all verification checks for a repository.
+// If repoRef is empty, only basic auth and scope checks are performed.
+func VerifyAuthForRepo(repoRef string) *VerifyResult {
+	result := &VerifyResult{
+		Errors: []error{},
+	}
+
+	// Check basic authentication
+	auth, err := CheckAuth()
+	if err != nil {
+		result.Errors = append(result.Errors, err)
+		return result
+	}
+	result.AuthStatus = auth
+
+	if !auth.Authenticated {
+		result.Errors = append(result.Errors, fmt.Errorf("not authenticated with GitHub"))
+		return result
+	}
+
+	// Check required scopes
+	result.Scopes = CheckRequiredScopes(auth.Scopes)
+	if !result.Scopes.HasRequired {
+		result.Errors = append(result.Errors,
+			fmt.Errorf("missing required OAuth scopes: %v", result.Scopes.Missing))
+	}
+
+	// Check repository permissions if repo specified
+	if repoRef != "" {
+		owner, repo, err := ParseRepoRef(repoRef)
+		if err != nil {
+			result.Errors = append(result.Errors, err)
+			return result
+		}
+
+		perms, err := CheckRepoPermissions(owner, repo)
+		if err != nil {
+			result.Errors = append(result.Errors, err)
+		} else {
+			result.RepoPermissions = perms
+			if !perms.Push {
+				result.Errors = append(result.Errors,
+					fmt.Errorf("no push access to %s/%s", owner, repo))
+			}
+		}
+	}
+
+	return result
+}
+
+// ParseRepoRef parses a repository reference in the form "owner/repo".
+func ParseRepoRef(ref string) (owner, repo string, err error) {
+	ref = strings.TrimSpace(ref)
+
+	// Handle URL format (e.g., https://github.com/owner/repo)
+	if strings.HasPrefix(ref, "https://") || strings.HasPrefix(ref, "http://") {
+		ref = strings.TrimPrefix(ref, "https://")
+		ref = strings.TrimPrefix(ref, "http://")
+		ref = strings.TrimPrefix(ref, "github.com/")
+		ref = strings.TrimSuffix(ref, ".git")
+	}
+
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid repository reference: %s (expected owner/repo)", ref)
+	}
+
+	return parts[0], parts[1], nil
+}

--- a/internal/github/auth_test.go
+++ b/internal/github/auth_test.go
@@ -1,0 +1,254 @@
+package github
+
+import (
+	"testing"
+)
+
+func TestParseRepoRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{
+			name:      "simple owner/repo",
+			input:     "owner/repo",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "with https URL",
+			input:     "https://github.com/owner/repo",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "with http URL",
+			input:     "http://github.com/owner/repo",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "with .git suffix",
+			input:     "https://github.com/owner/repo.git",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "with whitespace",
+			input:     "  owner/repo  ",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:    "missing repo",
+			input:   "owner/",
+			wantErr: true,
+		},
+		{
+			name:    "missing owner",
+			input:   "/repo",
+			wantErr: true,
+		},
+		{
+			name:    "no slash",
+			input:   "ownerrepo",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, err := ParseRepoRef(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseRepoRef(%q) expected error, got none", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ParseRepoRef(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("ParseRepoRef(%q) owner = %q, want %q", tt.input, owner, tt.wantOwner)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("ParseRepoRef(%q) repo = %q, want %q", tt.input, repo, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestCheckRequiredScopes(t *testing.T) {
+	tests := []struct {
+		name        string
+		scopes      []string
+		wantHas     bool
+		wantPresent []string
+		wantMissing []string
+	}{
+		{
+			name:        "has all required scopes",
+			scopes:      []string{"repo", "read:org", "gist"},
+			wantHas:     true,
+			wantPresent: []string{"repo"},
+			wantMissing: []string{},
+		},
+		{
+			name:        "missing repo scope",
+			scopes:      []string{"read:org", "gist"},
+			wantHas:     false,
+			wantPresent: []string{},
+			wantMissing: []string{"repo"},
+		},
+		{
+			name:        "empty scopes",
+			scopes:      []string{},
+			wantHas:     false,
+			wantPresent: []string{},
+			wantMissing: []string{"repo"},
+		},
+		{
+			name:        "only repo scope",
+			scopes:      []string{"repo"},
+			wantHas:     true,
+			wantPresent: []string{"repo"},
+			wantMissing: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckRequiredScopes(tt.scopes)
+
+			if result.HasRequired != tt.wantHas {
+				t.Errorf("HasRequired = %v, want %v", result.HasRequired, tt.wantHas)
+			}
+
+			if len(result.Present) != len(tt.wantPresent) {
+				t.Errorf("Present = %v, want %v", result.Present, tt.wantPresent)
+			}
+			for i, want := range tt.wantPresent {
+				if i >= len(result.Present) || result.Present[i] != want {
+					t.Errorf("Present[%d] = %v, want %v", i, result.Present, tt.wantPresent)
+					break
+				}
+			}
+
+			if len(result.Missing) != len(tt.wantMissing) {
+				t.Errorf("Missing = %v, want %v", result.Missing, tt.wantMissing)
+			}
+			for i, want := range tt.wantMissing {
+				if i >= len(result.Missing) || result.Missing[i] != want {
+					t.Errorf("Missing[%d] = %v, want %v", i, result.Missing, tt.wantMissing)
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestVerifyResult_Errors(t *testing.T) {
+	// Test that VerifyResult properly collects errors
+	result := &VerifyResult{
+		Errors: []error{},
+	}
+
+	if len(result.Errors) != 0 {
+		t.Error("expected empty errors slice")
+	}
+
+	// Test that auth status can be nil
+	if result.AuthStatus != nil {
+		t.Error("expected nil AuthStatus")
+	}
+
+	// Test that scopes can be nil
+	if result.Scopes != nil {
+		t.Error("expected nil Scopes")
+	}
+
+	// Test that repo permissions can be nil
+	if result.RepoPermissions != nil {
+		t.Error("expected nil RepoPermissions")
+	}
+}
+
+func TestAuthStatus_Fields(t *testing.T) {
+	status := &AuthStatus{
+		Authenticated: true,
+		Username:      "testuser",
+		Scopes:        []string{"repo", "gist"},
+	}
+
+	if !status.Authenticated {
+		t.Error("expected Authenticated to be true")
+	}
+	if status.Username != "testuser" {
+		t.Errorf("Username = %q, want %q", status.Username, "testuser")
+	}
+	if len(status.Scopes) != 2 {
+		t.Errorf("Scopes = %v, want 2 items", status.Scopes)
+	}
+}
+
+func TestRepoPermissions_Fields(t *testing.T) {
+	perms := &RepoPermissions{
+		Owner:    "owner",
+		Repo:     "repo",
+		Pull:     true,
+		Push:     true,
+		Maintain: false,
+		Admin:    false,
+	}
+
+	if perms.Owner != "owner" {
+		t.Errorf("Owner = %q, want %q", perms.Owner, "owner")
+	}
+	if perms.Repo != "repo" {
+		t.Errorf("Repo = %q, want %q", perms.Repo, "repo")
+	}
+	if !perms.Pull {
+		t.Error("expected Pull to be true")
+	}
+	if !perms.Push {
+		t.Error("expected Push to be true")
+	}
+	if perms.Maintain {
+		t.Error("expected Maintain to be false")
+	}
+	if perms.Admin {
+		t.Error("expected Admin to be false")
+	}
+}
+
+func TestScopesResult_Fields(t *testing.T) {
+	result := &ScopesResult{
+		HasRequired: true,
+		Present:     []string{"repo"},
+		Missing:     []string{},
+	}
+
+	if !result.HasRequired {
+		t.Error("expected HasRequired to be true")
+	}
+	if len(result.Present) != 1 || result.Present[0] != "repo" {
+		t.Errorf("Present = %v, want [repo]", result.Present)
+	}
+	if len(result.Missing) != 0 {
+		t.Errorf("Missing = %v, want empty", result.Missing)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `multiclaude auth check [owner/repo]` command to verify GitHub CLI authentication and repository permissions
- Add `internal/github` package with auth verification logic  
- Add 5 new error constructors in `internal/errors` for auth-related errors

This helps diagnose permission issues early, addressing the need identified in PR #186.

## Changes

### New `internal/github` package
- `CheckAuth()` - verifies gh CLI is installed and user is authenticated
- `CheckRequiredScopes()` - ensures token has required OAuth scopes (e.g., `repo`)
- `CheckRepoPermissions()` - checks user's permissions on a specific repository
- `VerifyAuthForRepo()` - combines all checks for pre-operation verification
- `ParseRepoRef()` - parses owner/repo format from various URL formats

### New `auth check` CLI command
```bash
# Check basic auth status
multiclaude auth check

# Also check repo permissions
multiclaude auth check owner/repo
```

Example output:
```
Checking GitHub CLI authentication...

  Authenticated: yes
  Username: example
  Token scopes: gist, read:org, repo
  Required scopes: present

Checking permissions on owner/repo...
  Pull: true
  Push: false
  Maintain: false
  Admin: false

Warning: You don't have push access to this repository.
Merge queue operations will fail without push permissions.
```

### New error constructors
- `GitHubCLINotFound()` - gh CLI not installed
- `GitHubNotAuthenticated()` - user not logged in
- `GitHubAuthScopesMissing()` - required OAuth scopes not granted
- `GitHubRepoAccessDenied()` - insufficient repo permissions
- `GitHubAPIFailed()` - GitHub API call failed

## Test plan
- [x] All existing tests pass
- [x] New tests for error constructors
- [x] New tests for github package (ParseRepoRef, CheckRequiredScopes, etc.)
- [x] Build succeeds
- [x] CLI docs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)