### PR TITLE
fix(cli): generate new session ID in `multiclaude claude` when no history

### DIFF
--- a/docs/extending/SOCKET_API.md
+++ b/docs/extending/SOCKET_API.md
@@ -13,6 +13,7 @@ list_agents
 complete_agent
 restart_agent
 trigger_cleanup
+trigger_refresh
 repair_state
 get_repo_config
 update_repo_config
@@ -49,6 +50,7 @@ Each command below matches a `case` in `handleRequest`.
 | `complete_agent` | Mark agent ready for cleanup | `repo`, `name`, `summary`, `failure_reason` |
 | `restart_agent` | Restart a persistent agent | `repo`, `name` |
 | `trigger_cleanup` | Force cleanup cycle | none |
+| `trigger_refresh` | Force worktree refresh cycle | none |
 | `repair_state` | Run state repair routine | none |
 | `get_repo_config` | Get merge-queue / pr-shepherd config | `repo` |
 | `update_repo_config` | Update repo config | `repo`, `config` (JSON object) |
@@ -643,6 +645,27 @@ class MulticlaudeClient {
   "data": "Cleanup triggered"
 }
 ```
+
+#### trigger_refresh
+
+**Description:** Trigger immediate worktree refresh for all agents (syncs with main branch)
+
+**Request:**
+```json
+{
+  "command": "trigger_refresh"
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": "Worktree refresh triggered"
+}
+```
+
+**Note:** Refresh runs asynchronously in the background.
 
 #### repair_state
 


### PR DESCRIPTION
## Summary
- Fixes "Session ID is already in use" error when running `multiclaude claude`
- When no session history exists, generates a new session ID instead of reusing the old one
- Adds missing `trigger_refresh` socket command documentation (fixes pre-commit check)

## Problem
When running `multiclaude claude` and Claude had previously exited abnormally (or the session was never used), the command would fail with:
```
Error: Session ID 4dc74532-623a-4cd3-805c-bd5cbb8c5238 is already in use.
```

This happened because the code reused the old session ID even when there was no session history to resume.

## Solution
When `hasHistory` is false (no session file or empty), generate a new UUID for the session ID and update the agent state before starting Claude.

## Test plan
- [x] `go build ./cmd/multiclaude` - builds successfully
- [x] `go test ./...` - all tests pass
- [x] `make pre-commit` - all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)