### PR TITLE
feat: improve GitHub authentication and auto-create repositories

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1092,6 +1092,7 @@ func (c *CLI) initRepo(args []string) error {
 	fmt.Printf("Cloning to: %s\n", repoPath)
 
 	cmd := exec.Command("git", "clone", githubURL, repoPath)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -1958,6 +1959,7 @@ func (c *CLI) createWorker(args []string) error {
 	fmt.Println("Fetching latest from origin...")
 	fetchCmd := exec.Command("git", "fetch", "origin")
 	fetchCmd.Dir = repoPath
+	fetchCmd.Stdin = os.Stdin
 	if err := fetchCmd.Run(); err != nil {
 		// Best effort - don't fail if offline or fetch fails
 		fmt.Printf("Warning: failed to fetch from origin: %v (continuing with local refs)\n", err)
@@ -3941,6 +3943,7 @@ func (c *CLI) reviewPR(args []string) error {
 	localRef := fmt.Sprintf("refs/multiclaude/pr-%s", prNumber)
 	cmd := exec.Command("git", "fetch", "origin", fmt.Sprintf("%s:%s", prRef, localRef))
 	cmd.Dir = repoPath
+	cmd.Stdin = os.Stdin
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return errors.Wrap(errors.CategoryRuntime, fmt.Sprintf("failed to fetch PR #%s: %s", prNumber, strings.TrimSpace(string(output))), err).
 			WithSuggestion("ensure the PR exists and you have access to the repository")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1092,6 +1092,16 @@ func (c *CLI) initRepo(args []string) error {
 		return errors.GitOperationFailed("clone", err)
 	}
 
+	// Check if repository is empty (has no commits)
+	checkHeadCmd := exec.Command("git", "rev-parse", "--verify", "HEAD")
+	checkHeadCmd.Dir = repoPath
+	if err := checkHeadCmd.Run(); err != nil {
+		return errors.Wrap(errors.CategoryUsage,
+			"cannot initialize empty repository (no commits found)",
+			err).
+			WithSuggestion("push at least one commit to the repository before initializing with multiclaude")
+	}
+
 	// Detect if this is a fork
 	forkInfo, err := fork.DetectFork(repoPath)
 	if err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2141,6 +2141,16 @@ func TestInitRepoNameParsing(t *testing.T) {
 			wantError: false, // TrimRight removes all trailing slashes
 		},
 		{
+			name:      "SSH URL without .git suffix",
+			url:       "git@github.com:user/repo",
+			wantError: false,
+		},
+		{
+			name:      "SSH URL with .git suffix",
+			url:       "git@github.com:user/repo.git",
+			wantError: false,
+		},
+		{
 			name:        "URL that is just slashes",
 			url:         "///",
 			wantError:   true,
@@ -2277,6 +2287,99 @@ func TestNormalizeGitHubURL(t *testing.T) {
 			got := normalizeGitHubURL(tt.url)
 			if got != tt.want {
 				t.Errorf("normalizeGitHubURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractRepoNameFromURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "HTTPS URL",
+			url:  "https://github.com/user/repo",
+			want: "repo",
+		},
+		{
+			name: "HTTPS URL with .git",
+			url:  "https://github.com/user/repo.git",
+			want: "repo",
+		},
+		{
+			name: "SSH URL",
+			url:  "git@github.com:user/repo",
+			want: "repo",
+		},
+		{
+			name: "SSH URL with .git",
+			url:  "git@github.com:user/repo.git",
+			want: "repo",
+		},
+		{
+			name: "HTTP URL",
+			url:  "http://github.com/user/repo",
+			want: "repo",
+		},
+		{
+			name: "git:// protocol",
+			url:  "git://github.com/user/repo.git",
+			want: "repo",
+		},
+		{
+			name: "URL with trailing slash",
+			url:  "https://github.com/user/repo/",
+			want: "repo",
+		},
+		{
+			name: "organization repo",
+			url:  "https://github.com/dlorenc/multiclaude",
+			want: "multiclaude",
+		},
+		{
+			name: "organization repo SSH",
+			url:  "git@github.com:dlorenc/multiclaude.git",
+			want: "multiclaude",
+		},
+		{
+			name: "whitespace trimmed",
+			url:  "  https://github.com/user/repo  ",
+			want: "repo",
+		},
+		{
+			name: "empty string",
+			url:  "",
+			want: "",
+		},
+		{
+			name: "invalid URL",
+			url:  "not-a-url",
+			want: "",
+		},
+		{
+			name: "non-GitHub URL",
+			url:  "https://gitlab.com/user/repo",
+			want: "",
+		},
+		{
+			name: "incomplete HTTPS URL",
+			url:  "https://github.com/user",
+			want: "",
+		},
+		{
+			name: "incomplete SSH URL",
+			url:  "git@github.com:user",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractRepoNameFromURL(tt.url)
+			if got != tt.want {
+				t.Errorf("extractRepoNameFromURL(%q) = %q, want %q", tt.url, got, tt.want)
 			}
 		})
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2292,6 +2292,73 @@ func TestNormalizeGitHubURL(t *testing.T) {
 	}
 }
 
+func TestParseGitHubURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantOwner string
+		wantRepo  string
+	}{
+		{
+			name:      "HTTPS URL",
+			url:       "https://github.com/dustinkirkland/libcensus",
+			wantOwner: "dustinkirkland",
+			wantRepo:  "libcensus",
+		},
+		{
+			name:      "HTTPS URL with .git",
+			url:       "https://github.com/dustinkirkland/libcensus.git",
+			wantOwner: "dustinkirkland",
+			wantRepo:  "libcensus",
+		},
+		{
+			name:      "SSH URL",
+			url:       "git@github.com:dustinkirkland/libcensus",
+			wantOwner: "dustinkirkland",
+			wantRepo:  "libcensus",
+		},
+		{
+			name:      "SSH URL with .git",
+			url:       "git@github.com:dustinkirkland/libcensus.git",
+			wantOwner: "dustinkirkland",
+			wantRepo:  "libcensus",
+		},
+		{
+			name:      "HTTP URL",
+			url:       "http://github.com/user/repo",
+			wantOwner: "user",
+			wantRepo:  "repo",
+		},
+		{
+			name:      "git:// protocol",
+			url:       "git://github.com/user/repo.git",
+			wantOwner: "user",
+			wantRepo:  "repo",
+		},
+		{
+			name:      "empty string",
+			url:       "",
+			wantOwner: "",
+			wantRepo:  "",
+		},
+		{
+			name:      "invalid URL",
+			url:       "not-a-url",
+			wantOwner: "",
+			wantRepo:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOwner, gotRepo := parseGitHubURL(tt.url)
+			if gotOwner != tt.wantOwner || gotRepo != tt.wantRepo {
+				t.Errorf("parseGitHubURL(%q) = (%q, %q), want (%q, %q)", tt.url, gotOwner, gotRepo, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+}
+
 func TestExtractRepoNameFromURL(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

This PR improves multiclaude's GitHub integration by fixing authentication issues and adding the ability to automatically create missing repositories during initialization.

## Changes

### 1. Fix SSH Authentication (666db86)
**Problem:** Git commands couldn't access SSH keys or credential helpers because stdin wasn't connected.

**Solution:** Connected stdin to git commands (`git clone`, `git fetch`) so they can:
- Prompt for SSH key passphrases
- Use interactive credential helpers
- Access existing authentication

### 2. Add SSH URL Support (52309ed)
**Problem:** Only HTTPS URLs (`https://github.com/user/repo`) were supported for repository initialization.

**Solution:** Added support for SSH URL format (`git@github.com:user/repo`):
- Created `extractRepoNameFromURL()` function to parse both formats
- Supports URLs with/without `.git` suffix
- Works with HTTPS, SSH, HTTP, and git:// protocols

### 3. Detect Empty Repositories (be9ead0)
**Problem:** Multiclaude crashed with cryptic git errors when trying to initialize empty repositories (no commits).

**Solution:** Added validation after cloning to detect empty repos and provide clear error:
```
cannot initialize empty repository (no commits found)
Try: push at least one commit to the repository before initializing with multiclaude
```

### 4. Auto-Create Missing Repositories (8bfae12)
**Problem:** Users had to manually create repositories on GitHub before using multiclaude.

**Solution:** When a repository doesn't exist, multiclaude now:
- Detects "Repository not found" errors
- Prompts: "Would you like to create it? [y/N]"
- Creates the repository using `gh repo create --add-readme`
- Includes initial README commit to avoid empty repo issues
- Retries clone and continues initialization

## Testing

All changes have been tested with:
- ✅ SSH URLs: `git@github.com:user/repo`
- ✅ HTTPS URLs: `https://github.com/user/repo`
- ✅ Empty repository detection
- ✅ Auto-creation of missing repositories
- ✅ Unit tests added for URL parsing

## Example Usage

```bash
# Works with SSH URLs now
multiclaude repo init git@github.com:dustinkirkland/libcensus

# Prompts to create if repository doesn't exist
⚠ Repository dustinkirkland/libcensus does not exist.
Would you like to create it? [y/N]: y
Creating repository dustinkirkland/libcensus with initial commit...
✓ Repository initialized successfully!
```

## Dependencies

Auto-creation feature requires `gh` CLI to be installed and authenticated.

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>