### PR TITLE
feat: add multiclaude refresh command for on-demand worktree sync

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -644,6 +644,9 @@ func (d *Daemon) handleRequest(req socket.Request) socket.Response {
 	case "spawn_agent":
 		return d.handleSpawnAgent(req)
 
+	case "trigger_refresh":
+		return d.handleTriggerRefresh(req)
+
 	default:
 		return socket.Response{
 			Success: false,
@@ -1144,6 +1147,19 @@ func (d *Daemon) handleTriggerCleanup(req socket.Request) socket.Response {
 	return socket.Response{
 		Success: true,
 		Data:    "Cleanup triggered",
+	}
+}
+
+// handleTriggerRefresh manually triggers worktree refresh for all agents
+func (d *Daemon) handleTriggerRefresh(req socket.Request) socket.Response {
+	d.logger.Info("Manual worktree refresh triggered")
+
+	// Run refresh in background so we can return immediately
+	go d.refreshWorktrees()
+
+	return socket.Response{
+		Success: true,
+		Data:    "Worktree refresh triggered",
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `trigger_refresh` socket command in daemon for programmatic refresh triggering
- Adds `multiclaude refresh` CLI command that triggers immediate worktree sync
- Allows merge-queue or users to force refresh after PRs merge instead of waiting for 5-minute polling interval

Addresses P0 roadmap item "Worktree sync: Keep agent worktrees in sync with main as PRs merge"

## Changes

| File | Change |
|------|--------|
| `internal/daemon/daemon.go` | Added `handleTriggerRefresh` handler and `trigger_refresh` socket command |
| `internal/cli/cli.go` | Added `refresh` command registration and implementation |

## Test plan

- [x] `go build ./cmd/multiclaude` - compiles successfully
- [x] `go test ./internal/daemon/...` - all tests pass
- [x] `go test ./internal/cli/...` - all tests pass
- [x] Manual test: `multiclaude refresh` triggers refresh and shows success message
- [x] Daemon logs confirm refresh is executed

## Usage

```bash
# Trigger immediate worktree refresh for all agents
multiclaude refresh
```

🤖 Generated with [Claude Code](https://claude.ai/code)