### PR TITLE
feat: add OpenSpec proposal for repo lifecycle management

### DIFF
--- a/openspec/changes/add-repo-lifecycle/design.md
+++ b/openspec/changes/add-repo-lifecycle/design.md
@@ -1,0 +1,166 @@
+# Design: Repo Lifecycle Management
+
+## Context
+
+Users interact with multiclaude through fragmented commands that don't provide a cohesive "session" experience. Starting work on a repo requires multiple commands, and there's no way to pause/resume work or get comprehensive status.
+
+**Stakeholders**: CLI users, automation scripts, external tools (TUI, web dashboard)
+
+**Constraints**:
+- Must be backward compatible (existing commands unchanged)
+- State changes must be atomic (crash-safe)
+- Output formats must be consistent across commands
+
+## Goals / Non-Goals
+
+### Goals
+- Unified repo lifecycle: start → work → hibernate → wake → clean
+- Comprehensive status in single command
+- Machine-readable output for tooling integration
+- Interactive TUI for power users
+- WebSocket streaming for external dashboards
+
+### Non-Goals
+- Web UI (separate project: multiclaude-ui)
+- Multi-machine coordination
+- Cloud sync of hibernation state
+
+## Decisions
+
+### Decision 1: Hibernation vs Stop
+
+**What**: Hibernate preserves agent configuration for later resume. Stop terminates completely.
+
+**Why**: Users often context-switch between repos. Hibernate allows quick resume without re-specifying agent configuration.
+
+**Alternatives considered**:
+- Just use stop/start: Loses agent configuration and task context
+- Auto-save always: Adds complexity, may save unwanted state
+
+### Decision 2: Output Format Architecture
+
+**What**: All commands use `OutputFormatter` interface with implementations for text/json/yaml.
+
+```go
+type OutputFormatter interface {
+    FormatStatus(status *RepoStatus) ([]byte, error)
+    FormatList(repos []RepoInfo) ([]byte, error)
+    FormatResult(result *CommandResult) ([]byte, error)
+}
+```
+
+**Why**: Consistent formatting, easy to add new formats, testable.
+
+**Alternatives considered**:
+- Per-command formatting: Leads to inconsistency
+- Template-based: Harder to maintain, less flexible
+
+### Decision 3: TUI Library
+
+**What**: Use [bubbletea](https://github.com/charmbracelet/bubbletea) for TUI.
+
+**Why**:
+- Popular in Go ecosystem (more LLM training data)
+- Elm architecture is simple and testable
+- Good accessibility support
+- Active maintenance
+
+**Alternatives considered**:
+- [tview](https://github.com/rivo/tview): More traditional, less modern feel
+- Custom: Too much work, maintenance burden
+
+### Decision 4: WebSocket Protocol
+
+**What**: JSON messages over WebSocket with message types.
+
+```json
+{
+  "type": "status_update",
+  "repo": "myrepo",
+  "data": { /* RepoStatus JSON */ }
+}
+```
+
+**Why**: Simple, standard, easy to consume from any language.
+
+**Alternatives considered**:
+- gRPC streaming: Overkill for local use
+- Server-Sent Events: Less bidirectional capability
+
+### Decision 5: Refresh Strategy
+
+**What**: Parallel worktree rebase with continue-on-failure.
+
+**Why**:
+- Don't block all worktrees if one has conflicts
+- Report all issues at once
+- User can address conflicts selectively
+
+**Alternatives considered**:
+- Sequential: Slower, stops at first failure
+- Merge instead of rebase: Creates merge commits, messier history
+
+## Data Model Changes
+
+### State.json Extensions
+
+```go
+type Repository struct {
+    // ... existing fields ...
+
+    // New fields
+    Status          RepoStatus       `json:"status"`           // active, hibernated
+    HibernatedAt    *time.Time       `json:"hibernated_at"`    // when hibernated
+    HibernationData *HibernationData `json:"hibernation_data"` // preserved state
+}
+
+type RepoStatus string
+
+const (
+    RepoStatusActive      RepoStatus = "active"
+    RepoStatusHibernated  RepoStatus = "hibernated"
+    RepoStatusUninitialized RepoStatus = "uninitialized"
+)
+
+type HibernationData struct {
+    Agents    map[string]AgentConfig `json:"agents"`     // agent configs to restore
+    Timestamp time.Time              `json:"timestamp"`
+}
+
+type AgentConfig struct {
+    Type    AgentType `json:"type"`
+    Task    string    `json:"task,omitempty"`
+    Branch  string    `json:"branch,omitempty"`
+}
+```
+
+## Risks / Trade-offs
+
+### Risk: Hibernation state becomes stale
+- **Mitigation**: Warn if hibernation > 7 days old
+- **Mitigation**: Offer `--fresh` flag to ignore hibernation state
+
+### Risk: WebSocket adds daemon complexity
+- **Mitigation**: Make it opt-in (only when --websocket flag used)
+- **Mitigation**: Separate goroutine, isolated from main daemon logic
+
+### Risk: TUI dependency adds bloat
+- **Mitigation**: Lazy-load TUI (only import when --tui used)
+- **Mitigation**: Consider making TUI a separate binary
+
+### Trade-off: Parallel refresh can leave partial state
+- **Accepted**: Better than blocking. Clear error reporting mitigates.
+
+## Migration Plan
+
+1. **Phase 1** (this change): Core commands (start, status, hibernate, wake, refresh, clean)
+2. **Phase 2**: TUI mode
+3. **Phase 3**: WebSocket streaming
+
+No breaking changes. Existing commands continue to work.
+
+## Open Questions
+
+1. Should `repo start` be the default when running `multiclaude` with a repo argument?
+2. Should hibernation auto-expire after N days?
+3. Should WebSocket require authentication for security?

--- a/openspec/changes/add-repo-lifecycle/proposal.md
+++ b/openspec/changes/add-repo-lifecycle/proposal.md
@@ -1,0 +1,48 @@
+# Change: Add Repo Lifecycle Management Commands
+
+## Why
+
+Currently, multiclaude has fragmented commands for managing repositories:
+- `repo init/list/rm` for basic repo tracking
+- `daemon start/stop` for the global daemon
+- `worker create/list/rm` for individual workers
+- `agents spawn` for persistent agents
+
+There's no unified way to:
+1. **Start** a full repo session (supervisor + merge-queue + workspace)
+2. Get **comprehensive status** of all repo activity
+3. **Hibernate** a repo (pause agents without losing state)
+4. **Refresh** all worktrees atomically
+5. **Clean** orphaned resources for a specific repo
+
+Users must manually orchestrate these operations, leading to inconsistent states.
+
+## What Changes
+
+Add new `repo` subcommands for complete lifecycle management:
+
+| Command | Purpose |
+|---------|---------|
+| `repo start [name]` | Start all agents (supervisor, merge-queue, workspace) |
+| `repo status [name]` | Comprehensive status with agents, PRs, messages, health |
+| `repo hibernate [name]` | Pause all agents, preserve state |
+| `repo wake [name]` | Resume hibernated repo |
+| `repo refresh [name]` | Sync all worktrees with main branch |
+| `repo clean [name]` | Clean orphaned resources for repo |
+
+Add output format options to all commands:
+- `--format=text` (default) - Human-readable
+- `--format=json` - Machine-readable JSON
+- `--format=yaml` - YAML output
+- `--tui` - Interactive terminal UI
+- `--websocket` - Stream to WebSocket server
+
+## Impact
+
+- **Affected specs**: New capability (repo-lifecycle)
+- **Affected code**:
+  - `multiclaude/internal/cli/cli.go` - New commands
+  - `multiclaude/internal/daemon/daemon.go` - Hibernate/wake support
+  - `multiclaude/internal/state/state.go` - Hibernation state
+- **Breaking changes**: None (additive only)
+- **Dependencies**: TUI requires new dependency (bubbletea or similar)

--- a/openspec/changes/add-repo-lifecycle/specs/repo-lifecycle/spec.md
+++ b/openspec/changes/add-repo-lifecycle/specs/repo-lifecycle/spec.md
@@ -1,0 +1,176 @@
+# Repo Lifecycle Management
+
+## ADDED Requirements
+
+### Requirement: Repo Start Command
+The system SHALL provide a `repo start [name]` command that initializes all standard agents for a repository.
+
+#### Scenario: Start repo with default agents
+- **WHEN** user runs `multiclaude repo start myrepo`
+- **THEN** system spawns supervisor, merge-queue, and workspace agents
+- **AND** all agents are running in tmux session `mc-myrepo`
+- **AND** command returns success with agent summary
+
+#### Scenario: Start repo already running
+- **WHEN** user runs `multiclaude repo start myrepo` on running repo
+- **THEN** system reports current status without spawning duplicates
+- **AND** suggests using `repo status` for detailed view
+
+#### Scenario: Start with specific agents
+- **WHEN** user runs `multiclaude repo start myrepo --agents=supervisor,workspace`
+- **THEN** system spawns only specified agents
+- **AND** merge-queue is not started
+
+### Requirement: Repo Status Command
+The system SHALL provide a `repo status [name]` command that displays comprehensive repository state.
+
+#### Scenario: Full status display
+- **WHEN** user runs `multiclaude repo status myrepo`
+- **THEN** system displays:
+  - Agent list with type, status, task, last activity
+  - Open PRs with mergeable state and CI status
+  - Pending messages count per agent
+  - Worktree sync status (ahead/behind main)
+  - Health indicators
+
+#### Scenario: Status with JSON output
+- **WHEN** user runs `multiclaude repo status myrepo --format=json`
+- **THEN** system outputs structured JSON with all status fields
+- **AND** output is machine-parseable
+
+#### Scenario: Status with YAML output
+- **WHEN** user runs `multiclaude repo status myrepo --format=yaml`
+- **THEN** system outputs YAML-formatted status
+- **AND** output follows standard YAML conventions
+
+#### Scenario: Status in TUI mode
+- **WHEN** user runs `multiclaude repo status myrepo --tui`
+- **THEN** system launches interactive terminal UI
+- **AND** UI updates in real-time as state changes
+- **AND** user can navigate with keyboard
+
+### Requirement: Repo Hibernate Command
+The system SHALL provide a `repo hibernate [name]` command that pauses all agents while preserving state.
+
+#### Scenario: Hibernate active repo
+- **WHEN** user runs `multiclaude repo hibernate myrepo`
+- **THEN** system gracefully stops all agents
+- **AND** agent state is saved to disk
+- **AND** worktrees are preserved
+- **AND** messages are preserved
+- **AND** repo is marked as hibernated in state.json
+
+#### Scenario: Hibernate with timeout
+- **WHEN** user runs `multiclaude repo hibernate myrepo --timeout=30s`
+- **THEN** system waits up to 30s for graceful shutdown
+- **AND** force-kills agents after timeout
+
+#### Scenario: Hibernate already hibernated repo
+- **WHEN** user runs `multiclaude repo hibernate myrepo` on hibernated repo
+- **THEN** system reports repo is already hibernated
+- **AND** no changes are made
+
+### Requirement: Repo Wake Command
+The system SHALL provide a `repo wake [name]` command that resumes a hibernated repository.
+
+#### Scenario: Wake hibernated repo
+- **WHEN** user runs `multiclaude repo wake myrepo`
+- **THEN** system restores all previously active agents
+- **AND** agents resume with their saved state
+- **AND** messages are delivered to awakened agents
+- **AND** repo is marked as active
+
+#### Scenario: Wake with fresh state
+- **WHEN** user runs `multiclaude repo wake myrepo --fresh`
+- **THEN** system starts default agents (supervisor, merge-queue, workspace)
+- **AND** previous agent state is discarded
+
+#### Scenario: Wake non-hibernated repo
+- **WHEN** user runs `multiclaude repo wake myrepo` on active repo
+- **THEN** system reports repo is already active
+- **AND** suggests using `repo status`
+
+### Requirement: Repo Refresh Command
+The system SHALL provide a `repo refresh [name]` command that syncs all worktrees with main branch.
+
+#### Scenario: Refresh all worktrees
+- **WHEN** user runs `multiclaude repo refresh myrepo`
+- **THEN** system fetches latest from remote
+- **AND** rebases each worktree onto main
+- **AND** reports success/failure per worktree
+
+#### Scenario: Refresh with conflicts
+- **WHEN** user runs `multiclaude repo refresh myrepo` and conflicts exist
+- **THEN** system reports which worktrees have conflicts
+- **AND** provides resolution guidance
+- **AND** does not abort other worktrees
+
+#### Scenario: Refresh specific worktree
+- **WHEN** user runs `multiclaude repo refresh myrepo --agent=worker-1`
+- **THEN** system refreshes only that agent's worktree
+
+### Requirement: Repo Clean Command
+The system SHALL provide a `repo clean [name]` command that removes orphaned resources.
+
+#### Scenario: Clean orphaned worktrees
+- **WHEN** user runs `multiclaude repo clean myrepo`
+- **THEN** system identifies worktrees without active agents
+- **AND** prompts for confirmation
+- **AND** removes orphaned worktrees
+
+#### Scenario: Clean with dry-run
+- **WHEN** user runs `multiclaude repo clean myrepo --dry-run`
+- **THEN** system lists what would be cleaned
+- **AND** does not remove anything
+
+#### Scenario: Clean with force
+- **WHEN** user runs `multiclaude repo clean myrepo --force`
+- **THEN** system removes orphaned resources without confirmation
+
+### Requirement: Output Format Options
+The system SHALL support multiple output formats for all repo commands.
+
+#### Scenario: Text output (default)
+- **WHEN** user runs any repo command without --format flag
+- **THEN** output is human-readable text with formatting
+- **AND** uses colors when terminal supports it
+
+#### Scenario: JSON output
+- **WHEN** user runs repo command with `--format=json`
+- **THEN** output is valid JSON
+- **AND** includes all data fields
+- **AND** is suitable for piping to jq
+
+#### Scenario: YAML output
+- **WHEN** user runs repo command with `--format=yaml`
+- **THEN** output is valid YAML
+- **AND** uses standard YAML formatting
+
+#### Scenario: TUI mode
+- **WHEN** user runs repo command with `--tui`
+- **THEN** launches interactive terminal interface
+- **AND** interface supports keyboard navigation
+- **AND** updates in real-time for status commands
+
+#### Scenario: WebSocket streaming
+- **WHEN** user runs `multiclaude repo status --websocket=:8080`
+- **THEN** system starts WebSocket server on port 8080
+- **AND** streams status updates as JSON messages
+- **AND** clients can connect and receive updates
+
+### Requirement: Repo List Enhancement
+The system SHALL enhance `repo list` with status information and output formats.
+
+#### Scenario: List with status
+- **WHEN** user runs `multiclaude repo list`
+- **THEN** output includes for each repo:
+  - Name and GitHub URL
+  - Status (active/hibernated/uninitialized)
+  - Agent count and types
+  - Open PR count
+  - Last activity timestamp
+
+#### Scenario: List with format option
+- **WHEN** user runs `multiclaude repo list --format=json`
+- **THEN** output is JSON array of repo objects
+- **AND** each object contains full status information

--- a/openspec/changes/add-repo-lifecycle/tasks.md
+++ b/openspec/changes/add-repo-lifecycle/tasks.md
@@ -1,0 +1,79 @@
+# Implementation Tasks
+
+## 1. Core Infrastructure
+
+- [ ] 1.1 Add `RepoState` enum to state.go (active, hibernated, uninitialized)
+- [ ] 1.2 Add `HibernationState` struct to preserve agent configuration
+- [ ] 1.3 Add output format types (text, json, yaml) to CLI
+- [ ] 1.4 Create `OutputFormatter` interface for consistent formatting
+
+## 2. Repo Start Command
+
+- [ ] 2.1 Implement `repo start` command in cli.go
+- [ ] 2.2 Add `--agents` flag for selective agent spawning
+- [ ] 2.3 Add daemon socket handler for start operation
+- [ ] 2.4 Add idempotency check (skip already running agents)
+- [ ] 2.5 Write tests for start command
+
+## 3. Repo Status Command
+
+- [ ] 3.1 Implement `repo status` command in cli.go
+- [ ] 3.2 Aggregate data: agents, PRs (via gh), messages, worktree sync
+- [ ] 3.3 Implement text formatter with colors
+- [ ] 3.4 Implement JSON formatter
+- [ ] 3.5 Implement YAML formatter
+- [ ] 3.6 Write tests for status command
+
+## 4. Repo Hibernate/Wake Commands
+
+- [ ] 4.1 Implement `repo hibernate` command
+- [ ] 4.2 Add graceful agent shutdown with timeout
+- [ ] 4.3 Save hibernation state to state.json
+- [ ] 4.4 Implement `repo wake` command
+- [ ] 4.5 Restore agents from hibernation state
+- [ ] 4.6 Add `--fresh` flag for clean wake
+- [ ] 4.7 Write tests for hibernate/wake cycle
+
+## 5. Repo Refresh Command
+
+- [ ] 5.1 Implement `repo refresh` command
+- [ ] 5.2 Add parallel worktree rebase logic
+- [ ] 5.3 Handle conflicts gracefully (continue others)
+- [ ] 5.4 Add `--agent` flag for single worktree
+- [ ] 5.5 Write tests for refresh command
+
+## 6. Repo Clean Command
+
+- [ ] 6.1 Implement `repo clean` command
+- [ ] 6.2 Identify orphaned worktrees (no agent match)
+- [ ] 6.3 Add confirmation prompt
+- [ ] 6.4 Add `--dry-run` and `--force` flags
+- [ ] 6.5 Write tests for clean command
+
+## 7. Repo List Enhancement
+
+- [ ] 7.1 Extend list output with status info
+- [ ] 7.2 Add `--format` flag to list command
+- [ ] 7.3 Write tests for enhanced list
+
+## 8. TUI Mode (Phase 2)
+
+- [ ] 8.1 Add bubbletea dependency
+- [ ] 8.2 Create TUI model for status display
+- [ ] 8.3 Implement real-time updates via state watcher
+- [ ] 8.4 Add keyboard navigation
+- [ ] 8.5 Write TUI tests
+
+## 9. WebSocket Streaming (Phase 2)
+
+- [ ] 9.1 Add WebSocket server to daemon
+- [ ] 9.2 Implement status streaming endpoint
+- [ ] 9.3 Add client connection management
+- [ ] 9.4 Write WebSocket integration tests
+
+## 10. Documentation
+
+- [ ] 10.1 Update CLI docs with new commands
+- [ ] 10.2 Add examples to README
+- [ ] 10.3 Update COMMANDS.md reference
+- [ ] 10.4 Run `go generate ./pkg/config` to regenerate docs


### PR DESCRIPTION
## Summary

Adds spec-driven proposal for unified repo lifecycle commands:
- `repo start` - Initialize all standard agents (supervisor, merge-queue, workspace)
- `repo status` - Comprehensive status with agents, PRs, messages, health
- `repo hibernate` - Pause agents, preserve state for later resume
- `repo wake` - Resume hibernated repo
- `repo refresh` - Sync all worktrees with main branch
- `repo clean` - Remove orphaned resources

Also includes:
- Output format options: text (default), JSON, YAML, TUI, WebSocket
- Design decisions (hibernation vs stop, OutputFormatter interface, bubbletea TUI)
- Implementation task breakdown (10 phases)
- Detailed specs with scenarios

## Test plan

- [ ] Review proposal.md for completeness
- [ ] Verify specs match implementation PRs (#314, #315, #316)
- [ ] Check task breakdown aligns with implementation order

🤖 Generated with [Claude Code](https://claude.com/claude-code)