### PR TITLE
fix: detect running Claude before restarting to prevent session ID conflicts

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -11,6 +11,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/dlorenc/multiclaude/internal/agents"
@@ -5042,6 +5043,7 @@ func (c *CLI) localRepair(verbose bool) error {
 }
 
 // restartClaude restarts Claude in the current agent context.
+// It checks if Claude is already running and provides helpful error messages if so.
 // It auto-detects whether to use --resume or --session-id based on session history.
 func (c *CLI) restartClaude(args []string) error {
 	// Infer agent context from cwd
@@ -5063,6 +5065,41 @@ func (c *CLI) restartClaude(args []string) error {
 
 	if agent.SessionID == "" {
 		return fmt.Errorf("agent has no session ID - try removing and recreating the agent")
+	}
+
+	// Check if Claude is already running
+	if agent.PID > 0 {
+		// Check if the process is still alive
+		process, err := os.FindProcess(agent.PID)
+		if err == nil {
+			// Send signal 0 to check if process exists (doesn't actually signal, just checks)
+			err = process.Signal(syscall.Signal(0))
+			if err == nil {
+				// Process is still running - provide helpful error
+				return fmt.Errorf("Claude is already running (PID %d) in this context.\n\nTo restart:\n  1. Exit Claude first (Ctrl+D or /exit)\n  2. Then run 'multiclaude claude' again\n\nOr attach to the running session:\n  multiclaude attach %s", agent.PID, agentName)
+			}
+		}
+	}
+
+	// Get repo for tmux session info
+	repo, exists := st.GetRepo(repoName)
+	if !exists {
+		return fmt.Errorf("repo '%s' not found in state", repoName)
+	}
+
+	// Double-check: get the current PID in the tmux pane to detect any running process
+	tmuxClient := tmux.NewClient()
+	currentPID, err := tmuxClient.GetPanePID(context.Background(), repo.TmuxSession, agent.TmuxWindow)
+	if err == nil && currentPID > 0 {
+		// Check if this PID is alive and different from what we checked above
+		if currentPID != agent.PID {
+			if process, err := os.FindProcess(currentPID); err == nil {
+				if err := process.Signal(syscall.Signal(0)); err == nil {
+					// There's a different running process in the pane
+					return fmt.Errorf("A process (PID %d) is already running in this tmux pane.\n\nTo restart:\n  1. Exit the current process first\n  2. Then run 'multiclaude claude' again\n\nOr attach to view:\n  multiclaude attach %s", currentPID, agentName)
+				}
+			}
+		}
 	}
 
 	// Get the prompt file path (stored as ~/.multiclaude/prompts/<agent-name>.md)


### PR DESCRIPTION
## Summary

Fixes bug where `multiclaude claude` command fails with "Session ID already in use" error when Claude is already running in the agent context.

## Problem

The command would attempt to restart Claude with `--session-id` or `--resume` flags without checking if a Claude process was already active using that session ID. This resulted in conflicts when the session ID was already in use by a running Claude instance.

## Solution

- Added process alive check for stored agent PID before attempting restart
- Added double-check for any running process in the tmux pane (in case PID differs)
- Provides clear, actionable error messages with steps to exit and restart
- Users can choose to properly exit and restart, or attach to the existing session

## Changes

- Import `syscall` package for signal-based process detection
- Check if stored agent.PID is still alive using signal 0
- Query tmux pane PID to catch cases where a different process is running
- Return helpful error messages with next steps instead of attempting conflicting restart

## Test Plan

- [x] All existing tests pass (`go test ./...`)
- [x] Code compiles without errors
- [x] Manual testing would verify:
  - Running `multiclaude claude` when Claude is already active shows helpful error
  - Running `multiclaude claude` when Claude is not running starts it successfully
  - Error messages include both exit-and-restart and attach options

## Related Files

- `internal/cli/cli.go:5047` - restartClaude function

🤖 Generated with [Claude Code](https://claude.com/claude-code)