### PR TITLE
feat: Improve multiclaude refresh with agent-context awareness

### DIFF
--- a/internal/prompts/commands/refresh.md
+++ b/internal/prompts/commands/refresh.md
@@ -2,7 +2,22 @@
 
 Sync your worktree with the latest changes from the main branch.
 
-## Instructions
+## Quick Method (Recommended)
+
+Run this CLI command - it handles everything automatically:
+
+```bash
+multiclaude refresh
+```
+
+This will:
+- Detect your worktree context automatically
+- Fetch from the correct remote (upstream if fork, otherwise origin)
+- Stash any uncommitted changes
+- Rebase your branch onto main
+- Restore stashed changes
+
+## Manual Instructions (Alternative)
 
 1. First, determine the correct remote to use. Check if an upstream remote exists (indicates a fork):
    ```bash


### PR DESCRIPTION
## Summary

- **Agent-context aware refresh**: When run inside an agent worktree, `multiclaude refresh` now syncs just that worktree directly with immediate feedback
- **--all flag**: Explicitly triggers global daemon-based refresh (previous behavior)
- **Updated /refresh slash command**: Now recommends the CLI method as the quick path

## Changes

| File | Change |
|------|--------|
| `internal/cli/cli.go` | Added context detection and direct worktree refresh |
| `internal/prompts/commands/refresh.md` | Added "Quick Method" section recommending CLI |

## Behavior

| Context | Action |
|---------|--------|
| Inside agent worktree | Refreshes that worktree directly with detailed output |
| Outside agent context | Triggers daemon-based global refresh |
| With `--all` flag | Always triggers daemon-based global refresh |

## Test plan

- [x] Build compiles successfully
- [x] All worktree tests pass
- [x] All daemon refresh tests pass
- [x] CLI help shows updated usage

## Roadmap

P0 item: **Worktree sync** - Keep agent worktrees in sync with main as PRs merge

🤖 Generated with [Claude Code](https://claude.ai/code)