### PR TITLE
fix(lint): Apply De Morgan's law to character validation

### DIFF
--- a/WORKER_NAMING_EXAMPLES.md
+++ b/WORKER_NAMING_EXAMPLES.md
@@ -1,0 +1,116 @@
+# Worker Naming Examples
+
+This document demonstrates the new task-based worker naming feature.
+
+## Before (Random Names)
+
+```bash
+$ multiclaude worker create "Fix session ID bug in authentication"
+Creating worker 'calm-owl' in repo 'myproject'
+
+$ multiclaude worker create "Add user profile editing"
+Creating worker 'jolly-hawk' in repo 'myproject'
+```
+
+Workers had random adjective-animal names that provided no context about their purpose.
+
+## After (Task-Based Names)
+
+```bash
+$ multiclaude worker create "Fix session ID bug in authentication"
+Creating worker 'fix-session-id-bug' in repo 'myproject'
+
+$ multiclaude worker create "Add user profile editing"
+Creating worker 'add-user-profile-editing' in repo 'myproject'
+```
+
+Workers now have descriptive names derived from their task descriptions.
+
+## How It Works
+
+### 1. Keyword Extraction
+
+The system extracts meaningful keywords from the task description:
+
+```
+Task: "Fix the session ID bug in authentication"
+Keywords: ["fix", "session", "id", "bug"]  (stop words removed: "the", "in")
+Name: "fix-session-id-bug"
+```
+
+### 2. Sanitization
+
+Names are converted to valid format:
+
+- Lowercase letters only
+- Hyphens separate words
+- Special characters removed
+- Maximum 50 characters
+
+```
+Task: "Update API (v2) endpoint configuration!!!"
+Keywords: ["update", "api", "v2", "endpoint"]
+Name: "update-api-v2-endpoint"
+```
+
+### 3. Uniqueness
+
+Duplicate names get numeric suffixes:
+
+```bash
+$ multiclaude worker create "Fix bug in login"
+Creating worker 'fix-bug-login' in repo 'myproject'
+
+$ multiclaude worker create "Fix bug in login"  # Same task
+Creating worker 'fix-bug-login-2' in repo 'myproject'
+
+$ multiclaude worker create "Fix bug in login"  # Again
+Creating worker 'fix-bug-login-3' in repo 'myproject'
+```
+
+### 4. Fallback to Random Names
+
+If the task description is invalid or too short, the system falls back to random names:
+
+```bash
+$ multiclaude worker create "!!!"
+Creating worker 'happy-platypus' in repo 'myproject'  # Fallback
+
+$ multiclaude worker create "the a an is"  # Only stop words
+Creating worker 'clever-dolphin' in repo 'myproject'  # Fallback
+```
+
+## Manual Override
+
+The `--name` flag still works for manual naming:
+
+```bash
+$ multiclaude worker create "Fix bug" --name my-custom-name
+Creating worker 'my-custom-name' in repo 'myproject'
+```
+
+## Real-World Examples
+
+| Task Description | Generated Name |
+|-----------------|----------------|
+| "Fix memory leak in database connection pool" | `fix-memory-leak-database` |
+| "Implement OAuth2 authentication flow" | `implement-oauth2-authentication-flow` |
+| "Refactor user service to use new API" | `refactor-user-service-new` |
+| "Add unit tests for payment module" | `add-unit-tests-payment` |
+| "Update README with installation instructions" | `update-readme-installation-instructions` |
+| "Debug timeout in webhook handler" | `debug-timeout-webhook-handler` |
+
+## Benefits
+
+1. **Clarity**: Immediately understand what each worker is doing
+2. **Tracking**: Easier to monitor worker progress in logs and tmux
+3. **Git branches**: Branch names like `work/fix-session-id-bug` are self-documenting
+4. **PR identification**: PRs are easier to identify from their branch names
+5. **Debugging**: When something goes wrong, you know which worker to investigate
+
+## Technical Details
+
+- Implementation: `internal/names/names.go`
+- Tests: `internal/names/names_test.go`
+- Specification: `WORKER_NAMING_SPEC.md`
+- Integration: `internal/cli/cli.go:createWorker()`

--- a/WORKER_NAMING_SPEC.md
+++ b/WORKER_NAMING_SPEC.md
@@ -1,0 +1,106 @@
+# Worker Naming Specification
+
+## Overview
+
+Workers should have descriptive, task-based names instead of random adjective-animal combinations. This makes it easier to identify what each worker is doing at a glance.
+
+## Requirements
+
+### 1. Task Summary Extraction
+
+Extract a 3-4 word summary from the task description using heuristic processing:
+
+- Remove common stop words (a, an, the, is, are, to, for, in, on, at, etc.)
+- Identify and extract meaningful keywords (nouns, verbs, technical terms)
+- Prioritize words at the beginning of the task description
+- Limit to 3-4 words to keep names concise
+
+### 2. Sanitization
+
+Convert the extracted summary to a valid worker name:
+
+- Convert to lowercase
+- Replace spaces with hyphens
+- Remove or replace special characters (keep only alphanumeric and hyphens)
+- Collapse multiple consecutive hyphens into one
+- Trim leading/trailing hyphens
+- Maximum length: 50 characters (truncate if needed)
+
+### 3. Uniqueness Handling
+
+Ensure worker names are unique within a repository:
+
+- Check if the generated name already exists
+- If it exists, append numeric suffix: `-2`, `-3`, etc.
+- Keep incrementing until a unique name is found
+
+### 4. Fallback Strategy
+
+If task extraction fails or produces invalid names:
+
+- Fall back to the existing random name generator (`names.Generate()`)
+- This ensures workers can always be created, even with unusual task descriptions
+
+### 5. Manual Override
+
+Preserve the existing `--name` flag to allow users to manually specify worker names.
+
+## Examples
+
+| Task Description | Generated Name |
+|-----------------|----------------|
+| "Fix the session ID bug in authentication" | `fix-session-id-bug` |
+| "Add user profile editing feature" | `add-user-profile` |
+| "Refactor the database connection logic" | `refactor-database-connection` |
+| "Update README documentation" | `update-readme-documentation` |
+| "Implement OAuth2 login flow" | `implement-oauth2-login` |
+| "Fix bug" (too short) | `fix-bug` |
+| "!!!" (invalid) | `happy-platypus` (fallback) |
+
+## Implementation Details
+
+### Stop Words List
+
+Common words to filter out:
+```
+a, an, the, is, are, am, was, were, be, been, being, have, has, had,
+do, does, did, will, would, should, could, may, might, must, can,
+to, for, of, in, on, at, by, with, from, as, into, through,
+this, that, these, those, it, its, they, their, there, here,
+and, or, but, if, because, when, where, how, what, which, who, why
+```
+
+### Name Validation
+
+A valid worker name must:
+- Be between 3 and 50 characters long
+- Contain at least one alphabetic character
+- Not start or end with a hyphen
+- Contain only lowercase letters, numbers, and hyphens
+
+### Edge Cases
+
+- Empty task description → fallback to random name
+- Task with only stop words → fallback to random name
+- Task producing name less than 3 characters → fallback to random name
+- Very long task → extract key terms and truncate
+- Special characters in task → sanitize and remove
+- Duplicate name → append numeric suffix
+
+## Testing Requirements
+
+Comprehensive tests must cover:
+
+1. **Basic extraction**: Verify correct keyword extraction from various task descriptions
+2. **Sanitization**: Test lowercase conversion, special character handling, hyphen collapsing
+3. **Uniqueness**: Test numeric suffix appending for duplicate names
+4. **Fallback**: Verify fallback to random names for invalid inputs
+5. **Edge cases**: Empty strings, very long strings, special characters only
+6. **Integration**: Test within the full worker creation flow
+
+## Migration
+
+Existing code should continue to work:
+- The `names.Generate()` function remains available for backward compatibility
+- New function `names.FromTask(task string)` implements the task-based naming
+- CLI code updated to use `FromTask()` by default, with `Generate()` as fallback

--- a/internal/names/names.go
+++ b/internal/names/names.go
@@ -167,7 +167,7 @@ func isValidName(name string) bool {
 
 	// Must only contain valid characters
 	for _, r := range name {
-		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-') {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
 			return false
 		}
 	}

--- a/internal/names/names.go
+++ b/internal/names/names.go
@@ -2,6 +2,8 @@ package names
 
 import (
 	"math/rand"
+	"regexp"
+	"strings"
 	"time"
 )
 
@@ -20,7 +22,26 @@ var (
 		"deer", "rabbit", "squirrel", "badger", "raccoon",
 	}
 
+	// Stop words to filter out when extracting task names
+	stopWords = map[string]bool{
+		"a": true, "an": true, "the": true, "is": true, "are": true, "am": true,
+		"was": true, "were": true, "be": true, "been": true, "being": true,
+		"have": true, "has": true, "had": true, "do": true, "does": true, "did": true,
+		"will": true, "would": true, "should": true, "could": true, "may": true,
+		"might": true, "must": true, "can": true, "to": true, "for": true, "of": true,
+		"in": true, "on": true, "at": true, "by": true, "with": true, "from": true,
+		"as": true, "into": true, "through": true, "this": true, "that": true,
+		"these": true, "those": true, "it": true, "its": true, "they": true,
+		"their": true, "there": true, "here": true, "and": true, "or": true,
+		"but": true, "if": true, "because": true, "when": true, "where": true,
+		"how": true, "what": true, "which": true, "who": true, "why": true,
+	}
+
 	rng *rand.Rand
+
+	// Regex for sanitizing names
+	invalidCharsRegex    = regexp.MustCompile(`[^a-z0-9-]+`)
+	multipleHyphensRegex = regexp.MustCompile(`-+`)
 )
 
 func init() {
@@ -32,4 +53,163 @@ func Generate() string {
 	adj := adjectives[rng.Intn(len(adjectives))]
 	animal := animals[rng.Intn(len(animals))]
 	return adj + "-" + animal
+}
+
+// FromTask generates a descriptive worker name from a task description.
+// It extracts 3-4 meaningful keywords, sanitizes them to lowercase-hyphenated format,
+// and falls back to Generate() if extraction fails.
+func FromTask(task string) string {
+	// Extract keywords
+	keywords := extractKeywords(task)
+	if len(keywords) == 0 {
+		return Generate()
+	}
+
+	// Limit to 3-4 words
+	if len(keywords) > 4 {
+		keywords = keywords[:4]
+	}
+
+	// Join and sanitize
+	name := strings.Join(keywords, "-")
+	name = sanitizeName(name)
+
+	// Validate
+	if !isValidName(name) {
+		return Generate()
+	}
+
+	return name
+}
+
+// extractKeywords extracts meaningful keywords from a task description
+func extractKeywords(task string) []string {
+	// Normalize to lowercase
+	task = strings.ToLower(task)
+
+	// Split into words
+	words := strings.Fields(task)
+
+	var keywords []string
+	for _, word := range words {
+		// Remove punctuation from word boundaries
+		word = strings.Trim(word, ".,!?;:\"'`()[]{}/<>")
+
+		// Skip if empty after trimming
+		if word == "" {
+			continue
+		}
+
+		// Skip stop words
+		if stopWords[word] {
+			continue
+		}
+
+		// Skip very short words (likely not meaningful)
+		if len(word) < 2 {
+			continue
+		}
+
+		keywords = append(keywords, word)
+	}
+
+	return keywords
+}
+
+// sanitizeName converts a name to a valid worker name format
+func sanitizeName(name string) string {
+	// Convert to lowercase
+	name = strings.ToLower(name)
+
+	// Replace invalid characters with hyphens
+	name = invalidCharsRegex.ReplaceAllString(name, "-")
+
+	// Collapse multiple hyphens
+	name = multipleHyphensRegex.ReplaceAllString(name, "-")
+
+	// Trim hyphens from edges
+	name = strings.Trim(name, "-")
+
+	// Truncate if too long
+	const maxLength = 50
+	if len(name) > maxLength {
+		name = name[:maxLength]
+		// Ensure we don't end with a hyphen after truncation
+		name = strings.TrimRight(name, "-")
+	}
+
+	return name
+}
+
+// isValidName checks if a generated name meets validation criteria
+func isValidName(name string) bool {
+	// Must be between 3 and 50 characters
+	if len(name) < 3 || len(name) > 50 {
+		return false
+	}
+
+	// Must contain at least one alphabetic character
+	hasAlpha := false
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			hasAlpha = true
+			break
+		}
+	}
+	if !hasAlpha {
+		return false
+	}
+
+	// Must not start or end with hyphen
+	if strings.HasPrefix(name, "-") || strings.HasSuffix(name, "-") {
+		return false
+	}
+
+	// Must only contain valid characters
+	for _, r := range name {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-') {
+			return false
+		}
+	}
+
+	return true
+}
+
+// EnsureUnique adds a numeric suffix to the name if it already exists in the given list
+func EnsureUnique(name string, existingNames []string) string {
+	// Create a map for O(1) lookup
+	exists := make(map[string]bool)
+	for _, n := range existingNames {
+		exists[n] = true
+	}
+
+	// If name is unique, return as-is
+	if !exists[name] {
+		return name
+	}
+
+	// Try numeric suffixes
+	for i := 2; i < 1000; i++ {
+		candidate := name + "-" + intToString(i)
+		if !exists[candidate] {
+			return candidate
+		}
+	}
+
+	// Fallback to random name if we somehow exhaust numeric suffixes
+	return Generate()
+}
+
+// intToString converts an integer to a string without importing fmt or strconv
+func intToString(n int) string {
+	if n == 0 {
+		return "0"
+	}
+
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
 }

--- a/internal/names/names_test.go
+++ b/internal/names/names_test.go
@@ -148,3 +148,307 @@ func TestGenerateUniqueness(t *testing.T) {
 		t.Errorf("Generate() shows poor distribution: one name appeared %d times in %d iterations", maxCount, iterations)
 	}
 }
+
+// Tests for task-based naming
+
+func TestFromTask(t *testing.T) {
+	tests := []struct {
+		name     string
+		task     string
+		expected string
+	}{
+		{
+			name:     "basic task with meaningful words",
+			task:     "Fix the session ID bug in authentication",
+			expected: "fix-session-id-bug",
+		},
+		{
+			name:     "task with action verb",
+			task:     "Add user profile editing feature",
+			expected: "add-user-profile-editing",
+		},
+		{
+			name:     "task with technical terms",
+			task:     "Refactor the database connection logic",
+			expected: "refactor-database-connection-logic",
+		},
+		{
+			name:     "simple task",
+			task:     "Update README documentation",
+			expected: "update-readme-documentation",
+		},
+		{
+			name:     "task with acronym",
+			task:     "Implement OAuth2 login flow",
+			expected: "implement-oauth2-login-flow",
+		},
+		{
+			name:     "task with punctuation",
+			task:     "Fix bug: session expires too quickly!",
+			expected: "fix-bug-session-expires",
+		},
+		{
+			name:     "task with special characters",
+			task:     "Update API (v2) endpoint configuration",
+			expected: "update-api-v2-endpoint",
+		},
+		{
+			name:     "task with multiple spaces",
+			task:     "Fix    the    spacing    issue",
+			expected: "fix-spacing-issue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FromTask(tt.task)
+			if result != tt.expected {
+				t.Errorf("FromTask(%q) = %q, expected %q", tt.task, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFromTaskFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		task string
+	}{
+		{"empty string", ""},
+		{"only stop words", "the a an is are to for"},
+		{"only punctuation", "!@#$%^&*()"},
+		{"only spaces", "     "},
+		{"very short", "ab"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FromTask(tt.task)
+			// Should fall back to random name (adjective-animal format)
+			parts := strings.Split(result, "-")
+			if len(parts) != 2 {
+				t.Errorf("FromTask(%q) = %q, expected fallback to adjective-animal format", tt.task, result)
+			}
+		})
+	}
+}
+
+func TestFromTaskTruncation(t *testing.T) {
+	// Very long task should be truncated to max 50 characters
+	longTask := "Fix the extremely long and verbose task description that goes on and on with many words"
+	result := FromTask(longTask)
+
+	if len(result) > 50 {
+		t.Errorf("FromTask() produced name longer than 50 chars: %q (%d chars)", result, len(result))
+	}
+
+	// Should still be valid
+	if !isValidName(result) {
+		t.Errorf("FromTask() produced invalid name after truncation: %q", result)
+	}
+}
+
+func TestExtractKeywords(t *testing.T) {
+	tests := []struct {
+		name     string
+		task     string
+		expected []string
+	}{
+		{
+			name:     "basic extraction",
+			task:     "Fix the bug in the system",
+			expected: []string{"fix", "bug", "system"},
+		},
+		{
+			name:     "filters stop words",
+			task:     "The user can login to the system",
+			expected: []string{"user", "login", "system"},
+		},
+		{
+			name:     "handles punctuation",
+			task:     "Fix bug: system crashes!",
+			expected: []string{"fix", "bug", "system", "crashes"},
+		},
+		{
+			name:     "empty string",
+			task:     "",
+			expected: []string{},
+		},
+		{
+			name:     "only stop words",
+			task:     "the a an is",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractKeywords(tt.task)
+			if len(result) != len(tt.expected) {
+				t.Errorf("extractKeywords(%q) = %v, expected %v", tt.task, result, tt.expected)
+				return
+			}
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("extractKeywords(%q) = %v, expected %v", tt.task, result, tt.expected)
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "basic sanitization",
+			input:    "Fix Bug System",
+			expected: "fix-bug-system",
+		},
+		{
+			name:     "removes special chars",
+			input:    "fix@bug#system",
+			expected: "fix-bug-system",
+		},
+		{
+			name:     "collapses multiple hyphens",
+			input:    "fix---bug---system",
+			expected: "fix-bug-system",
+		},
+		{
+			name:     "trims edge hyphens",
+			input:    "-fix-bug-system-",
+			expected: "fix-bug-system",
+		},
+		{
+			name:     "handles mixed case",
+			input:    "FixBugSystem",
+			expected: "fixbugsystem",
+		},
+		{
+			name:     "truncates long names",
+			input:    "this-is-a-very-long-name-that-exceeds-the-maximum-length-limit-for-worker-names",
+			expected: "this-is-a-very-long-name-that-exceeds-the-maximum",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeName(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeName(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsValidName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		{"valid name", "fix-bug-system", true},
+		{"valid short name", "fix", true},
+		{"valid with numbers", "fix-bug-v2", true},
+		{"too short", "ab", false},
+		{"too long", strings.Repeat("a", 51), false},
+		{"starts with hyphen", "-fix-bug", false},
+		{"ends with hyphen", "fix-bug-", false},
+		{"no alphabetic chars", "123-456", false},
+		{"has uppercase", "Fix-Bug", false},
+		{"has special chars", "fix_bug", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isValidName(tt.input)
+			if result != tt.valid {
+				t.Errorf("isValidName(%q) = %v, expected %v", tt.input, result, tt.valid)
+			}
+		})
+	}
+}
+
+func TestEnsureUnique(t *testing.T) {
+	existing := []string{"fix-bug", "add-feature", "update-docs"}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "unique name",
+			input:    "new-feature",
+			expected: "new-feature",
+		},
+		{
+			name:     "duplicate gets suffix",
+			input:    "fix-bug",
+			expected: "fix-bug-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EnsureUnique(tt.input, existing)
+			if result != tt.expected {
+				t.Errorf("EnsureUnique(%q, existing) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEnsureUniqueMultipleDuplicates(t *testing.T) {
+	// Test that multiple duplicates get incrementing suffixes
+	existing := []string{"fix-bug", "fix-bug-2", "fix-bug-3"}
+
+	result := EnsureUnique("fix-bug", existing)
+	expected := "fix-bug-4"
+
+	if result != expected {
+		t.Errorf("EnsureUnique(fix-bug) = %q, expected %q", result, expected)
+	}
+}
+
+func TestIntToString(t *testing.T) {
+	tests := []struct {
+		input    int
+		expected string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{9, "9"},
+		{10, "10"},
+		{99, "99"},
+		{100, "100"},
+		{999, "999"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := intToString(tt.input)
+			if result != tt.expected {
+				t.Errorf("intToString(%d) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFromTaskWordLimit(t *testing.T) {
+	// Task with more than 4 keywords should be limited to 4
+	task := "Fix the critical bug in user authentication system database connection"
+	result := FromTask(task)
+
+	// Count words in result
+	words := strings.Split(result, "-")
+	if len(words) > 4 {
+		t.Errorf("FromTask() produced more than 4 words: %q (%d words)", result, len(words))
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes lint failure in PR #323 (feat: implement task-based worker naming)
- Applies De Morgan's law to character validation condition per staticcheck QF1001

The condition:
```go
!((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-')
```
is rewritten as:
```go
(r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-'
```

## Test plan

- [x] `go test ./internal/names/...` passes
- [x] Logic is equivalent (De Morgan's law transformation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)