### PR TITLE
fix: lowercase error messages to satisfy staticcheck ST1005

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5527,7 +5527,7 @@ func (c *CLI) restartClaude(args []string) error {
 			err = process.Signal(syscall.Signal(0))
 			if err == nil {
 				// Process is still running - provide helpful error
-				return fmt.Errorf("Claude is already running (PID %d) in this context.\n\nTo restart:\n  1. Exit Claude first (Ctrl+D or /exit)\n  2. Then run 'multiclaude claude' again\n\nOr attach to the running session:\n  multiclaude attach %s", agent.PID, agentName)
+				return fmt.Errorf("claude is already running (PID %d) in this context.\n\nTo restart:\n  1. Exit Claude first (Ctrl+D or /exit)\n  2. Then run 'multiclaude claude' again\n\nOr attach to the running session:\n  multiclaude attach %s", agent.PID, agentName)
 			}
 		}
 	}
@@ -5547,7 +5547,7 @@ func (c *CLI) restartClaude(args []string) error {
 			if process, err := os.FindProcess(currentPID); err == nil {
 				if err := process.Signal(syscall.Signal(0)); err == nil {
 					// There's a different running process in the pane
-					return fmt.Errorf("A process (PID %d) is already running in this tmux pane.\n\nTo restart:\n  1. Exit the current process first\n  2. Then run 'multiclaude claude' again\n\nOr attach to view:\n  multiclaude attach %s", currentPID, agentName)
+					return fmt.Errorf("a process (PID %d) is already running in this tmux pane.\n\nTo restart:\n  1. Exit the current process first\n  2. Then run 'multiclaude claude' again\n\nOr attach to view:\n  multiclaude attach %s", currentPID, agentName)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes lint failures in PR #321 by making error message strings start with lowercase letters.

## Problem

Two error messages in `internal/cli/cli.go` violated staticcheck rule ST1005 (error strings should not be capitalized). This caused the Lint CI check to fail while all other checks passed.

## Solution

Changed the first character of both error messages to lowercase:
- `internal/cli/cli.go:5530` - "Claude is already running..." → "claude is already running..."
- `internal/cli/cli.go:5550` - "A process..." → "a process..."

This follows Go's convention that error strings should not be capitalized since they may be wrapped in other error contexts (e.g., `fmt.Errorf("failed to restart: %w", err)`).

The error messages remain multi-line and user-friendly with clear instructions, just with lowercase starting characters.

## Changes

- Updated 2 error message strings in `internal/cli/cli.go:5530` and `internal/cli/cli.go:5550`

## Test Plan

- [x] All unit tests pass (`go test ./...`)
- [x] Staticcheck ST1005 errors resolved (verified with `staticcheck`)
- [x] Error messages remain helpful and user-facing
- [x] No functional changes to error handling logic

## Related

Fixes lint failures in #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)