### PR TITLE
feat: add multiclaude status command for system overview

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -320,6 +320,14 @@ func (c *CLI) registerCommands() {
 		Run:         c.startDaemon,
 	}
 
+	// Root-level status command - comprehensive system overview
+	c.rootCmd.Subcommands["status"] = &Command{
+		Name:        "status",
+		Description: "Show system status overview",
+		Usage:       "multiclaude status",
+		Run:         c.systemStatus,
+	}
+
 	daemonCmd := &Command{
 		Name:        "daemon",
 		Description: "Manage the multiclaude daemon",
@@ -798,6 +806,112 @@ func (c *CLI) daemonStatus(args []string) error {
 		fmt.Println(string(jsonData))
 	}
 
+	return nil
+}
+
+// systemStatus shows a comprehensive system overview that gracefully handles
+// the daemon not running (unlike list commands which error).
+func (c *CLI) systemStatus(args []string) error {
+	// Check PID file first
+	pidFile := daemon.NewPIDFile(c.paths.DaemonPID)
+	running, pid, err := pidFile.IsRunning()
+	if err != nil {
+		return fmt.Errorf("failed to check daemon status: %w", err)
+	}
+
+	if !running {
+		format.Header("Multiclaude Status")
+		fmt.Println()
+		fmt.Printf("  Daemon: %s\n", format.Red.Sprint("not running"))
+		fmt.Println()
+		format.Dimmed("Start with: multiclaude daemon start")
+		return nil
+	}
+
+	// Try to connect to daemon and get rich status
+	client := socket.NewClient(c.paths.DaemonSock)
+	resp, err := client.Send(socket.Request{
+		Command: "list_repos",
+		Args:    map[string]interface{}{"rich": true},
+	})
+
+	if err != nil {
+		format.Header("Multiclaude Status")
+		fmt.Println()
+		fmt.Printf("  Daemon: %s (PID: %d, not responding)\n", format.Yellow.Sprint("unhealthy"), pid)
+		fmt.Println()
+		format.Dimmed("Try: multiclaude daemon stop && multiclaude daemon start")
+		return nil
+	}
+
+	if !resp.Success {
+		format.Header("Multiclaude Status")
+		fmt.Println()
+		fmt.Printf("  Daemon: %s (PID: %d)\n", format.Yellow.Sprint("error"), pid)
+		fmt.Printf("  Error: %s\n", resp.Error)
+		return nil
+	}
+
+	// Print status header
+	format.Header("Multiclaude Status")
+	fmt.Println()
+	fmt.Printf("  Daemon: %s (PID: %d)\n", format.Green.Sprint("running"), pid)
+
+	repos, ok := resp.Data.([]interface{})
+	if !ok || len(repos) == 0 {
+		fmt.Printf("  Repos:  %s\n", format.Dim.Sprint("none"))
+		fmt.Println()
+		format.Dimmed("Initialize a repo with: multiclaude init <github-url>")
+		return nil
+	}
+
+	fmt.Printf("  Repos:  %d\n", len(repos))
+	fmt.Println()
+
+	// Show each repo with agents
+	for _, repo := range repos {
+		repoMap, ok := repo.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		name, _ := repoMap["name"].(string)
+		totalAgents := 0
+		if v, ok := repoMap["total_agents"].(float64); ok {
+			totalAgents = int(v)
+		}
+		workerCount := 0
+		if v, ok := repoMap["worker_count"].(float64); ok {
+			workerCount = int(v)
+		}
+		sessionHealthy, _ := repoMap["session_healthy"].(bool)
+
+		// Repo line
+		repoStatus := format.Green.Sprint("●")
+		if !sessionHealthy {
+			repoStatus = format.Yellow.Sprint("○")
+		}
+		fmt.Printf("  %s %s\n", repoStatus, format.Bold.Sprint(name))
+
+		// Agent summary
+		coreAgents := totalAgents - workerCount
+		if coreAgents < 0 {
+			coreAgents = 0
+		}
+		fmt.Printf("      Agents: %d core, %d workers\n", coreAgents, workerCount)
+
+		// Show fork info if applicable
+		if isFork, _ := repoMap["is_fork"].(bool); isFork {
+			upstreamOwner, _ := repoMap["upstream_owner"].(string)
+			upstreamRepo, _ := repoMap["upstream_repo"].(string)
+			if upstreamOwner != "" && upstreamRepo != "" {
+				fmt.Printf("      Fork of: %s/%s\n", upstreamOwner, upstreamRepo)
+			}
+		}
+	}
+
+	fmt.Println()
+	format.Dimmed("Details: multiclaude repo list | multiclaude worker list")
 	return nil
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -399,6 +399,51 @@ func TestCLIDaemonStatus(t *testing.T) {
 	}
 }
 
+func TestCLISystemStatusWithDaemon(t *testing.T) {
+	cli, d, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// System status with daemon running but no repos
+	err := cli.Execute([]string{"status"})
+	if err != nil {
+		t.Errorf("system status failed: %v", err)
+	}
+
+	// Add a repo and check again
+	repo := &state.Repository{
+		GithubURL:   "https://github.com/test/repo",
+		TmuxSession: "mc-test-repo",
+		Agents:      make(map[string]state.Agent),
+	}
+	if err := d.GetState().AddRepo("test-repo", repo); err != nil {
+		t.Fatalf("Failed to add repo: %v", err)
+	}
+
+	// System status should show the repo
+	err = cli.Execute([]string{"status"})
+	if err != nil {
+		t.Errorf("system status with repo failed: %v", err)
+	}
+}
+
+func TestCLISystemStatusWithoutDaemon(t *testing.T) {
+	// Create CLI without starting daemon
+	tmpDir, err := os.MkdirTemp("", "cli-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	paths := config.NewTestPaths(tmpDir)
+	cli := NewWithPaths(paths)
+
+	// System status should NOT error when daemon not running
+	err = cli.Execute([]string{"status"})
+	if err != nil {
+		t.Errorf("system status should not error when daemon not running: %v", err)
+	}
+}
+
 func TestCLIWorkListEmpty(t *testing.T) {
 	cli, d, cleanup := setupTestEnvironment(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

- Adds new `multiclaude status` command that shows system overview
- Gracefully handles daemon not running (shows "not running" instead of erroring)
- Shows tracked repos with agent counts in a compact format
- More memorable name than `multiclaude list`

Closes #305

## Test plan

- [x] Added unit tests for status with daemon running
- [x] Added unit test for status without daemon (verifies no error)
- [x] Manual testing confirmed output is readable
- [x] Existing tests pass

## Example output

```
Multiclaude Status

  Daemon: running (PID: 59827)
  Repos:  4

  ● multiclaude
      Agents: 2 core, 3 workers
  ● multiclaude-ui
      Agents: 2 core, 0 workers

Details: multiclaude repo list | multiclaude worker list
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)