### PR TITLE
fix: Clean up acknowledged messages in message routing loop

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -419,6 +419,14 @@ func (d *Daemon) routeMessages() {
 
 				d.logger.Info("Delivered message %s from %s to %s/%s", msg.ID, msg.From, repoName, agentName)
 			}
+
+			// Clean up acknowledged messages to prevent pile-up
+			count, err := msgMgr.DeleteAcked(repoName, agentName)
+			if err != nil {
+				d.logger.Error("Failed to clean up acked messages for %s/%s: %v", repoName, agentName, err)
+			} else if count > 0 {
+				d.logger.Debug("Cleaned up %d acked messages for %s/%s", count, repoName, agentName)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Messages were piling up in the filesystem because acknowledged messages were never deleted. The `messages.Manager` had a `DeleteAcked()` method, but it was never called by the daemon's message routing loop.

**Evidence:**
- 128 message files accumulated in production
- 17 acked messages that should have been deleted  
- 111 delivered messages never acknowledged

## Root Cause

The `messageRouterLoop` delivered messages and marked them as "delivered", but had no cleanup mechanism. The `DeleteAcked()` method existed but was only used in tests.

## Solution

Added automatic cleanup of acknowledged messages to the `routeMessages()` function in `internal/daemon/daemon.go:423-429`. After delivering pending messages to each agent, the loop now calls `DeleteAcked()` to remove any messages that have been acknowledged.

The cleanup:
- Runs every 2 minutes as part of the normal message routing cycle
- Only deletes messages with status "acked"
- Logs cleanup activity at debug level for visibility
- Handles errors gracefully without disrupting message delivery

## Testing

- ✅ Added `TestMessageRoutingCleansUpAckedMessages` to verify cleanup works
- ✅ All existing daemon tests pass (9.9s)
- ✅ Full test suite passes (71s for CLI tests)
- ✅ Verified in production: 17 acked messages cleaned up after daemon restart

## Files Changed

- `internal/daemon/daemon.go` - Added cleanup call in `routeMessages()` (8 lines)
- `internal/daemon/daemon_test.go` - Added test for message cleanup (76 lines)

## Impact

- ✅ Prevents unbounded growth of message files
- ✅ Reduces filesystem clutter
- ✅ Makes the message system more reliable
- ✅ No breaking changes to message API or behavior

## Future Opportunities

While this PR fixes the acked message accumulation, there are still 111 delivered messages that were never acknowledged. These could be addressed in a future PR by:
- Adding automatic cleanup of old delivered messages (e.g., >24 hours old)
- Improving agent message acknowledgment workflow
- Adding metrics for message queue health

🤖 Generated with [Claude Code](https://claude.com/claude-code)