### PR TITLE
docs: pr-triage-b2 opportunities and simplification review

### DIFF
--- a/PRESS_RELEASE.md
+++ b/PRESS_RELEASE.md
@@ -1,0 +1,149 @@
+# multiclaude: A Brownian Ratchet for AI-Assisted Development
+
+**Lightweight orchestration for multiple Claude Code agents**
+
+## The Problem
+
+Modern AI coding assistants are powerful, but they work one task at a time.
+When you have a backlog of issues, tests to write, and documentation to
+update, you wait. Each task queues behind the last.
+
+What if you could parallelize?
+
+## The Solution
+
+**multiclaude** is a lightweight orchestrator that runs multiple Claude Code
+agents simultaneously on your GitHub repository. Each agent works in its own
+isolated environment, and you can spawn as many as you need.
+
+```bash
+multiclaude init https://github.com/your/repo
+multiclaude work "Add unit tests for auth"
+multiclaude work "Fix issue #42"
+multiclaude work "Update API documentation"
+```
+
+Three tasks. Three agents. Running in parallel.
+
+## The Philosophy: Brownian Ratchet
+
+In physics, a Brownian ratchet converts random molecular motion into
+directed movement through a mechanism that allows motion in only one
+direction.
+
+multiclaude applies this principle to software development:
+
+**The Chaos**: Multiple agents work simultaneously. They may duplicate
+effort, create conflicts, or produce suboptimal solutions. This is fine.
+More attempts mean more chances for progress.
+
+**The Ratchet**: CI is the arbiter. If tests pass, the code merges. Every
+merged PR clicks forward one notch. Progress is permanent.
+
+This approach optimizes for throughput of successful changes, not efficiency
+of individual agents. Redundant work is cheaper than blocked work.
+
+## Key Features
+
+**Observable**: All agents run in tmux windows. Attach anytime to watch them
+work or intervene when needed.
+
+**Isolated**: Each agent gets its own git worktree. No interference between
+parallel tasks.
+
+**Self-Healing**: The daemon monitors agent health, restarts crashed
+processes, and cleans up finished work.
+
+**Simple**: Filesystem for state. Tmux for visibility. Git for isolation. No
+databases, no cloud dependencies, no complex setup.
+
+## How It Works
+
+multiclaude spawns three types of agents:
+
+1. **Supervisor** - Coordinates agents, helps stuck workers, tracks progress
+2. **Workers** - Execute tasks, create pull requests
+3. **Merge Queue** - Monitors PRs, merges when CI passes
+
+Workers communicate via filesystem-based messages. The supervisor nudges
+stuck agents. The merge queue ensures only passing code lands.
+
+## Remote-First Design
+
+Unlike tools designed for solo development, multiclaude treats software
+engineering as an MMORPG:
+
+- Your **workspace** is your persistent home base
+- **Workers** are party members you spawn for quests
+- The **supervisor** coordinates the guild
+- The **merge queue** is the raid boss guarding main
+
+The system keeps running when you're away. Spawn workers before lunch.
+Review their PRs when you return.
+
+## Comparison with Gastown
+
+multiclaude was developed independently but shares goals with Steve Yegge's
+Gastown project. Both orchestrate multiple Claude Code instances using tmux
+and git worktrees.
+
+**Where they differ:**
+
+| Aspect | multiclaude | Gastown |
+|--------|-------------|---------|
+| Agent model | 3 roles | 7 roles |
+| Philosophy | Minimal, Unix-style | Comprehensive orchestration |
+| State | JSON + filesystem | Git-backed hooks |
+| Target | Remote-first teams | Solo development |
+
+Choose multiclaude for simplicity. Choose Gastown for sophisticated features
+like work swarming and structured work units.
+
+## Getting Started
+
+```bash
+# Install
+go install github.com/dlorenc/multiclaude/cmd/multiclaude@latest
+
+# Start the daemon
+multiclaude start
+
+# Initialize a repository
+multiclaude init https://github.com/your/repo
+
+# Spawn a worker
+multiclaude work "Your task here"
+
+# Watch it work
+tmux attach -t mc-repo
+```
+
+## Requirements
+
+- Go 1.21+
+- tmux
+- git
+- GitHub CLI (authenticated)
+
+## Open Source
+
+multiclaude is MIT licensed and available on GitHub:
+
+https://github.com/dlorenc/multiclaude
+
+Contributions welcome. Issues and PRs are the ratchet - if CI passes, it
+ships.
+
+## About
+
+multiclaude embraces a counterintuitive truth: in AI-assisted development,
+chaos is fine as long as you ratchet forward. Perfect coordination is
+expensive and fragile. Multiple imperfect attempts that occasionally succeed
+beat waiting for one perfect solution.
+
+Let the agents work. Let CI judge. Click the ratchet forward.
+
+---
+
+*For more information, see the project documentation or open an issue on
+GitHub.*

--- a/README.md
+++ b/README.md
@@ -1,60 +1,105 @@
 # multiclaude
 
-A lightweight orchestrator for running multiple Claude Code agents on GitHub repositories.
+A lightweight orchestrator for running multiple Claude Code agents on
+GitHub repositories.
 
-multiclaude spawns and coordinates autonomous Claude Code instances that work together on your codebase. Each agent runs in its own tmux window with an isolated git worktree, making all work observable and interruptible at any time.
+multiclaude spawns and coordinates autonomous Claude Code instances
+that work together on your codebase. Each agent runs in its own tmux
+window with an isolated git worktree, making all work observable and
+interruptible at any time.
 
 ## Philosophy: The Brownian Ratchet
 
-multiclaude embraces a counterintuitive design principle: **chaos is fine, as long as we ratchet forward**.
+multiclaude embraces a counterintuitive design principle: **chaos is
+fine, as long as we ratchet forward**.
 
-In physics, a Brownian ratchet is a thought experiment where random molecular motion is converted into directed movement through a mechanism that allows motion in only one direction. multiclaude applies this principle to software development.
+In physics, a Brownian ratchet is a thought experiment where random
+molecular motion is converted into directed movement through a
+mechanism that allows motion in only one direction. multiclaude applies
+this principle to software development.
 
-**The Chaos**: Multiple autonomous agents work simultaneously on overlapping concerns. They may duplicate effort, create conflicting changes, or produce suboptimal solutions. This apparent disorder is not a bug—it's a feature. More attempts mean more chances for progress.
+**The Chaos**: Multiple autonomous agents work simultaneously on
+overlapping concerns. They may duplicate effort, create conflicting
+changes, or produce suboptimal solutions. This apparent disorder is not
+a bug—it's a feature. More attempts mean more chances for progress.
 
-**The Ratchet**: CI is the arbiter. If it passes, the code goes in. Every merged PR clicks the ratchet forward one notch. Progress is permanent—we never go backward. The merge queue agent serves as this ratchet mechanism, ensuring that any work meeting the CI bar gets incorporated.
+**The Ratchet**: CI is the arbiter. If it passes, the code goes in.
+Every merged PR clicks the ratchet forward one notch. Progress is
+permanent—we never go backward. The merge queue agent serves as this
+ratchet mechanism, ensuring that any work meeting the CI bar gets
+incorporated.
 
 **Why This Works**:
-- Agents don't need perfect coordination. Redundant work is cheaper than blocked work.
+- Agents don't need perfect coordination. Redundant work is cheaper than
+  blocked work.
 - Failed attempts cost nothing. Only successful attempts matter.
-- Incremental progress compounds. Many small PRs beat waiting for one perfect PR.
-- The system is antifragile. More agents mean more chaos but also more forward motion.
+- Incremental progress compounds. Many small PRs beat waiting for one
+  perfect PR.
+- The system is antifragile. More agents mean more chaos but also more
+  forward motion.
 
-This philosophy means we optimize for throughput of successful changes, not efficiency of individual agents. An agent that produces a mergeable PR has succeeded, even if another agent was working on the same thing.
+This philosophy means we optimize for throughput of successful changes,
+not efficiency of individual agents. An agent that produces a mergeable
+PR has succeeded, even if another agent was working on the same thing.
 
 ## Our Opinions
 
-multiclaude is intentionally opinionated. These aren't configuration options—they're core beliefs baked into how the system works:
+multiclaude is intentionally opinionated. These aren't configuration
+options—they're core beliefs baked into how the system works:
 
 ### CI is King
 
-CI is the source of truth. Period. If tests pass, the code can ship. If tests fail, the code doesn't ship. There's no "but the change looks right" or "I'm pretty sure it's fine." The automation decides.
+CI is the source of truth. Period. If tests pass, the code can ship. If
+tests fail, the code doesn't ship. There's no "but the change looks
+right" or "I'm pretty sure it's fine." The automation decides.
 
-Agents are forbidden from weakening CI to make their work pass. No skipping tests, no reducing coverage requirements, no "temporary" workarounds. If an agent can't pass CI, it asks for help or tries a different approach.
+Agents are forbidden from weakening CI to make their work pass. No
+skipping tests, no reducing coverage requirements, no "temporary"
+workarounds. If an agent can't pass CI, it asks for help or tries a
+different approach.
 
 ### Forward Progress Over Perfection
 
-Any incremental progress is good. A reviewable PR is progress. A partial implementation with tests is progress. The only failure is an agent that doesn't push the ball forward at all.
+Any incremental progress is good. A reviewable PR is progress. A
+partial implementation with tests is progress. The only failure is an
+agent that doesn't push the ball forward at all.
 
-This means we'd rather have three okay PRs than wait for one perfect PR. We'd rather merge working code now and improve it later than block on getting everything right the first time. Small, frequent commits beat large, infrequent ones.
+This means we'd rather have three okay PRs than wait for one perfect
+PR. We'd rather merge working code now and improve it later than block
+on getting everything right the first time. Small, frequent commits
+beat large, infrequent ones.
 
 ### Chaos is Expected
 
-Multiple agents working simultaneously will create conflicts, duplicate work, and occasionally step on each other's toes. This is fine. This is the plan.
+Multiple agents working simultaneously will create conflicts, duplicate
+work, and occasionally step on each other's toes. This is fine. This is
+the plan.
 
-Trying to perfectly coordinate agent work is both expensive and fragile. Instead, we let chaos happen and use CI as the ratchet that captures forward progress. Wasted work is cheap; blocked work is expensive.
+Trying to perfectly coordinate agent work is both expensive and fragile.
+Instead, we let chaos happen and use CI as the ratchet that captures
+forward progress. Wasted work is cheap; blocked work is expensive.
 
 ### Humans Approve, Agents Execute
 
-Agents do the work. Humans set the direction and approve the results. Agents should never make decisions that require human judgment—they should ask.
+Agents do the work. Humans set the direction and approve the results.
+Agents should never make decisions that require human judgment—they
+should ask.
 
-This means agents create PRs for human review. Agents ask the supervisor when they're stuck. Agents don't bypass review requirements or merge without appropriate approval. The merge queue agent can auto-merge, but only when CI passes and review requirements are met.
+This means agents create PRs for human review. Agents ask the
+supervisor when they're stuck. Agents don't bypass review requirements
+or merge without appropriate approval. The merge queue agent can
+auto-merge, but only when CI passes and review requirements are met.
 
 ## Gastown and multiclaude
 
-multiclaude was developed independently but shares similar goals with [Gastown](https://github.com/steveyegge/gastown), Steve Yegge's multi-agent orchestrator for Claude Code released in January 2026.
+multiclaude was developed independently but shares similar goals with
+[Gastown](https://github.com/steveyegge/gastown), Steve Yegge's
+multi-agent orchestrator for Claude Code released in January 2026.
 
-Both projects solve the same fundamental problem: coordinating multiple Claude Code instances working on a shared codebase. Both use Go, tmux for observability, and git worktrees for isolation. If you're evaluating multi-agent orchestrators, you should look at both.
+Both projects solve the same fundamental problem: coordinating multiple
+Claude Code instances working on a shared codebase. Both use Go, tmux
+for observability, and git worktrees for isolation. If you're
+evaluating multi-agent orchestrators, you should look at both.
 
 **Where they differ:**
 
@@ -67,23 +112,39 @@ Both projects solve the same fundamental problem: coordinating multiple Claude C
 | Philosophy | Minimal, Unix-style simplicity | Comprehensive orchestration system |
 | Maturity | Early development | More established, larger feature set |
 
-multiclaude aims to be a simpler, more lightweight alternative—the "worse is better" approach. If you need sophisticated orchestration features, work swarming, or built-in crash recovery, Gastown may be a better fit.
+multiclaude aims to be a simpler, more lightweight alternative—the
+"worse is better" approach. If you need sophisticated orchestration
+features, work swarming, or built-in crash recovery, Gastown may be a
+better fit.
 
 ### Remote-First: Software is an MMORPG
 
-The biggest philosophical difference: **multiclaude is designed for remote-first collaboration**.
+The biggest philosophical difference: **multiclaude is designed for
+remote-first collaboration**.
 
-Gastown treats agents as NPCs in a single-player game. You're the player, agents are your minions. This works great for solo development where you want to parallelize your own work.
+Gastown treats agents as NPCs in a single-player game. You're the
+player, agents are your minions. This works great for solo development
+where you want to parallelize your own work.
 
-multiclaude treats software engineering as an **MMORPG**. You're one player among many—some human, some AI. The workspace agent is your character, but other humans have their own workspaces. Workers are party members you spawn for quests. The supervisor coordinates the guild. The merge queue is the raid boss that decides what loot (code) makes it into the vault (main branch).
+multiclaude treats software engineering as an **MMORPG**. You're one
+player among many—some human, some AI. The workspace agent is your
+character, but other humans have their own workspaces. Workers are
+party members you spawn for quests. The supervisor coordinates the
+guild. The merge queue is the raid boss that decides what loot (code)
+makes it into the vault (main branch).
 
 This means:
-- **Your workspace persists**. It's your home base, not a temporary session.
-- **You interact with workers, not control them**. Spawn them with a task, check on them later.
+- **Your workspace persists**. It's your home base, not a temporary
+  session.
+- **You interact with workers, not control them**. Spawn them with a
+  task, check on them later.
 - **Other humans can have their own workspaces** on the same repo.
-- **The system keeps running when you're away**. Agents work, PRs merge, CI runs.
+- **The system keeps running when you're away**. Agents work, PRs
+  merge, CI runs.
 
-The workspace is where you hop in to spawn agents, check on progress, review what landed, and plan the next sprint—then hop out and let the system work while you sleep.
+The workspace is where you hop in to spawn agents, check on progress,
+review what landed, and plan the next sprint—then hop out and let the
+system work while you sleep.
 
 ## Quick Start
 
@@ -108,13 +169,18 @@ tmux attach -t mc-repo
 
 ## How It Works
 
-multiclaude creates a tmux session for each repository with three types of agents:
+multiclaude creates a tmux session for each repository with three types
+of agents:
 
-1. **Supervisor** - Coordinates all agents, answers status questions, nudges stuck workers
+1. **Supervisor** - Coordinates all agents, answers status questions,
+   nudges stuck workers
 2. **Workers** - Execute specific tasks, create PRs when done
-3. **Merge Queue** - Monitors PRs, merges when CI passes, spawns fixup workers as needed
+3. **Merge Queue** - Monitors PRs, merges when CI passes, spawns fixup
+   workers as needed
 
-Agents communicate via a filesystem-based message system. The daemon routes messages and periodically nudges agents to keep work moving forward.
+Agents communicate via a filesystem-based message system. The daemon
+routes messages and periodically nudges agents to keep work moving
+forward.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -136,71 +202,109 @@ Agents communicate via a filesystem-based message system. The daemon routes mess
 ### Daemon
 
 ```bash
-multiclaude start              # Start the daemon
-multiclaude daemon stop        # Stop the daemon
-multiclaude daemon status      # Show daemon status
-multiclaude daemon logs -f     # Follow daemon logs
-multiclaude stop-all           # Stop everything, kill all tmux sessions
-multiclaude stop-all --clean   # Stop and remove all state files
+# Start the daemon
+multiclaude start
+# Stop the daemon
+multiclaude daemon stop
+# Show daemon status
+multiclaude daemon status
+# Follow daemon logs
+multiclaude daemon logs -f
+# Stop everything, kill all tmux sessions
+multiclaude stop-all
+# Stop and remove all state files
+multiclaude stop-all --clean
 ```
 
 ### Repositories
 
 ```bash
-multiclaude init <github-url>              # Initialize repository tracking
-multiclaude init <github-url> [path] [name] # With custom local path or name
-multiclaude list                           # List tracked repositories
-multiclaude repo rm <name>                 # Remove a tracked repository
+# Initialize repository tracking
+multiclaude init <github-url>
+# With custom local path or name
+multiclaude init <github-url> [path] [name]
+# List tracked repositories
+multiclaude list
+# Remove a tracked repository
+multiclaude repo rm <name>
 ```
 
 ### Workspaces
 
-Workspaces are persistent Claude sessions where you interact with the codebase, spawn workers, and manage your development flow. Each workspace has its own git worktree, tmux window, and Claude instance.
+Workspaces are persistent Claude sessions where you interact with the
+codebase, spawn workers, and manage your development flow. Each
+workspace has its own git worktree, tmux window, and Claude instance.
 
 ```bash
-multiclaude workspace add <name>           # Create a new workspace
-multiclaude workspace add <name> --branch main  # Create from specific branch
-multiclaude workspace list                 # List all workspaces
-multiclaude workspace connect <name>       # Attach to a workspace
-multiclaude workspace rm <name>            # Remove workspace (warns if uncommitted work)
-multiclaude workspace                      # List workspaces (shorthand)
-multiclaude workspace <name>               # Connect to workspace (shorthand)
+# Create a new workspace
+multiclaude workspace add <name>
+# Create from specific branch
+multiclaude workspace add <name> --branch main
+# List all workspaces
+multiclaude workspace list
+# Attach to a workspace
+multiclaude workspace connect <name>
+# Remove workspace (warns if uncommitted work)
+multiclaude workspace rm <name>
+# List workspaces (shorthand)
+multiclaude workspace
+# Connect to workspace (shorthand)
+multiclaude workspace <name>
 ```
 
 **Notes:**
 - Workspaces use the branch naming convention `workspace/<name>`
-- Workspace names follow git branch naming rules (no spaces, special characters, etc.)
-- A "default" workspace is created automatically when you run `multiclaude init`
-- Use `multiclaude attach <workspace-name>` as an alternative to `workspace connect`
+- Workspace names follow git branch naming rules (no spaces, special
+  characters, etc.)
+- A "default" workspace is created automatically when you run
+  `multiclaude init`
+- Use `multiclaude attach <workspace-name>` as an alternative to
+  `workspace connect`
 
 ### Workers
 
 ```bash
-multiclaude work "task description"        # Create worker for task
-multiclaude work "task" --branch feature   # Start from specific branch
-multiclaude work "Fix tests" --branch origin/work/fox --push-to work/fox  # Iterate on existing PR
-multiclaude work list                      # List active workers
-multiclaude work rm <name>                 # Remove worker (warns if uncommitted work)
+# Create worker for task
+multiclaude work "task description"
+# Start from specific branch
+multiclaude work "task" --branch feature
+# Iterate on existing PR
+multiclaude work "Fix tests" \
+  --branch origin/work/fox --push-to work/fox
+# List active workers
+multiclaude work list
+# Remove worker (warns if uncommitted work)
+multiclaude work rm <name>
 ```
 
-The `--push-to` flag creates a worker that pushes to an existing branch instead of creating a new PR. Use this when you want to iterate on an existing PR.
+The `--push-to` flag creates a worker that pushes to an existing branch
+instead of creating a new PR. Use this when you want to iterate on an
+existing PR.
 
 ### Observing
 
 ```bash
-multiclaude attach <agent-name>            # Attach to agent's tmux window
-multiclaude attach <agent-name> --read-only # Observe without interaction
-tmux attach -t mc-<repo>                   # Attach to entire repo session
+# Attach to agent's tmux window
+multiclaude attach <agent-name>
+# Observe without interaction
+multiclaude attach <agent-name> --read-only
+# Attach to entire repo session
+tmux attach -t mc-<repo>
 ```
 
 ### Agent Commands (run from within Claude)
 
 ```bash
-multiclaude agent send-message <to> "msg"  # Send message to another agent
-multiclaude agent send-message --all "msg" # Broadcast to all agents
-multiclaude agent list-messages            # List incoming messages
-multiclaude agent ack-message <id>         # Acknowledge a message
-multiclaude agent complete                 # Signal task completion (workers)
+# Send message to another agent
+multiclaude agent send-message <to> "msg"
+# Broadcast to all agents
+multiclaude agent send-message --all "msg"
+# List incoming messages
+multiclaude agent list-messages
+# Acknowledge a message
+multiclaude agent ack-message <id>
+# Signal task completion (workers)
+multiclaude agent complete
 ```
 
 ### Agent Slash Commands (available within Claude sessions)
@@ -216,31 +320,34 @@ Agents have access to multiclaude-specific slash commands:
 
 ### What the tmux Session Looks Like
 
-When you attach to a repo's tmux session, you'll see multiple windows—one per agent:
+When you attach to a repo's tmux session, you'll see multiple
+windows—one per agent:
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│ mc-myrepo: supervisor | merge-queue | workspace | swift-eagle | calm-deer   │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                                                                             │
-│  $ claude                                                                   │
-│                                                                             │
-│  ╭─────────────────────────────────────────────────────────────────────────╮│
-│  │ I'll check on the current workers and see if anyone needs help.        ││
-│  │                                                                         ││
-│  │ > multiclaude work list                                                 ││
-│  │ Workers (2):                                                            ││
-│  │   - swift-eagle: working on issue #44                                   ││
-│  │   - calm-deer: working on issue #24                                     ││
-│  │                                                                         ││
-│  │ Both workers are making progress. swift-eagle just pushed a commit.    ││
-│  │ I'll check back in a few minutes.                                       ││
-│  ╰─────────────────────────────────────────────────────────────────────────╯│
-│                                                                             │
-│  ─────────────────────────────────────────────────────────────────────────  │
-│  > What would you like to do?                                               │
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│ mc-myrepo: supervisor | merge-queue | workspace | swift-eagle |  │
+│            calm-deer                                             │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  $ claude                                                        │
+│                                                                  │
+│  ╭──────────────────────────────────────────────────────────────╮│
+│  │ I'll check on the current workers and see if anyone needs   ││
+│  │ help.                                                        ││
+│  │                                                              ││
+│  │ > multiclaude work list                                      ││
+│  │ Workers (2):                                                 ││
+│  │   - swift-eagle: working on issue #44                        ││
+│  │   - calm-deer: working on issue #24                          ││
+│  │                                                              ││
+│  │ Both workers are making progress. swift-eagle just pushed a  ││
+│  │ commit. I'll check back in a few minutes.                    ││
+│  ╰──────────────────────────────────────────────────────────────╯│
+│                                                                  │
+│  ──────────────────────────────────────────────────────────────  │
+│  > What would you like to do?                                    │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
 ```
 
 Use standard tmux navigation:
@@ -251,88 +358,93 @@ Use standard tmux navigation:
 
 ### Workflow: Spawning Workers from Your Workspace
 
-Your workspace is a persistent Claude session where you can spawn and manage workers:
+Your workspace is a persistent Claude session where you can spawn and
+manage workers:
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│ You (in workspace):                                                         │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                                                                             │
-│  > Let's tackle issues #44 and #45 in parallel                              │
-│                                                                             │
-│  ╭─────────────────────────────────────────────────────────────────────────╮│
-│  │ I'll spawn workers for both issues.                                     ││
-│  │                                                                         ││
-│  │ > multiclaude work "Implement rich list commands per issue #44"         ││
-│  │ ✓ Worker created: swift-eagle (branch: work/swift-eagle)                ││
-│  │                                                                         ││
-│  │ > multiclaude work "Improve error messages per issue #45"               ││
-│  │ ✓ Worker created: calm-deer (branch: work/calm-deer)                    ││
-│  │                                                                         ││
-│  │ Both workers are now running. You can check on them with:               ││
-│  │   multiclaude work list                                                 ││
-│  │   multiclaude attach swift-eagle                                        ││
-│  ╰─────────────────────────────────────────────────────────────────────────╯│
-│                                                                             │
-│  > Great, let me know when they finish. I'm going to grab lunch.            │
-│                                                                             │
-│  ╭─────────────────────────────────────────────────────────────────────────╮│
-│  │ Will do! I'll get notified when they complete and can summarize         ││
-│  │ their PRs when you're back. The workers will keep running while         ││
-│  │ you're away.                                                            ││
-│  ╰─────────────────────────────────────────────────────────────────────────╯│
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│ You (in workspace):                                              │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  > Let's tackle issues #44 and #45 in parallel                   │
+│                                                                  │
+│  ╭──────────────────────────────────────────────────────────────╮│
+│  │ I'll spawn workers for both issues.                         ││
+│  │                                                              ││
+│  │ > multiclaude work "Implement rich list commands per issue   ││
+│  │   #44"                                                       ││
+│  │ ✓ Worker created: swift-eagle (branch: work/swift-eagle)    ││
+│  │                                                              ││
+│  │ > multiclaude work "Improve error messages per issue #45"    ││
+│  │ ✓ Worker created: calm-deer (branch: work/calm-deer)        ││
+│  │                                                              ││
+│  │ Both workers are now running. You can check on them with:    ││
+│  │   multiclaude work list                                      ││
+│  │   multiclaude attach swift-eagle                             ││
+│  ╰──────────────────────────────────────────────────────────────╯│
+│                                                                  │
+│  > Great, let me know when they finish. I'm going to grab lunch. │
+│                                                                  │
+│  ╭──────────────────────────────────────────────────────────────╮│
+│  │ Will do! I'll get notified when they complete and can       ││
+│  │ summarize their PRs when you're back. The workers will keep  ││
+│  │ running while you're away.                                   ││
+│  ╰──────────────────────────────────────────────────────────────╯│
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
 ```
 
 Later, when you return:
 
 ```
-│  > I'm back. What happened while I was gone?                                │
-│                                                                             │
-│  ╭─────────────────────────────────────────────────────────────────────────╮│
-│  │ Welcome back! Here's the update:                                        ││
-│  │                                                                         ││
-│  │ ✓ swift-eagle completed - PR #47 created for rich list commands         ││
-│  │ ✓ calm-deer completed - PR #48 created for error messages               ││
-│  │                                                                         ││
-│  │ Both PRs are passing CI. The merge queue is monitoring them.            ││
-│  ╰─────────────────────────────────────────────────────────────────────────╯│
+│  > I'm back. What happened while I was gone?                     │
+│                                                                  │
+│  ╭──────────────────────────────────────────────────────────────╮│
+│  │ Welcome back! Here's the update:                            ││
+│  │                                                              ││
+│  │ ✓ swift-eagle completed - PR #47 created for rich list      ││
+│  │   commands                                                   ││
+│  │ ✓ calm-deer completed - PR #48 created for error messages   ││
+│  │                                                              ││
+│  │ Both PRs are passing CI. The merge queue is monitoring them. ││
+│  ╰──────────────────────────────────────────────────────────────╯│
 ```
 
 ### Watching the Supervisor
 
-The supervisor coordinates agents and provides status updates. Attach to watch it work:
+The supervisor coordinates agents and provides status updates. Attach
+to watch it work:
 
 ```bash
 multiclaude attach supervisor --read-only
 ```
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│ Supervisor:                                                                 │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                                                                             │
-│  ╭─────────────────────────────────────────────────────────────────────────╮│
-│  │ [Periodic check - 14:32]                                                ││
-│  │                                                                         ││
-│  │ Checking agent status...                                                ││
-│  │                                                                         ││
-│  │ Agents:                                                                 ││
-│  │   supervisor: healthy (me)                                              ││
-│  │   merge-queue: healthy, monitoring 2 PRs                                ││
-│  │   workspace: healthy, user attached                                     ││
-│  │   swift-eagle: healthy, working on #44                                  ││
-│  │   calm-deer: needs attention - stuck on test failure                    ││
-│  │                                                                         ││
-│  │ Sending help to calm-deer...                                            ││
-│  │                                                                         ││
-│  │ > multiclaude agent send-message calm-deer "I see you're stuck on a     ││
-│  │   test failure. The flaky test in auth_test.go sometimes fails due to   ││
-│  │   timing. Try adding a retry or mocking the clock."                     ││
-│  ╰─────────────────────────────────────────────────────────────────────────╯│
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│ Supervisor:                                                      │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ╭──────────────────────────────────────────────────────────────╮│
+│  │ [Periodic check - 14:32]                                    ││
+│  │                                                              ││
+│  │ Checking agent status...                                     ││
+│  │                                                              ││
+│  │ Agents:                                                      ││
+│  │   supervisor: healthy (me)                                   ││
+│  │   merge-queue: healthy, monitoring 2 PRs                     ││
+│  │   workspace: healthy, user attached                          ││
+│  │   swift-eagle: healthy, working on #44                       ││
+│  │   calm-deer: needs attention - stuck on test failure         ││
+│  │                                                              ││
+│  │ Sending help to calm-deer...                                 ││
+│  │                                                              ││
+│  │ > multiclaude agent send-message calm-deer "I see you're     ││
+│  │   stuck on a test failure. The flaky test in auth_test.go    ││
+│  │   sometimes fails due to timing. Try adding a retry or       ││
+│  │   mocking the clock."                                        ││
+│  ╰──────────────────────────────────────────────────────────────╯│
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
 ```
 
 ### Watching the Merge Queue
@@ -344,70 +456,78 @@ multiclaude attach merge-queue --read-only
 ```
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│ Merge Queue:                                                                │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                                                                             │
-│  ╭─────────────────────────────────────────────────────────────────────────╮│
-│  │ [PR Check - 14:45]                                                      ││
-│  │                                                                         ││
-│  │ Checking open PRs...                                                    ││
-│  │                                                                         ││
-│  │ > gh pr list --author @me                                               ││
-│  │ #47  Add rich list commands      swift-eagle   work/swift-eagle         ││
-│  │ #48  Improve error messages      calm-deer     work/calm-deer           ││
-│  │                                                                         ││
-│  │ Checking CI status for #47...                                           ││
-│  │ > gh pr checks 47                                                       ││
-│  │ ✓ All checks passed                                                     ││
-│  │                                                                         ││
-│  │ PR #47 is ready to merge!                                               ││
-│  │ > gh pr merge 47 --squash --auto                                        ││
-│  │ ✓ Merged #47 into main                                                  ││
-│  │                                                                         ││
-│  │ Notifying supervisor of merge...                                        ││
-│  │ > multiclaude agent send-message supervisor "Merged PR #47: Add rich    ││
-│  │   list commands"                                                        ││
-│  ╰─────────────────────────────────────────────────────────────────────────╯│
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│ Merge Queue:                                                     │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ╭──────────────────────────────────────────────────────────────╮│
+│  │ [PR Check - 14:45]                                          ││
+│  │                                                              ││
+│  │ Checking open PRs...                                         ││
+│  │                                                              ││
+│  │ > gh pr list --author @me                                    ││
+│  │ #47  Add rich list commands    swift-eagle  work/swift-eagle││
+│  │ #48  Improve error messages    calm-deer    work/calm-deer  ││
+│  │                                                              ││
+│  │ Checking CI status for #47...                                ││
+│  │ > gh pr checks 47                                            ││
+│  │ ✓ All checks passed                                          ││
+│  │                                                              ││
+│  │ PR #47 is ready to merge!                                    ││
+│  │ > gh pr merge 47 --squash --auto                             ││
+│  │ ✓ Merged #47 into main                                       ││
+│  │                                                              ││
+│  │ Notifying supervisor of merge...                             ││
+│  │ > multiclaude agent send-message supervisor "Merged PR #47:  ││
+│  │   Add rich list commands"                                    ││
+│  ╰──────────────────────────────────────────────────────────────╯│
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
 ```
 
 When CI fails, the merge queue can spawn workers to fix it:
 
 ```
-│  │ Checking CI status for #48...                                           ││
-│  │ ✗ Tests failed: 2 failures in error_test.go                             ││
-│  │                                                                         ││
-│  │ Spawning fixup worker for #48...                                        ││
-│  │ > multiclaude work "Fix test failures in PR #48" --branch work/calm-deer││
-│  │ ✓ Worker created: quick-fox                                             ││
-│  │                                                                         ││
-│  │ I'll check back on #48 after quick-fox pushes a fix.                    ││
+│  │ Checking CI status for #48...                                ││
+│  │ ✗ Tests failed: 2 failures in error_test.go                  ││
+│  │                                                              ││
+│  │ Spawning fixup worker for #48...                             ││
+│  │ > multiclaude work "Fix test failures in PR #48" \           ││
+│  │   --branch work/calm-deer                                    ││
+│  │ ✓ Worker created: quick-fox                                  ││
+│  │                                                              ││
+│  │ I'll check back on #48 after quick-fox pushes a fix.         ││
 ```
 
 ## Architecture
 
 ### Design Principles
 
-1. **Observable** - All agent activity visible via tmux. Attach anytime to watch or intervene.
-2. **Isolated** - Each agent works in its own git worktree. No interference between tasks.
-3. **Recoverable** - State persists to disk. Daemon recovers gracefully from crashes.
-4. **Safe** - Agents never weaken CI or bypass checks without human approval.
-5. **Simple** - Minimal abstractions. Filesystem for state, tmux for visibility, git for isolation.
+1. **Observable** - All agent activity visible via tmux. Attach anytime
+   to watch or intervene.
+2. **Isolated** - Each agent works in its own git worktree. No
+   interference between tasks.
+3. **Recoverable** - State persists to disk. Daemon recovers gracefully
+   from crashes.
+4. **Safe** - Agents never weaken CI or bypass checks without human
+   approval.
+5. **Simple** - Minimal abstractions. Filesystem for state, tmux for
+   visibility, git for isolation.
 
 ### Directory Structure
 
 ```
 ~/.multiclaude/
-├── daemon.pid          # Daemon process ID
-├── daemon.sock         # Unix socket for CLI
-├── daemon.log          # Daemon logs
-├── state.json          # Persisted state
-├── repos/<repo>/       # Cloned repositories
-├── wts/<repo>/         # Git worktrees (supervisor, merge-queue, workers)
-├── messages/<repo>/    # Inter-agent messages
-└── claude-config/<repo>/<agent>/  # Per-agent Claude configuration (slash commands)
+├── daemon.pid                      # Daemon process ID
+├── daemon.sock                     # Unix socket for CLI
+├── daemon.log                      # Daemon logs
+├── state.json                      # Persisted state
+├── repos/<repo>/                   # Cloned repositories
+├── wts/<repo>/                     # Git worktrees (supervisor,
+│                                   # merge-queue, workers)
+├── messages/<repo>/                # Inter-agent messages
+└── claude-config/<repo>/<agent>/   # Per-agent Claude configuration
+                                    # (slash commands)
 ```
 
 ### Repository Configuration
@@ -424,7 +544,8 @@ Repositories can include optional configuration in `.multiclaude/`:
 
 ## Public Libraries
 
-multiclaude includes two reusable Go packages that can be used independently of the orchestrator:
+multiclaude includes two reusable Go packages that can be used
+independently of the orchestrator:
 
 ### pkg/tmux - Programmatic tmux Interaction
 
@@ -432,15 +553,23 @@ multiclaude includes two reusable Go packages that can be used independently of 
 go get github.com/dlorenc/multiclaude/pkg/tmux
 ```
 
-Unlike existing Go tmux libraries ([gotmux](https://github.com/GianlucaP106/gotmux), [go-tmux](https://github.com/jubnzv/go-tmux)) that focus on workspace setup, this package provides features for **programmatic interaction with running CLI applications**:
+Unlike existing Go tmux libraries
+([gotmux](https://github.com/GianlucaP106/gotmux),
+[go-tmux](https://github.com/jubnzv/go-tmux)) that focus on workspace
+setup, this package provides features for **programmatic interaction
+with running CLI applications**:
 
-- **Multiline text via paste-buffer** - Send multi-line input atomically without triggering intermediate processing
-- **Pane PID extraction** - Monitor whether processes in panes are still alive
-- **pipe-pane output capture** - Capture all pane output to files for logging/analysis
+- **Multiline text via paste-buffer** - Send multi-line input
+  atomically without triggering intermediate processing
+- **Pane PID extraction** - Monitor whether processes in panes are
+  still alive
+- **pipe-pane output capture** - Capture all pane output to files for
+  logging/analysis
 
 ```go
 client := tmux.NewClient()
-client.SendKeysLiteral("session", "window", "multi\nline\ntext")  // Uses paste-buffer
+// Uses paste-buffer
+client.SendKeysLiteral("session", "window", "multi\nline\ntext")
 pid, _ := client.GetPanePID("session", "window")
 client.StartPipePane("session", "window", "/tmp/output.log")
 ```
@@ -453,21 +582,29 @@ client.StartPipePane("session", "window", "/tmp/output.log")
 go get github.com/dlorenc/multiclaude/pkg/claude
 ```
 
-A library for launching and interacting with Claude Code instances in terminals:
+A library for launching and interacting with Claude Code instances in
+terminals:
 
-- **Terminal abstraction** - Works with tmux or custom terminal implementations
-- **Session management** - Automatic UUID session IDs and process tracking
+- **Terminal abstraction** - Works with tmux or custom terminal
+  implementations
+- **Session management** - Automatic UUID session IDs and process
+  tracking
 - **Output capture** - Route Claude output to files
-- **Multiline support** - Properly handles multi-line messages to Claude
+- **Multiline support** - Properly handles multi-line messages to
+  Claude
 
 ```go
 runner := claude.NewRunner(
     claude.WithTerminal(tmuxClient),
     claude.WithBinaryPath(claude.ResolveBinaryPath()),
 )
-result, _ := runner.Start("session", "window", claude.Config{
-    SystemPromptFile: "/path/to/prompt.md",
-})
+result, _ := runner.Start(
+    "session",
+    "window",
+    claude.Config{
+        SystemPromptFile: "/path/to/prompt.md",
+    },
+)
 runner.SendMessage("session", "window", "Hello, Claude!")
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,105 +1,60 @@
 # multiclaude
 
-A lightweight orchestrator for running multiple Claude Code agents on
-GitHub repositories.
+A lightweight orchestrator for running multiple Claude Code agents on GitHub repositories.
 
-multiclaude spawns and coordinates autonomous Claude Code instances
-that work together on your codebase. Each agent runs in its own tmux
-window with an isolated git worktree, making all work observable and
-interruptible at any time.
+multiclaude spawns and coordinates autonomous Claude Code instances that work together on your codebase. Each agent runs in its own tmux window with an isolated git worktree, making all work observable and interruptible at any time.
 
 ## Philosophy: The Brownian Ratchet
 
-multiclaude embraces a counterintuitive design principle: **chaos is
-fine, as long as we ratchet forward**.
+multiclaude embraces a counterintuitive design principle: **chaos is fine, as long as we ratchet forward**.
 
-In physics, a Brownian ratchet is a thought experiment where random
-molecular motion is converted into directed movement through a
-mechanism that allows motion in only one direction. multiclaude applies
-this principle to software development.
+In physics, a Brownian ratchet is a thought experiment where random molecular motion is converted into directed movement through a mechanism that allows motion in only one direction. multiclaude applies this principle to software development.
 
-**The Chaos**: Multiple autonomous agents work simultaneously on
-overlapping concerns. They may duplicate effort, create conflicting
-changes, or produce suboptimal solutions. This apparent disorder is not
-a bug—it's a feature. More attempts mean more chances for progress.
+**The Chaos**: Multiple autonomous agents work simultaneously on overlapping concerns. They may duplicate effort, create conflicting changes, or produce suboptimal solutions. This apparent disorder is not a bug—it's a feature. More attempts mean more chances for progress.
 
-**The Ratchet**: CI is the arbiter. If it passes, the code goes in.
-Every merged PR clicks the ratchet forward one notch. Progress is
-permanent—we never go backward. The merge queue agent serves as this
-ratchet mechanism, ensuring that any work meeting the CI bar gets
-incorporated.
+**The Ratchet**: CI is the arbiter. If it passes, the code goes in. Every merged PR clicks the ratchet forward one notch. Progress is permanent—we never go backward. The merge queue agent serves as this ratchet mechanism, ensuring that any work meeting the CI bar gets incorporated.
 
 **Why This Works**:
-- Agents don't need perfect coordination. Redundant work is cheaper than
-  blocked work.
+- Agents don't need perfect coordination. Redundant work is cheaper than blocked work.
 - Failed attempts cost nothing. Only successful attempts matter.
-- Incremental progress compounds. Many small PRs beat waiting for one
-  perfect PR.
-- The system is antifragile. More agents mean more chaos but also more
-  forward motion.
+- Incremental progress compounds. Many small PRs beat waiting for one perfect PR.
+- The system is antifragile. More agents mean more chaos but also more forward motion.
 
-This philosophy means we optimize for throughput of successful changes,
-not efficiency of individual agents. An agent that produces a mergeable
-PR has succeeded, even if another agent was working on the same thing.
+This philosophy means we optimize for throughput of successful changes, not efficiency of individual agents. An agent that produces a mergeable PR has succeeded, even if another agent was working on the same thing.
 
 ## Our Opinions
 
-multiclaude is intentionally opinionated. These aren't configuration
-options—they're core beliefs baked into how the system works:
+multiclaude is intentionally opinionated. These aren't configuration options—they're core beliefs baked into how the system works:
 
 ### CI is King
 
-CI is the source of truth. Period. If tests pass, the code can ship. If
-tests fail, the code doesn't ship. There's no "but the change looks
-right" or "I'm pretty sure it's fine." The automation decides.
+CI is the source of truth. Period. If tests pass, the code can ship. If tests fail, the code doesn't ship. There's no "but the change looks right" or "I'm pretty sure it's fine." The automation decides.
 
-Agents are forbidden from weakening CI to make their work pass. No
-skipping tests, no reducing coverage requirements, no "temporary"
-workarounds. If an agent can't pass CI, it asks for help or tries a
-different approach.
+Agents are forbidden from weakening CI to make their work pass. No skipping tests, no reducing coverage requirements, no "temporary" workarounds. If an agent can't pass CI, it asks for help or tries a different approach.
 
 ### Forward Progress Over Perfection
 
-Any incremental progress is good. A reviewable PR is progress. A
-partial implementation with tests is progress. The only failure is an
-agent that doesn't push the ball forward at all.
+Any incremental progress is good. A reviewable PR is progress. A partial implementation with tests is progress. The only failure is an agent that doesn't push the ball forward at all.
 
-This means we'd rather have three okay PRs than wait for one perfect
-PR. We'd rather merge working code now and improve it later than block
-on getting everything right the first time. Small, frequent commits
-beat large, infrequent ones.
+This means we'd rather have three okay PRs than wait for one perfect PR. We'd rather merge working code now and improve it later than block on getting everything right the first time. Small, frequent commits beat large, infrequent ones.
 
 ### Chaos is Expected
 
-Multiple agents working simultaneously will create conflicts, duplicate
-work, and occasionally step on each other's toes. This is fine. This is
-the plan.
+Multiple agents working simultaneously will create conflicts, duplicate work, and occasionally step on each other's toes. This is fine. This is the plan.
 
-Trying to perfectly coordinate agent work is both expensive and fragile.
-Instead, we let chaos happen and use CI as the ratchet that captures
-forward progress. Wasted work is cheap; blocked work is expensive.
+Trying to perfectly coordinate agent work is both expensive and fragile. Instead, we let chaos happen and use CI as the ratchet that captures forward progress. Wasted work is cheap; blocked work is expensive.
 
 ### Humans Approve, Agents Execute
 
-Agents do the work. Humans set the direction and approve the results.
-Agents should never make decisions that require human judgment—they
-should ask.
+Agents do the work. Humans set the direction and approve the results. Agents should never make decisions that require human judgment—they should ask.
 
-This means agents create PRs for human review. Agents ask the
-supervisor when they're stuck. Agents don't bypass review requirements
-or merge without appropriate approval. The merge queue agent can
-auto-merge, but only when CI passes and review requirements are met.
+This means agents create PRs for human review. Agents ask the supervisor when they're stuck. Agents don't bypass review requirements or merge without appropriate approval. The merge queue agent can auto-merge, but only when CI passes and review requirements are met.
 
 ## Gastown and multiclaude
 
-multiclaude was developed independently but shares similar goals with
-[Gastown](https://github.com/steveyegge/gastown), Steve Yegge's
-multi-agent orchestrator for Claude Code released in January 2026.
+multiclaude was developed independently but shares similar goals with [Gastown](https://github.com/steveyegge/gastown), Steve Yegge's multi-agent orchestrator for Claude Code released in January 2026.
 
-Both projects solve the same fundamental problem: coordinating multiple
-Claude Code instances working on a shared codebase. Both use Go, tmux
-for observability, and git worktrees for isolation. If you're
-evaluating multi-agent orchestrators, you should look at both.
+Both projects solve the same fundamental problem: coordinating multiple Claude Code instances working on a shared codebase. Both use Go, tmux for observability, and git worktrees for isolation. If you're evaluating multi-agent orchestrators, you should look at both.
 
 **Where they differ:**
 
@@ -112,39 +67,23 @@ evaluating multi-agent orchestrators, you should look at both.
 | Philosophy | Minimal, Unix-style simplicity | Comprehensive orchestration system |
 | Maturity | Early development | More established, larger feature set |
 
-multiclaude aims to be a simpler, more lightweight alternative—the
-"worse is better" approach. If you need sophisticated orchestration
-features, work swarming, or built-in crash recovery, Gastown may be a
-better fit.
+multiclaude aims to be a simpler, more lightweight alternative—the "worse is better" approach. If you need sophisticated orchestration features, work swarming, or built-in crash recovery, Gastown may be a better fit.
 
 ### Remote-First: Software is an MMORPG
 
-The biggest philosophical difference: **multiclaude is designed for
-remote-first collaboration**.
+The biggest philosophical difference: **multiclaude is designed for remote-first collaboration**.
 
-Gastown treats agents as NPCs in a single-player game. You're the
-player, agents are your minions. This works great for solo development
-where you want to parallelize your own work.
+Gastown treats agents as NPCs in a single-player game. You're the player, agents are your minions. This works great for solo development where you want to parallelize your own work.
 
-multiclaude treats software engineering as an **MMORPG**. You're one
-player among many—some human, some AI. The workspace agent is your
-character, but other humans have their own workspaces. Workers are
-party members you spawn for quests. The supervisor coordinates the
-guild. The merge queue is the raid boss that decides what loot (code)
-makes it into the vault (main branch).
+multiclaude treats software engineering as an **MMORPG**. You're one player among many—some human, some AI. The workspace agent is your character, but other humans have their own workspaces. Workers are party members you spawn for quests. The supervisor coordinates the guild. The merge queue is the raid boss that decides what loot (code) makes it into the vault (main branch).
 
 This means:
-- **Your workspace persists**. It's your home base, not a temporary
-  session.
-- **You interact with workers, not control them**. Spawn them with a
-  task, check on them later.
+- **Your workspace persists**. It's your home base, not a temporary session.
+- **You interact with workers, not control them**. Spawn them with a task, check on them later.
 - **Other humans can have their own workspaces** on the same repo.
-- **The system keeps running when you're away**. Agents work, PRs
-  merge, CI runs.
+- **The system keeps running when you're away**. Agents work, PRs merge, CI runs.
 
-The workspace is where you hop in to spawn agents, check on progress,
-review what landed, and plan the next sprint—then hop out and let the
-system work while you sleep.
+The workspace is where you hop in to spawn agents, check on progress, review what landed, and plan the next sprint—then hop out and let the system work while you sleep.
 
 ## Quick Start
 
@@ -169,18 +108,13 @@ tmux attach -t mc-repo
 
 ## How It Works
 
-multiclaude creates a tmux session for each repository with three types
-of agents:
+multiclaude creates a tmux session for each repository with three types of agents:
 
-1. **Supervisor** - Coordinates all agents, answers status questions,
-   nudges stuck workers
+1. **Supervisor** - Coordinates all agents, answers status questions, nudges stuck workers
 2. **Workers** - Execute specific tasks, create PRs when done
-3. **Merge Queue** - Monitors PRs, merges when CI passes, spawns fixup
-   workers as needed
+3. **Merge Queue** - Monitors PRs, merges when CI passes, spawns fixup workers as needed
 
-Agents communicate via a filesystem-based message system. The daemon
-routes messages and periodically nudges agents to keep work moving
-forward.
+Agents communicate via a filesystem-based message system. The daemon routes messages and periodically nudges agents to keep work moving forward.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -202,109 +136,71 @@ forward.
 ### Daemon
 
 ```bash
-# Start the daemon
-multiclaude start
-# Stop the daemon
-multiclaude daemon stop
-# Show daemon status
-multiclaude daemon status
-# Follow daemon logs
-multiclaude daemon logs -f
-# Stop everything, kill all tmux sessions
-multiclaude stop-all
-# Stop and remove all state files
-multiclaude stop-all --clean
+multiclaude start              # Start the daemon
+multiclaude daemon stop        # Stop the daemon
+multiclaude daemon status      # Show daemon status
+multiclaude daemon logs -f     # Follow daemon logs
+multiclaude stop-all           # Stop everything, kill all tmux sessions
+multiclaude stop-all --clean   # Stop and remove all state files
 ```
 
 ### Repositories
 
 ```bash
-# Initialize repository tracking
-multiclaude init <github-url>
-# With custom local path or name
-multiclaude init <github-url> [path] [name]
-# List tracked repositories
-multiclaude list
-# Remove a tracked repository
-multiclaude repo rm <name>
+multiclaude init <github-url>              # Initialize repository tracking
+multiclaude init <github-url> [path] [name] # With custom local path or name
+multiclaude list                           # List tracked repositories
+multiclaude repo rm <name>                 # Remove a tracked repository
 ```
 
 ### Workspaces
 
-Workspaces are persistent Claude sessions where you interact with the
-codebase, spawn workers, and manage your development flow. Each
-workspace has its own git worktree, tmux window, and Claude instance.
+Workspaces are persistent Claude sessions where you interact with the codebase, spawn workers, and manage your development flow. Each workspace has its own git worktree, tmux window, and Claude instance.
 
 ```bash
-# Create a new workspace
-multiclaude workspace add <name>
-# Create from specific branch
-multiclaude workspace add <name> --branch main
-# List all workspaces
-multiclaude workspace list
-# Attach to a workspace
-multiclaude workspace connect <name>
-# Remove workspace (warns if uncommitted work)
-multiclaude workspace rm <name>
-# List workspaces (shorthand)
-multiclaude workspace
-# Connect to workspace (shorthand)
-multiclaude workspace <name>
+multiclaude workspace add <name>           # Create a new workspace
+multiclaude workspace add <name> --branch main  # Create from specific branch
+multiclaude workspace list                 # List all workspaces
+multiclaude workspace connect <name>       # Attach to a workspace
+multiclaude workspace rm <name>            # Remove workspace (warns if uncommitted work)
+multiclaude workspace                      # List workspaces (shorthand)
+multiclaude workspace <name>               # Connect to workspace (shorthand)
 ```
 
 **Notes:**
 - Workspaces use the branch naming convention `workspace/<name>`
-- Workspace names follow git branch naming rules (no spaces, special
-  characters, etc.)
-- A "default" workspace is created automatically when you run
-  `multiclaude init`
-- Use `multiclaude attach <workspace-name>` as an alternative to
-  `workspace connect`
+- Workspace names follow git branch naming rules (no spaces, special characters, etc.)
+- A "default" workspace is created automatically when you run `multiclaude init`
+- Use `multiclaude attach <workspace-name>` as an alternative to `workspace connect`
 
 ### Workers
 
 ```bash
-# Create worker for task
-multiclaude work "task description"
-# Start from specific branch
-multiclaude work "task" --branch feature
-# Iterate on existing PR
-multiclaude work "Fix tests" \
-  --branch origin/work/fox --push-to work/fox
-# List active workers
-multiclaude work list
-# Remove worker (warns if uncommitted work)
-multiclaude work rm <name>
+multiclaude work "task description"        # Create worker for task
+multiclaude work "task" --branch feature   # Start from specific branch
+multiclaude work "Fix tests" --branch origin/work/fox --push-to work/fox  # Iterate on existing PR
+multiclaude work list                      # List active workers
+multiclaude work rm <name>                 # Remove worker (warns if uncommitted work)
 ```
 
-The `--push-to` flag creates a worker that pushes to an existing branch
-instead of creating a new PR. Use this when you want to iterate on an
-existing PR.
+The `--push-to` flag creates a worker that pushes to an existing branch instead of creating a new PR. Use this when you want to iterate on an existing PR.
 
 ### Observing
 
 ```bash
-# Attach to agent's tmux window
-multiclaude attach <agent-name>
-# Observe without interaction
-multiclaude attach <agent-name> --read-only
-# Attach to entire repo session
-tmux attach -t mc-<repo>
+multiclaude attach <agent-name>            # Attach to agent's tmux window
+multiclaude attach <agent-name> --read-only # Observe without interaction
+tmux attach -t mc-<repo>                   # Attach to entire repo session
 ```
 
 ### Agent Commands (run from within Claude)
 
 ```bash
-# Send message to another agent
-multiclaude agent send-message <to> "msg"
-# Broadcast to all agents
-multiclaude agent send-message --all "msg"
-# List incoming messages
-multiclaude agent list-messages
-# Acknowledge a message
-multiclaude agent ack-message <id>
-# Signal task completion (workers)
-multiclaude agent complete
+multiclaude agent send-message <to> "msg"  # Send message to another agent
+multiclaude agent send-message --all "msg" # Broadcast to all agents
+multiclaude agent list-messages            # List incoming messages
+multiclaude agent ack-message <id>         # Acknowledge a message
+multiclaude agent complete                 # Signal task completion (workers)
 ```
 
 ### Agent Slash Commands (available within Claude sessions)
@@ -320,34 +216,31 @@ Agents have access to multiclaude-specific slash commands:
 
 ### What the tmux Session Looks Like
 
-When you attach to a repo's tmux session, you'll see multiple
-windows—one per agent:
+When you attach to a repo's tmux session, you'll see multiple windows—one per agent:
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│ mc-myrepo: supervisor | merge-queue | workspace | swift-eagle |  │
-│            calm-deer                                             │
-├──────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  $ claude                                                        │
-│                                                                  │
-│  ╭──────────────────────────────────────────────────────────────╮│
-│  │ I'll check on the current workers and see if anyone needs   ││
-│  │ help.                                                        ││
-│  │                                                              ││
-│  │ > multiclaude work list                                      ││
-│  │ Workers (2):                                                 ││
-│  │   - swift-eagle: working on issue #44                        ││
-│  │   - calm-deer: working on issue #24                          ││
-│  │                                                              ││
-│  │ Both workers are making progress. swift-eagle just pushed a  ││
-│  │ commit. I'll check back in a few minutes.                    ││
-│  ╰──────────────────────────────────────────────────────────────╯│
-│                                                                  │
-│  ──────────────────────────────────────────────────────────────  │
-│  > What would you like to do?                                    │
-│                                                                  │
-└──────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ mc-myrepo: supervisor | merge-queue | workspace | swift-eagle | calm-deer   │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  $ claude                                                                   │
+│                                                                             │
+│  ╭─────────────────────────────────────────────────────────────────────────╮│
+│  │ I'll check on the current workers and see if anyone needs help.        ││
+│  │                                                                         ││
+│  │ > multiclaude work list                                                 ││
+│  │ Workers (2):                                                            ││
+│  │   - swift-eagle: working on issue #44                                   ││
+│  │   - calm-deer: working on issue #24                                     ││
+│  │                                                                         ││
+│  │ Both workers are making progress. swift-eagle just pushed a commit.    ││
+│  │ I'll check back in a few minutes.                                       ││
+│  ╰─────────────────────────────────────────────────────────────────────────╯│
+│                                                                             │
+│  ─────────────────────────────────────────────────────────────────────────  │
+│  > What would you like to do?                                               │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
 ```
 
 Use standard tmux navigation:
@@ -358,93 +251,88 @@ Use standard tmux navigation:
 
 ### Workflow: Spawning Workers from Your Workspace
 
-Your workspace is a persistent Claude session where you can spawn and
-manage workers:
+Your workspace is a persistent Claude session where you can spawn and manage workers:
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│ You (in workspace):                                              │
-├──────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  > Let's tackle issues #44 and #45 in parallel                   │
-│                                                                  │
-│  ╭──────────────────────────────────────────────────────────────╮│
-│  │ I'll spawn workers for both issues.                         ││
-│  │                                                              ││
-│  │ > multiclaude work "Implement rich list commands per issue   ││
-│  │   #44"                                                       ││
-│  │ ✓ Worker created: swift-eagle (branch: work/swift-eagle)    ││
-│  │                                                              ││
-│  │ > multiclaude work "Improve error messages per issue #45"    ││
-│  │ ✓ Worker created: calm-deer (branch: work/calm-deer)        ││
-│  │                                                              ││
-│  │ Both workers are now running. You can check on them with:    ││
-│  │   multiclaude work list                                      ││
-│  │   multiclaude attach swift-eagle                             ││
-│  ╰──────────────────────────────────────────────────────────────╯│
-│                                                                  │
-│  > Great, let me know when they finish. I'm going to grab lunch. │
-│                                                                  │
-│  ╭──────────────────────────────────────────────────────────────╮│
-│  │ Will do! I'll get notified when they complete and can       ││
-│  │ summarize their PRs when you're back. The workers will keep  ││
-│  │ running while you're away.                                   ││
-│  ╰──────────────────────────────────────────────────────────────╯│
-│                                                                  │
-└──────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ You (in workspace):                                                         │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  > Let's tackle issues #44 and #45 in parallel                              │
+│                                                                             │
+│  ╭─────────────────────────────────────────────────────────────────────────╮│
+│  │ I'll spawn workers for both issues.                                     ││
+│  │                                                                         ││
+│  │ > multiclaude work "Implement rich list commands per issue #44"         ││
+│  │ ✓ Worker created: swift-eagle (branch: work/swift-eagle)                ││
+│  │                                                                         ││
+│  │ > multiclaude work "Improve error messages per issue #45"               ││
+│  │ ✓ Worker created: calm-deer (branch: work/calm-deer)                    ││
+│  │                                                                         ││
+│  │ Both workers are now running. You can check on them with:               ││
+│  │   multiclaude work list                                                 ││
+│  │   multiclaude attach swift-eagle                                        ││
+│  ╰─────────────────────────────────────────────────────────────────────────╯│
+│                                                                             │
+│  > Great, let me know when they finish. I'm going to grab lunch.            │
+│                                                                             │
+│  ╭─────────────────────────────────────────────────────────────────────────╮│
+│  │ Will do! I'll get notified when they complete and can summarize         ││
+│  │ their PRs when you're back. The workers will keep running while         ││
+│  │ you're away.                                                            ││
+│  ╰─────────────────────────────────────────────────────────────────────────╯│
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
 ```
 
 Later, when you return:
 
 ```
-│  > I'm back. What happened while I was gone?                     │
-│                                                                  │
-│  ╭──────────────────────────────────────────────────────────────╮│
-│  │ Welcome back! Here's the update:                            ││
-│  │                                                              ││
-│  │ ✓ swift-eagle completed - PR #47 created for rich list      ││
-│  │   commands                                                   ││
-│  │ ✓ calm-deer completed - PR #48 created for error messages   ││
-│  │                                                              ││
-│  │ Both PRs are passing CI. The merge queue is monitoring them. ││
-│  ╰──────────────────────────────────────────────────────────────╯│
+│  > I'm back. What happened while I was gone?                                │
+│                                                                             │
+│  ╭─────────────────────────────────────────────────────────────────────────╮│
+│  │ Welcome back! Here's the update:                                        ││
+│  │                                                                         ││
+│  │ ✓ swift-eagle completed - PR #47 created for rich list commands         ││
+│  │ ✓ calm-deer completed - PR #48 created for error messages               ││
+│  │                                                                         ││
+│  │ Both PRs are passing CI. The merge queue is monitoring them.            ││
+│  ╰─────────────────────────────────────────────────────────────────────────╯│
 ```
 
 ### Watching the Supervisor
 
-The supervisor coordinates agents and provides status updates. Attach
-to watch it work:
+The supervisor coordinates agents and provides status updates. Attach to watch it work:
 
 ```bash
 multiclaude attach supervisor --read-only
 ```
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│ Supervisor:                                                      │
-├──────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  ╭──────────────────────────────────────────────────────────────╮│
-│  │ [Periodic check - 14:32]                                    ││
-│  │                                                              ││
-│  │ Checking agent status...                                     ││
-│  │                                                              ││
-│  │ Agents:                                                      ││
-│  │   supervisor: healthy (me)                                   ││
-│  │   merge-queue: healthy, monitoring 2 PRs                     ││
-│  │   workspace: healthy, user attached                          ││
-│  │   swift-eagle: healthy, working on #44                       ││
-│  │   calm-deer: needs attention - stuck on test failure         ││
-│  │                                                              ││
-│  │ Sending help to calm-deer...                                 ││
-│  │                                                              ││
-│  │ > multiclaude agent send-message calm-deer "I see you're     ││
-│  │   stuck on a test failure. The flaky test in auth_test.go    ││
-│  │   sometimes fails due to timing. Try adding a retry or       ││
-│  │   mocking the clock."                                        ││
-│  ╰──────────────────────────────────────────────────────────────╯│
-│                                                                  │
-└──────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Supervisor:                                                                 │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ╭─────────────────────────────────────────────────────────────────────────╮│
+│  │ [Periodic check - 14:32]                                                ││
+│  │                                                                         ││
+│  │ Checking agent status...                                                ││
+│  │                                                                         ││
+│  │ Agents:                                                                 ││
+│  │   supervisor: healthy (me)                                              ││
+│  │   merge-queue: healthy, monitoring 2 PRs                                ││
+│  │   workspace: healthy, user attached                                     ││
+│  │   swift-eagle: healthy, working on #44                                  ││
+│  │   calm-deer: needs attention - stuck on test failure                    ││
+│  │                                                                         ││
+│  │ Sending help to calm-deer...                                            ││
+│  │                                                                         ││
+│  │ > multiclaude agent send-message calm-deer "I see you're stuck on a     ││
+│  │   test failure. The flaky test in auth_test.go sometimes fails due to   ││
+│  │   timing. Try adding a retry or mocking the clock."                     ││
+│  ╰─────────────────────────────────────────────────────────────────────────╯│
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Watching the Merge Queue
@@ -456,78 +344,70 @@ multiclaude attach merge-queue --read-only
 ```
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│ Merge Queue:                                                     │
-├──────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  ╭──────────────────────────────────────────────────────────────╮│
-│  │ [PR Check - 14:45]                                          ││
-│  │                                                              ││
-│  │ Checking open PRs...                                         ││
-│  │                                                              ││
-│  │ > gh pr list --author @me                                    ││
-│  │ #47  Add rich list commands    swift-eagle  work/swift-eagle││
-│  │ #48  Improve error messages    calm-deer    work/calm-deer  ││
-│  │                                                              ││
-│  │ Checking CI status for #47...                                ││
-│  │ > gh pr checks 47                                            ││
-│  │ ✓ All checks passed                                          ││
-│  │                                                              ││
-│  │ PR #47 is ready to merge!                                    ││
-│  │ > gh pr merge 47 --squash --auto                             ││
-│  │ ✓ Merged #47 into main                                       ││
-│  │                                                              ││
-│  │ Notifying supervisor of merge...                             ││
-│  │ > multiclaude agent send-message supervisor "Merged PR #47:  ││
-│  │   Add rich list commands"                                    ││
-│  ╰──────────────────────────────────────────────────────────────╯│
-│                                                                  │
-└──────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Merge Queue:                                                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ╭─────────────────────────────────────────────────────────────────────────╮│
+│  │ [PR Check - 14:45]                                                      ││
+│  │                                                                         ││
+│  │ Checking open PRs...                                                    ││
+│  │                                                                         ││
+│  │ > gh pr list --author @me                                               ││
+│  │ #47  Add rich list commands      swift-eagle   work/swift-eagle         ││
+│  │ #48  Improve error messages      calm-deer     work/calm-deer           ││
+│  │                                                                         ││
+│  │ Checking CI status for #47...                                           ││
+│  │ > gh pr checks 47                                                       ││
+│  │ ✓ All checks passed                                                     ││
+│  │                                                                         ││
+│  │ PR #47 is ready to merge!                                               ││
+│  │ > gh pr merge 47 --squash --auto                                        ││
+│  │ ✓ Merged #47 into main                                                  ││
+│  │                                                                         ││
+│  │ Notifying supervisor of merge...                                        ││
+│  │ > multiclaude agent send-message supervisor "Merged PR #47: Add rich    ││
+│  │   list commands"                                                        ││
+│  ╰─────────────────────────────────────────────────────────────────────────╯│
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
 ```
 
 When CI fails, the merge queue can spawn workers to fix it:
 
 ```
-│  │ Checking CI status for #48...                                ││
-│  │ ✗ Tests failed: 2 failures in error_test.go                  ││
-│  │                                                              ││
-│  │ Spawning fixup worker for #48...                             ││
-│  │ > multiclaude work "Fix test failures in PR #48" \           ││
-│  │   --branch work/calm-deer                                    ││
-│  │ ✓ Worker created: quick-fox                                  ││
-│  │                                                              ││
-│  │ I'll check back on #48 after quick-fox pushes a fix.         ││
+│  │ Checking CI status for #48...                                           ││
+│  │ ✗ Tests failed: 2 failures in error_test.go                             ││
+│  │                                                                         ││
+│  │ Spawning fixup worker for #48...                                        ││
+│  │ > multiclaude work "Fix test failures in PR #48" --branch work/calm-deer││
+│  │ ✓ Worker created: quick-fox                                             ││
+│  │                                                                         ││
+│  │ I'll check back on #48 after quick-fox pushes a fix.                    ││
 ```
 
 ## Architecture
 
 ### Design Principles
 
-1. **Observable** - All agent activity visible via tmux. Attach anytime
-   to watch or intervene.
-2. **Isolated** - Each agent works in its own git worktree. No
-   interference between tasks.
-3. **Recoverable** - State persists to disk. Daemon recovers gracefully
-   from crashes.
-4. **Safe** - Agents never weaken CI or bypass checks without human
-   approval.
-5. **Simple** - Minimal abstractions. Filesystem for state, tmux for
-   visibility, git for isolation.
+1. **Observable** - All agent activity visible via tmux. Attach anytime to watch or intervene.
+2. **Isolated** - Each agent works in its own git worktree. No interference between tasks.
+3. **Recoverable** - State persists to disk. Daemon recovers gracefully from crashes.
+4. **Safe** - Agents never weaken CI or bypass checks without human approval.
+5. **Simple** - Minimal abstractions. Filesystem for state, tmux for visibility, git for isolation.
 
 ### Directory Structure
 
 ```
 ~/.multiclaude/
-├── daemon.pid                      # Daemon process ID
-├── daemon.sock                     # Unix socket for CLI
-├── daemon.log                      # Daemon logs
-├── state.json                      # Persisted state
-├── repos/<repo>/                   # Cloned repositories
-├── wts/<repo>/                     # Git worktrees (supervisor,
-│                                   # merge-queue, workers)
-├── messages/<repo>/                # Inter-agent messages
-└── claude-config/<repo>/<agent>/   # Per-agent Claude configuration
-                                    # (slash commands)
+├── daemon.pid          # Daemon process ID
+├── daemon.sock         # Unix socket for CLI
+├── daemon.log          # Daemon logs
+├── state.json          # Persisted state
+├── repos/<repo>/       # Cloned repositories
+├── wts/<repo>/         # Git worktrees (supervisor, merge-queue, workers)
+├── messages/<repo>/    # Inter-agent messages
+└── claude-config/<repo>/<agent>/  # Per-agent Claude configuration (slash commands)
 ```
 
 ### Repository Configuration
@@ -544,8 +424,7 @@ Repositories can include optional configuration in `.multiclaude/`:
 
 ## Public Libraries
 
-multiclaude includes two reusable Go packages that can be used
-independently of the orchestrator:
+multiclaude includes two reusable Go packages that can be used independently of the orchestrator:
 
 ### pkg/tmux - Programmatic tmux Interaction
 
@@ -553,23 +432,15 @@ independently of the orchestrator:
 go get github.com/dlorenc/multiclaude/pkg/tmux
 ```
 
-Unlike existing Go tmux libraries
-([gotmux](https://github.com/GianlucaP106/gotmux),
-[go-tmux](https://github.com/jubnzv/go-tmux)) that focus on workspace
-setup, this package provides features for **programmatic interaction
-with running CLI applications**:
+Unlike existing Go tmux libraries ([gotmux](https://github.com/GianlucaP106/gotmux), [go-tmux](https://github.com/jubnzv/go-tmux)) that focus on workspace setup, this package provides features for **programmatic interaction with running CLI applications**:
 
-- **Multiline text via paste-buffer** - Send multi-line input
-  atomically without triggering intermediate processing
-- **Pane PID extraction** - Monitor whether processes in panes are
-  still alive
-- **pipe-pane output capture** - Capture all pane output to files for
-  logging/analysis
+- **Multiline text via paste-buffer** - Send multi-line input atomically without triggering intermediate processing
+- **Pane PID extraction** - Monitor whether processes in panes are still alive
+- **pipe-pane output capture** - Capture all pane output to files for logging/analysis
 
 ```go
 client := tmux.NewClient()
-// Uses paste-buffer
-client.SendKeysLiteral("session", "window", "multi\nline\ntext")
+client.SendKeysLiteral("session", "window", "multi\nline\ntext")  // Uses paste-buffer
 pid, _ := client.GetPanePID("session", "window")
 client.StartPipePane("session", "window", "/tmp/output.log")
 ```
@@ -582,29 +453,21 @@ client.StartPipePane("session", "window", "/tmp/output.log")
 go get github.com/dlorenc/multiclaude/pkg/claude
 ```
 
-A library for launching and interacting with Claude Code instances in
-terminals:
+A library for launching and interacting with Claude Code instances in terminals:
 
-- **Terminal abstraction** - Works with tmux or custom terminal
-  implementations
-- **Session management** - Automatic UUID session IDs and process
-  tracking
+- **Terminal abstraction** - Works with tmux or custom terminal implementations
+- **Session management** - Automatic UUID session IDs and process tracking
 - **Output capture** - Route Claude output to files
-- **Multiline support** - Properly handles multi-line messages to
-  Claude
+- **Multiline support** - Properly handles multi-line messages to Claude
 
 ```go
 runner := claude.NewRunner(
     claude.WithTerminal(tmuxClient),
     claude.WithBinaryPath(claude.ResolveBinaryPath()),
 )
-result, _ := runner.Start(
-    "session",
-    "window",
-    claude.Config{
-        SystemPromptFile: "/path/to/prompt.md",
-    },
-)
+result, _ := runner.Start("session", "window", claude.Config{
+    SystemPromptFile: "/path/to/prompt.md",
+})
 runner.SendMessage("session", "window", "Hello, Claude!")
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,60 +1,105 @@
 # multiclaude
 
-A lightweight orchestrator for running multiple Claude Code agents on GitHub repositories.
+A lightweight orchestrator for running multiple Claude Code agents on
+GitHub repositories.
 
-multiclaude spawns and coordinates autonomous Claude Code instances that work together on your codebase. Each agent runs in its own tmux window with an isolated git worktree, making all work observable and interruptible at any time.
+multiclaude spawns and coordinates autonomous Claude Code instances that
+work together on your codebase. Each agent runs in its own tmux window
+with an isolated git worktree, making all work observable and
+interruptible at any time.
 
 ## Philosophy: The Brownian Ratchet
 
-multiclaude embraces a counterintuitive design principle: **chaos is fine, as long as we ratchet forward**.
+multiclaude embraces a counterintuitive design principle: **chaos is
+fine, as long as we ratchet forward**.
 
-In physics, a Brownian ratchet is a thought experiment where random molecular motion is converted into directed movement through a mechanism that allows motion in only one direction. multiclaude applies this principle to software development.
+In physics, a Brownian ratchet is a thought experiment where random
+molecular motion is converted into directed movement through a mechanism
+that allows motion in only one direction. multiclaude applies this
+principle to software development.
 
-**The Chaos**: Multiple autonomous agents work simultaneously on overlapping concerns. They may duplicate effort, create conflicting changes, or produce suboptimal solutions. This apparent disorder is not a bug—it's a feature. More attempts mean more chances for progress.
+**The Chaos**: Multiple autonomous agents work simultaneously on
+overlapping concerns. They may duplicate effort, create conflicting
+changes, or produce suboptimal solutions. This apparent disorder is not
+a bug—it's a feature. More attempts mean more chances for progress.
 
-**The Ratchet**: CI is the arbiter. If it passes, the code goes in. Every merged PR clicks the ratchet forward one notch. Progress is permanent—we never go backward. The merge queue agent serves as this ratchet mechanism, ensuring that any work meeting the CI bar gets incorporated.
+**The Ratchet**: CI is the arbiter. If it passes, the code goes in.
+Every merged PR clicks the ratchet forward one notch. Progress is
+permanent—we never go backward. The merge queue agent serves as this
+ratchet mechanism, ensuring that any work meeting the CI bar gets
+incorporated.
 
 **Why This Works**:
-- Agents don't need perfect coordination. Redundant work is cheaper than blocked work.
+- Agents don't need perfect coordination. Redundant work is cheaper than
+  blocked work.
 - Failed attempts cost nothing. Only successful attempts matter.
-- Incremental progress compounds. Many small PRs beat waiting for one perfect PR.
-- The system is antifragile. More agents mean more chaos but also more forward motion.
+- Incremental progress compounds. Many small PRs beat waiting for one
+  perfect PR.
+- The system is antifragile. More agents mean more chaos but also more
+  forward motion.
 
-This philosophy means we optimize for throughput of successful changes, not efficiency of individual agents. An agent that produces a mergeable PR has succeeded, even if another agent was working on the same thing.
+This philosophy means we optimize for throughput of successful changes,
+not efficiency of individual agents. An agent that produces a mergeable
+PR has succeeded, even if another agent was working on the same thing.
 
 ## Our Opinions
 
-multiclaude is intentionally opinionated. These aren't configuration options—they're core beliefs baked into how the system works:
+multiclaude is intentionally opinionated. These aren't configuration
+options—they're core beliefs baked into how the system works:
 
 ### CI is King
 
-CI is the source of truth. Period. If tests pass, the code can ship. If tests fail, the code doesn't ship. There's no "but the change looks right" or "I'm pretty sure it's fine." The automation decides.
+CI is the source of truth. Period. If tests pass, the code can ship. If
+tests fail, the code doesn't ship. There's no "but the change looks
+right" or "I'm pretty sure it's fine." The automation decides.
 
-Agents are forbidden from weakening CI to make their work pass. No skipping tests, no reducing coverage requirements, no "temporary" workarounds. If an agent can't pass CI, it asks for help or tries a different approach.
+Agents are forbidden from weakening CI to make their work pass. No
+skipping tests, no reducing coverage requirements, no "temporary"
+workarounds. If an agent can't pass CI, it asks for help or tries a
+different approach.
 
 ### Forward Progress Over Perfection
 
-Any incremental progress is good. A reviewable PR is progress. A partial implementation with tests is progress. The only failure is an agent that doesn't push the ball forward at all.
+Any incremental progress is good. A reviewable PR is progress. A partial
+implementation with tests is progress. The only failure is an agent that
+doesn't push the ball forward at all.
 
-This means we'd rather have three okay PRs than wait for one perfect PR. We'd rather merge working code now and improve it later than block on getting everything right the first time. Small, frequent commits beat large, infrequent ones.
+This means we'd rather have three okay PRs than wait for one perfect PR.
+We'd rather merge working code now and improve it later than block on
+getting everything right the first time. Small, frequent commits beat
+large, infrequent ones.
 
 ### Chaos is Expected
 
-Multiple agents working simultaneously will create conflicts, duplicate work, and occasionally step on each other's toes. This is fine. This is the plan.
+Multiple agents working simultaneously will create conflicts, duplicate
+work, and occasionally step on each other's toes. This is fine. This is
+the plan.
 
-Trying to perfectly coordinate agent work is both expensive and fragile. Instead, we let chaos happen and use CI as the ratchet that captures forward progress. Wasted work is cheap; blocked work is expensive.
+Trying to perfectly coordinate agent work is both expensive and fragile.
+Instead, we let chaos happen and use CI as the ratchet that captures
+forward progress. Wasted work is cheap; blocked work is expensive.
 
 ### Humans Approve, Agents Execute
 
-Agents do the work. Humans set the direction and approve the results. Agents should never make decisions that require human judgment—they should ask.
+Agents do the work. Humans set the direction and approve the results.
+Agents should never make decisions that require human judgment—they
+should ask.
 
-This means agents create PRs for human review. Agents ask the supervisor when they're stuck. Agents don't bypass review requirements or merge without appropriate approval. The merge queue agent can auto-merge, but only when CI passes and review requirements are met.
+This means agents create PRs for human review. Agents ask the supervisor
+when they're stuck. Agents don't bypass review requirements or merge
+without appropriate approval. The merge queue agent can auto-merge, but
+only when CI passes and review requirements are met.
 
 ## Gastown and multiclaude
 
-multiclaude was developed independently but shares similar goals with [Gastown](https://github.com/steveyegge/gastown), Steve Yegge's multi-agent orchestrator for Claude Code released in January 2026.
+multiclaude was developed independently but shares similar goals with
+[Gastown](https://github.com/steveyegge/gastown), Steve Yegge's
+multi-agent orchestrator for Claude Code released in January 2026.
 
-Both projects solve the same fundamental problem: coordinating multiple Claude Code instances working on a shared codebase. Both use Go, tmux for observability, and git worktrees for isolation. If you're evaluating multi-agent orchestrators, you should look at both.
+Both projects solve the same fundamental problem: coordinating multiple
+Claude Code instances working on a shared codebase. Both use Go, tmux
+for observability, and git worktrees for isolation. If you're evaluating
+multi-agent orchestrators, you should look at both.
 
 **Where they differ:**
 
@@ -67,23 +112,39 @@ Both projects solve the same fundamental problem: coordinating multiple Claude C
 | Philosophy | Minimal, Unix-style simplicity | Comprehensive orchestration system |
 | Maturity | Early development | More established, larger feature set |
 
-multiclaude aims to be a simpler, more lightweight alternative—the "worse is better" approach. If you need sophisticated orchestration features, work swarming, or built-in crash recovery, Gastown may be a better fit.
+multiclaude aims to be a simpler, more lightweight alternative—the
+"worse is better" approach. If you need sophisticated orchestration
+features, work swarming, or built-in crash recovery, Gastown may be a
+better fit.
 
 ### Remote-First: Software is an MMORPG
 
-The biggest philosophical difference: **multiclaude is designed for remote-first collaboration**.
+The biggest philosophical difference: **multiclaude is designed for
+remote-first collaboration**.
 
-Gastown treats agents as NPCs in a single-player game. You're the player, agents are your minions. This works great for solo development where you want to parallelize your own work.
+Gastown treats agents as NPCs in a single-player game. You're the
+player, agents are your minions. This works great for solo development
+where you want to parallelize your own work.
 
-multiclaude treats software engineering as an **MMORPG**. You're one player among many—some human, some AI. The workspace agent is your character, but other humans have their own workspaces. Workers are party members you spawn for quests. The supervisor coordinates the guild. The merge queue is the raid boss that decides what loot (code) makes it into the vault (main branch).
+multiclaude treats software engineering as an **MMORPG**. You're one
+player among many—some human, some AI. The workspace agent is your
+character, but other humans have their own workspaces. Workers are party
+members you spawn for quests. The supervisor coordinates the guild. The
+merge queue is the raid boss that decides what loot (code) makes it into
+the vault (main branch).
 
 This means:
-- **Your workspace persists**. It's your home base, not a temporary session.
-- **You interact with workers, not control them**. Spawn them with a task, check on them later.
+- **Your workspace persists**. It's your home base, not a temporary
+  session.
+- **You interact with workers, not control them**. Spawn them with a
+  task, check on them later.
 - **Other humans can have their own workspaces** on the same repo.
-- **The system keeps running when you're away**. Agents work, PRs merge, CI runs.
+- **The system keeps running when you're away**. Agents work, PRs merge,
+  CI runs.
 
-The workspace is where you hop in to spawn agents, check on progress, review what landed, and plan the next sprint—then hop out and let the system work while you sleep.
+The workspace is where you hop in to spawn agents, check on progress,
+review what landed, and plan the next sprint—then hop out and let the
+system work while you sleep.
 
 ## Quick Start
 
@@ -108,13 +169,18 @@ tmux attach -t mc-repo
 
 ## How It Works
 
-multiclaude creates a tmux session for each repository with three types of agents:
+multiclaude creates a tmux session for each repository with three types
+of agents:
 
-1. **Supervisor** - Coordinates all agents, answers status questions, nudges stuck workers
+1. **Supervisor** - Coordinates all agents, answers status questions,
+   nudges stuck workers
 2. **Workers** - Execute specific tasks, create PRs when done
-3. **Merge Queue** - Monitors PRs, merges when CI passes, spawns fixup workers as needed
+3. **Merge Queue** - Monitors PRs, merges when CI passes, spawns fixup
+   workers as needed
 
-Agents communicate via a filesystem-based message system. The daemon routes messages and periodically nudges agents to keep work moving forward.
+Agents communicate via a filesystem-based message system. The daemon
+routes messages and periodically nudges agents to keep work moving
+forward.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -155,7 +221,9 @@ multiclaude repo rm <name>                 # Remove a tracked repository
 
 ### Workspaces
 
-Workspaces are persistent Claude sessions where you interact with the codebase, spawn workers, and manage your development flow. Each workspace has its own git worktree, tmux window, and Claude instance.
+Workspaces are persistent Claude sessions where you interact with the
+codebase, spawn workers, and manage your development flow. Each
+workspace has its own git worktree, tmux window, and Claude instance.
 
 ```bash
 multiclaude workspace add <name>           # Create a new workspace
@@ -169,9 +237,12 @@ multiclaude workspace <name>               # Connect to workspace (shorthand)
 
 **Notes:**
 - Workspaces use the branch naming convention `workspace/<name>`
-- Workspace names follow git branch naming rules (no spaces, special characters, etc.)
-- A "default" workspace is created automatically when you run `multiclaude init`
-- Use `multiclaude attach <workspace-name>` as an alternative to `workspace connect`
+- Workspace names follow git branch naming rules (no spaces, special
+  characters, etc.)
+- A "default" workspace is created automatically when you run
+  `multiclaude init`
+- Use `multiclaude attach <workspace-name>` as an alternative to
+  `workspace connect`
 
 ### Workers
 
@@ -183,7 +254,9 @@ multiclaude work list                      # List active workers
 multiclaude work rm <name>                 # Remove worker (warns if uncommitted work)
 ```
 
-The `--push-to` flag creates a worker that pushes to an existing branch instead of creating a new PR. Use this when you want to iterate on an existing PR.
+The `--push-to` flag creates a worker that pushes to an existing branch
+instead of creating a new PR. Use this when you want to iterate on an
+existing PR.
 
 ### Observing
 
@@ -216,7 +289,8 @@ Agents have access to multiclaude-specific slash commands:
 
 ### What the tmux Session Looks Like
 
-When you attach to a repo's tmux session, you'll see multiple windows—one per agent:
+When you attach to a repo's tmux session, you'll see multiple
+windows—one per agent:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -251,7 +325,8 @@ Use standard tmux navigation:
 
 ### Workflow: Spawning Workers from Your Workspace
 
-Your workspace is a persistent Claude session where you can spawn and manage workers:
+Your workspace is a persistent Claude session where you can spawn and
+manage workers:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -302,7 +377,8 @@ Later, when you return:
 
 ### Watching the Supervisor
 
-The supervisor coordinates agents and provides status updates. Attach to watch it work:
+The supervisor coordinates agents and provides status updates. Attach to
+watch it work:
 
 ```bash
 multiclaude attach supervisor --read-only
@@ -390,11 +466,16 @@ When CI fails, the merge queue can spawn workers to fix it:
 
 ### Design Principles
 
-1. **Observable** - All agent activity visible via tmux. Attach anytime to watch or intervene.
-2. **Isolated** - Each agent works in its own git worktree. No interference between tasks.
-3. **Recoverable** - State persists to disk. Daemon recovers gracefully from crashes.
-4. **Safe** - Agents never weaken CI or bypass checks without human approval.
-5. **Simple** - Minimal abstractions. Filesystem for state, tmux for visibility, git for isolation.
+1. **Observable** - All agent activity visible via tmux. Attach anytime
+   to watch or intervene.
+2. **Isolated** - Each agent works in its own git worktree. No
+   interference between tasks.
+3. **Recoverable** - State persists to disk. Daemon recovers gracefully
+   from crashes.
+4. **Safe** - Agents never weaken CI or bypass checks without human
+   approval.
+5. **Simple** - Minimal abstractions. Filesystem for state, tmux for
+   visibility, git for isolation.
 
 ### Directory Structure
 
@@ -424,7 +505,8 @@ Repositories can include optional configuration in `.multiclaude/`:
 
 ## Public Libraries
 
-multiclaude includes two reusable Go packages that can be used independently of the orchestrator:
+multiclaude includes two reusable Go packages that can be used
+independently of the orchestrator:
 
 ### pkg/tmux - Programmatic tmux Interaction
 
@@ -432,11 +514,18 @@ multiclaude includes two reusable Go packages that can be used independently of 
 go get github.com/dlorenc/multiclaude/pkg/tmux
 ```
 
-Unlike existing Go tmux libraries ([gotmux](https://github.com/GianlucaP106/gotmux), [go-tmux](https://github.com/jubnzv/go-tmux)) that focus on workspace setup, this package provides features for **programmatic interaction with running CLI applications**:
+Unlike existing Go tmux libraries
+([gotmux](https://github.com/GianlucaP106/gotmux),
+[go-tmux](https://github.com/jubnzv/go-tmux)) that focus on workspace
+setup, this package provides features for **programmatic interaction
+with running CLI applications**:
 
-- **Multiline text via paste-buffer** - Send multi-line input atomically without triggering intermediate processing
-- **Pane PID extraction** - Monitor whether processes in panes are still alive
-- **pipe-pane output capture** - Capture all pane output to files for logging/analysis
+- **Multiline text via paste-buffer** - Send multi-line input atomically
+  without triggering intermediate processing
+- **Pane PID extraction** - Monitor whether processes in panes are still
+  alive
+- **pipe-pane output capture** - Capture all pane output to files for
+  logging/analysis
 
 ```go
 client := tmux.NewClient()
@@ -453,10 +542,13 @@ client.StartPipePane("session", "window", "/tmp/output.log")
 go get github.com/dlorenc/multiclaude/pkg/claude
 ```
 
-A library for launching and interacting with Claude Code instances in terminals:
+A library for launching and interacting with Claude Code instances in
+terminals:
 
-- **Terminal abstraction** - Works with tmux or custom terminal implementations
-- **Session management** - Automatic UUID session IDs and process tracking
+- **Terminal abstraction** - Works with tmux or custom terminal
+  implementations
+- **Session management** - Automatic UUID session IDs and process
+  tracking
 - **Output capture** - Route Claude output to files
 - **Multiline support** - Properly handles multi-line messages to Claude
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Focus: Make the core experience rock-solid before adding features.
 
 ### P1 - Should Have (this quarter)
 
-- [ ] **Task history**: Track what workers have done and their outcomes (PR merged/closed/pending)
+- [x] **Task history**: Track what workers have done and their outcomes (PR merged/closed/pending)
 - [ ] **Agent restart**: Gracefully restart crashed agents without losing context
 - [ ] **Workspace refresh**: Easy command to sync workspace with latest main
 
@@ -96,4 +96,5 @@ These features are explicitly **not wanted**. PRs implementing them should be cl
 
 ## Changelog
 
+- **2026-02-03**: Marked Task history as complete (P1)
 - **2026-01-20**: Initial roadmap after Phase 1 cleanup (removed notifications, coordination, multi-provider)

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -1,0 +1,414 @@
+# Multiclaude Diagrams
+
+Visual diagrams for understanding multiclaude's architecture and data flows.
+
+## System Overview
+
+```mermaid
+flowchart TB
+    subgraph User["User's Machine"]
+        CLI[CLI Client]
+
+        subgraph Daemon["Daemon Process"]
+            Socket[Socket Server]
+            Health[Health Check<br/>2 min cycle]
+            Router[Message Router<br/>2 min cycle]
+            Wake[Wake/Nudge<br/>2 min cycle]
+            State[(state.json)]
+        end
+
+        subgraph Tmux["tmux session: mc-repo"]
+            Sup[supervisor]
+            MQ[merge-queue]
+            W1[worker-1]
+            W2[worker-2]
+        end
+
+        subgraph Worktrees["Git Worktrees"]
+            WT1[wts/repo/supervisor]
+            WT2[wts/repo/merge-queue]
+            WT3[wts/repo/worker-1]
+            WT4[wts/repo/worker-2]
+        end
+    end
+
+    CLI <-->|Unix Socket| Socket
+    Socket <--> State
+    Health --> Tmux
+    Router --> Tmux
+    Wake --> Tmux
+
+    Sup --> WT1
+    MQ --> WT2
+    W1 --> WT3
+    W2 --> WT4
+```
+
+## The Brownian Ratchet
+
+The core philosophy: chaos creates progress when filtered through CI.
+
+```mermaid
+flowchart LR
+    subgraph Chaos["Agent Activity (Chaotic)"]
+        WA[Worker A<br/>auth feature]
+        WB[Worker B<br/>auth feature]
+        WC[Worker C<br/>bugfix #42]
+    end
+
+    subgraph Ratchet["CI Gate"]
+        CI{CI Passes?}
+    end
+
+    subgraph Progress["Main Branch"]
+        Main[████████████<br/>irreversible progress]
+    end
+
+    WA -->|PR| CI
+    WB -->|PR| CI
+    WC -->|PR| CI
+
+    CI -->|pass| Main
+    CI -->|fail| Retry[retry or<br/>spawn fixup]
+    Retry --> Chaos
+```
+
+## Agent Types and Relationships
+
+```mermaid
+flowchart TB
+    Human[Human User]
+
+    subgraph Agents
+        WS[Workspace<br/>user interactive]
+        SUP[Supervisor<br/>coordination]
+        MQ[Merge Queue<br/>the ratchet]
+        W1[Worker 1]
+        W2[Worker 2]
+        REV[Review Agent]
+    end
+
+    subgraph External
+        GH[(GitHub)]
+        CI[CI System]
+    end
+
+    Human <-->|direct input| WS
+    Human -->|spawns| SUP
+    Human -->|spawns| MQ
+
+    WS -->|spawn| W1
+    SUP -->|guidance| W1
+    SUP -->|guidance| W2
+
+    W1 -->|PR| GH
+    W2 -->|PR| GH
+
+    MQ -->|monitor| GH
+    MQ -->|spawn| REV
+    MQ -->|merge| GH
+
+    REV -->|comments| GH
+
+    GH --> CI
+    CI -->|status| GH
+```
+
+## Worker Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Created: multiclaude work "task"
+
+    Created --> Working: Claude starts
+
+    state Working {
+        [*] --> Coding
+        Coding --> Testing
+        Testing --> Coding: tests fail
+        Testing --> PR: tests pass
+        PR --> [*]
+    }
+
+    Working --> Completing: multiclaude agent complete
+    Completing --> MarkedForCleanup: Daemon marks ReadyForCleanup
+    MarkedForCleanup --> NotifySupervisor: Daemon notifies
+    NotifySupervisor --> NotifyMergeQueue
+    NotifyMergeQueue --> HealthCheckCleanup: Health check runs
+    HealthCheckCleanup --> [*]: Kill window, remove worktree
+```
+
+## Worker Creation Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Daemon
+    participant Git
+    participant Tmux
+    participant Claude
+
+    User->>CLI: multiclaude work "Add tests"
+    CLI->>Daemon: list_agents (socket)
+    Daemon-->>CLI: agent list
+
+    CLI->>Git: worktree add
+    Git-->>CLI: worktree created
+
+    CLI->>Tmux: new-window
+    Tmux-->>CLI: window created
+
+    CLI->>CLI: write prompt file
+
+    CLI->>Tmux: send-keys (start Claude)
+    Tmux->>Claude: launch
+
+    CLI->>Tmux: send-keys (task message)
+
+    CLI->>Daemon: add_agent (worker)
+    Daemon->>Daemon: save state
+    Daemon-->>CLI: success
+
+    CLI-->>User: Worker 'clever-fox' created
+```
+
+## Message Routing
+
+```mermaid
+sequenceDiagram
+    participant AgentA as Worker A
+    participant FS as Filesystem
+    participant Daemon
+    participant Tmux
+    participant AgentB as Supervisor
+
+    AgentA->>FS: write message.json<br/>(status: pending)
+
+    Note over Daemon: 2 min later<br/>message router runs
+
+    Daemon->>FS: scan messages dir
+    FS-->>Daemon: pending messages
+
+    Daemon->>Tmux: send-keys (literal mode)
+    Tmux->>AgentB: paste message
+
+    Daemon->>FS: update status<br/>(pending → delivered)
+```
+
+## Message Status Flow
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending: Message created
+    pending --> delivered: Daemon sends via tmux
+    delivered --> read: Agent sees message
+    read --> acked: Agent acknowledges
+    acked --> [*]: Message deleted
+```
+
+## Repository Initialization
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Daemon
+    participant Git
+    participant Tmux
+    participant FS as Filesystem
+
+    User->>CLI: multiclaude init github.com/org/repo
+
+    CLI->>Daemon: ping
+    Daemon-->>CLI: pong
+
+    CLI->>Git: clone repo
+    Git-->>CLI: cloned
+
+    CLI->>Tmux: new-session mc-repo
+    CLI->>Tmux: new-window supervisor
+    CLI->>Tmux: new-window merge-queue
+
+    CLI->>FS: write prompt files
+
+    CLI->>Tmux: send-keys (start Claude)
+
+    CLI->>Daemon: add_repo
+    Daemon->>FS: save state
+    Daemon-->>CLI: success
+
+    CLI->>Daemon: add_agent (supervisor)
+    CLI->>Daemon: add_agent (merge-queue)
+
+    CLI-->>User: Repository initialized
+```
+
+## Health Check Loop
+
+```mermaid
+flowchart TD
+    Start[Health Check Starts<br/>every 2 min] --> CheckSession{tmux session<br/>exists?}
+
+    CheckSession -->|no| TryRestore[Attempt Restoration]
+    TryRestore -->|success| CheckAgents
+    TryRestore -->|fail| MarkCleanup[Mark agents<br/>for cleanup]
+
+    CheckSession -->|yes| CheckAgents[Check each agent]
+
+    CheckAgents --> WindowExists{tmux window<br/>exists?}
+
+    WindowExists -->|no| RemoveAgent[Remove from state]
+    WindowExists -->|yes| CheckReady{ReadyForCleanup?}
+
+    CheckReady -->|yes| Cleanup[Kill window<br/>Remove worktree<br/>Clean messages]
+    CheckReady -->|no| NextAgent[Check next agent]
+
+    Cleanup --> NextAgent
+    RemoveAgent --> NextAgent
+
+    NextAgent --> PruneOrphans[Prune orphaned<br/>worktrees & messages]
+    PruneOrphans --> End[Wait 2 min]
+    End --> Start
+```
+
+## Daemon Goroutines
+
+```mermaid
+flowchart LR
+    subgraph Daemon
+        Main[main goroutine]
+
+        subgraph Loops["Background Loops"]
+            Server[serverLoop<br/>continuous]
+            Health[healthCheckLoop<br/>2 min]
+            Router[messageRouterLoop<br/>2 min]
+            Wake[wakeLoop<br/>2 min]
+        end
+
+        WG[sync.WaitGroup]
+        Ctx[context.Context]
+    end
+
+    Main -->|spawn| Server
+    Main -->|spawn| Health
+    Main -->|spawn| Router
+    Main -->|spawn| Wake
+
+    WG -.->|tracks| Loops
+    Ctx -.->|cancels| Loops
+```
+
+## File System Layout
+
+```mermaid
+flowchart TB
+    subgraph Home["~/.multiclaude/"]
+        PID[daemon.pid]
+        Sock[daemon.sock]
+        Log[daemon.log]
+        State[state.json]
+
+        subgraph Prompts["prompts/"]
+            P1[supervisor.md]
+            P2[merge-queue.md]
+            P3[worker-name.md]
+        end
+
+        subgraph Repos["repos/"]
+            R1[my-repo/]
+        end
+
+        subgraph WTS["wts/"]
+            subgraph WTRepo["my-repo/"]
+                WT1[supervisor/]
+                WT2[merge-queue/]
+                WT3[clever-fox/]
+            end
+        end
+
+        subgraph Msgs["messages/"]
+            subgraph MsgRepo["my-repo/"]
+                MS[supervisor/]
+                MMQ[merge-queue/]
+                MW[clever-fox/]
+            end
+        end
+
+        subgraph Config["claude-config/"]
+            subgraph CfgRepo["my-repo/"]
+                subgraph Agent["clever-fox/"]
+                    Cmds[commands/]
+                end
+            end
+        end
+    end
+```
+
+## Shutdown Sequence
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Daemon
+    participant Goroutines
+    participant FS as Filesystem
+
+    User->>CLI: multiclaude stop-all
+    CLI->>Daemon: stop (socket)
+
+    Daemon->>Daemon: d.cancel()
+    Daemon->>Goroutines: context cancelled
+
+    par All goroutines
+        Goroutines->>Goroutines: check ctx.Done()
+        Goroutines->>Goroutines: return
+    end
+
+    Daemon->>Daemon: d.wg.Wait()
+    Note over Daemon: All goroutines stopped
+
+    Daemon->>Daemon: d.server.Stop()
+    Daemon->>FS: d.state.Save()
+    Daemon->>FS: d.pidFile.Remove()
+
+    Daemon-->>CLI: success
+    CLI-->>User: Daemon stopped
+```
+
+## State Thread Safety
+
+```mermaid
+flowchart TB
+    subgraph State["state.State"]
+        Mutex[sync.RWMutex]
+        Data[Repos map]
+    end
+
+    subgraph Readers["Read Operations"]
+        R1[GetRepo]
+        R2[GetAgent]
+        R3[ListAgents]
+    end
+
+    subgraph Writers["Write Operations"]
+        W1[AddRepo]
+        W2[AddAgent]
+        W3[RemoveAgent]
+    end
+
+    R1 -->|RLock| Mutex
+    R2 -->|RLock| Mutex
+    R3 -->|RLock| Mutex
+
+    W1 -->|Lock| Mutex
+    W2 -->|Lock| Mutex
+    W3 -->|Lock| Mutex
+
+    Mutex --> Data
+
+    W1 -->|auto-save| Disk[(state.json)]
+    W2 -->|auto-save| Disk
+    W3 -->|auto-save| Disk
+```

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,214 @@
+# Frequently Asked Questions
+
+## General
+
+### What is multiclaude?
+
+multiclaude is a lightweight orchestrator for running multiple Claude Code
+agents on GitHub repositories. Each agent runs in its own tmux window with
+an isolated git worktree.
+
+### How is it different from Gastown?
+
+Both solve multi-agent orchestration for Claude Code. multiclaude aims for
+Unix-style simplicity with fewer concepts: 3 agent roles vs 7, filesystem
+state vs git-backed hooks, minimal dependencies. Gastown offers more
+sophisticated features like work swarming and the Beads framework. See the
+[README comparison](../README.md#gastown-and-multiclaude) for details.
+
+### What are the prerequisites?
+
+- Go 1.21+
+- tmux (terminal multiplexer)
+- git
+- GitHub CLI (`gh`) authenticated via `gh auth login`
+
+## Agents
+
+### What types of agents are there?
+
+- **Supervisor**: Coordinates all agents, answers status questions, helps
+  stuck workers
+- **Workers**: Execute specific tasks, create PRs when done
+- **Merge Queue**: Monitors PRs, merges when CI passes
+- **Workspace**: Your interactive Claude session for spawning workers and
+  managing flow
+
+### How do agents communicate?
+
+Via filesystem-based JSON messages in `~/.multiclaude/messages/`. The daemon
+routes messages and periodically nudges agents to check their inbox.
+
+### What happens when an agent crashes?
+
+The daemon's health check (every 2 minutes) detects dead agents and attempts
+to restart them with `--resume` to preserve session context. See
+[CRASH_RECOVERY.md](CRASH_RECOVERY.md) for details.
+
+### Can I have multiple workers?
+
+Yes. Spawn as many as you want:
+
+```bash
+multiclaude work "Task 1"
+multiclaude work "Task 2"
+multiclaude work "Task 3"
+```
+
+They work in parallel, each in their own git worktree.
+
+## Workflow
+
+### How do I see what agents are doing?
+
+```bash
+# Attach to the tmux session (all agents)
+tmux attach -t mc-repo
+
+# Attach to a specific agent
+multiclaude attach happy-platypus --read-only
+```
+
+### How do I check worker status?
+
+```bash
+multiclaude work list          # Active workers
+multiclaude repo history       # Completed tasks and PRs
+multiclaude status             # Overall system status
+```
+
+### How do I stop a worker?
+
+```bash
+multiclaude work rm happy-platypus
+```
+
+This warns if there's uncommitted work.
+
+### How do I iterate on an existing PR?
+
+Use `--push-to` to have a worker push to an existing branch:
+
+```bash
+multiclaude work "Fix review comments" --branch origin/work/fox --push-to work/fox
+```
+
+## Troubleshooting
+
+### "daemon is not running"
+
+Start it:
+
+```bash
+multiclaude start
+```
+
+### "repository already initialized"
+
+The repo is already tracked. Check with:
+
+```bash
+multiclaude list
+```
+
+### "permission denied" on socket
+
+The daemon socket may have wrong permissions. Try:
+
+```bash
+multiclaude stop-all
+multiclaude start
+```
+
+### Agent seems stuck
+
+1. Check if Claude is waiting for input:
+   ```bash
+   multiclaude attach <agent> --read-only
+   ```
+
+2. Send it a nudge message:
+   ```bash
+   multiclaude agent send-message <agent> "Status update?"
+   ```
+
+3. The supervisor also periodically nudges stuck agents.
+
+### Uncommitted work in a dead worker
+
+```bash
+# Check the worktree
+cd ~/.multiclaude/wts/<repo>/<worker-name>
+git status
+
+# Save the work
+git add . && git commit -m "WIP"
+git push -u origin work/<worker-name>
+```
+
+### How do I reset everything?
+
+```bash
+multiclaude stop-all --clean
+```
+
+This stops all agents and removes state files (but preserves repo clones and
+worktrees).
+
+## Configuration
+
+### Can I customize agent behavior?
+
+Yes. Add files to `.multiclaude/` in your repository:
+
+- `SUPERVISOR.md` - Additional instructions for supervisor
+- `WORKER.md` - Additional instructions for workers
+- `REVIEWER.md` - Additional instructions for merge queue
+- `hooks.json` - Claude Code hooks configuration
+
+### Where does multiclaude store data?
+
+Everything lives in `~/.multiclaude/`:
+
+```
+~/.multiclaude/
+├── daemon.pid          # Daemon process ID
+├── daemon.sock         # Unix socket
+├── daemon.log          # Daemon logs
+├── state.json          # All state
+├── repos/<repo>/       # Cloned repositories
+├── wts/<repo>/         # Git worktrees
+└── messages/<repo>/    # Agent messages
+```
+
+See [DIRECTORY_STRUCTURE.md](DIRECTORY_STRUCTURE.md) for full details.
+
+### How do I view daemon logs?
+
+```bash
+multiclaude daemon logs -f     # Follow logs
+tail -f ~/.multiclaude/daemon.log
+```
+
+## Philosophy
+
+### Why "Brownian Ratchet"?
+
+In physics, a Brownian ratchet converts random motion into directed movement
+through a mechanism that only allows forward motion. multiclaude applies
+this: multiple agents create "chaos" (parallel, potentially overlapping
+work), but CI acts as the ratchet - only passing code merges, ensuring
+permanent forward progress.
+
+### Why embrace chaos instead of coordination?
+
+Trying to perfectly coordinate agent work is expensive and fragile. Instead:
+- Redundant work is cheaper than blocked work
+- Failed attempts cost nothing; only successful attempts matter
+- CI is the arbiter - if it passes, the code is good
+- More agents mean more chaos but also more forward motion
+
+### Why can't agents merge without CI?
+
+CI is King. Agents are forbidden from weakening CI or bypassing checks.
+This ensures the ratchet never slips backward.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,137 @@
+# Quickstart Guide
+
+Get multiclaude running in 5 minutes.
+
+## Prerequisites
+
+You need:
+- Go 1.21+
+- tmux
+- git
+- GitHub CLI (`gh`) - authenticated via `gh auth login`
+
+## Install
+
+```bash
+go install github.com/dlorenc/multiclaude/cmd/multiclaude@latest
+```
+
+## Start the Daemon
+
+multiclaude runs a background daemon that coordinates agents.
+
+```bash
+multiclaude start
+```
+
+Check it's running:
+
+```bash
+multiclaude daemon status
+```
+
+## Initialize a Repository
+
+Point multiclaude at a GitHub repository you want to work on:
+
+```bash
+multiclaude init https://github.com/your/repo
+```
+
+This:
+- Clones the repository
+- Creates a tmux session (`mc-repo`)
+- Spawns a supervisor agent
+- Spawns a merge-queue agent
+- Creates a default workspace for you
+
+## Spawn a Worker
+
+Create a worker to do a task:
+
+```bash
+multiclaude work "Add unit tests for the auth module"
+```
+
+The worker gets a fun name like `happy-platypus` and starts working
+immediately.
+
+## Watch Agents Work
+
+Attach to the tmux session to see all agents:
+
+```bash
+tmux attach -t mc-repo
+```
+
+Navigate between agent windows:
+- `Ctrl-b n` - next window
+- `Ctrl-b p` - previous window
+- `Ctrl-b w` - window picker
+- `Ctrl-b d` - detach (agents keep running)
+
+Or attach to a specific agent:
+
+```bash
+multiclaude attach happy-platypus --read-only
+```
+
+## Connect to Your Workspace
+
+Your workspace is a persistent Claude session where you interact with the
+codebase:
+
+```bash
+multiclaude workspace connect default
+```
+
+From here you can spawn more workers, check status, and manage your
+development flow.
+
+## Check Status
+
+```bash
+multiclaude status          # Overall status
+multiclaude work list       # List active workers
+multiclaude repo history    # What workers have done
+```
+
+## Stop Everything
+
+When you're done:
+
+```bash
+multiclaude stop-all        # Stop daemon and all agents
+```
+
+Or just stop the daemon (agents keep running in tmux):
+
+```bash
+multiclaude daemon stop
+```
+
+## Next Steps
+
+- Read the [README](../README.md) for the full philosophy and feature list
+- See [CRASH_RECOVERY.md](CRASH_RECOVERY.md) for what to do when things go
+  wrong
+- Check [DIRECTORY_STRUCTURE.md](DIRECTORY_STRUCTURE.md) to understand where
+  files live
+
+## Common Issues
+
+**"daemon is not running"**
+
+Start it: `multiclaude start`
+
+**"repository already initialized"**
+
+You've already set up this repo. Use `multiclaude list` to see tracked repos.
+
+**"gh auth error"**
+
+Authenticate GitHub CLI: `gh auth login`
+
+**tmux not found**
+
+Install tmux: `brew install tmux` (macOS) or `apt install tmux` (Linux)

--- a/docs/WORKER_LIFECYCLE_AUDIT.md
+++ b/docs/WORKER_LIFECYCLE_AUDIT.md
@@ -1,0 +1,235 @@
+# Worker Lifecycle Audit
+
+This document identifies gaps in the worker lifecycle where workers might fail
+to start, complete, or clean up properly.
+
+**Audit Date:** 2026-02-03
+**Reviewer:** calm-panda (worker agent)
+**Files Reviewed:**
+- `internal/cli/cli.go` (createWorker, completeWorker, removeWorker)
+- `internal/daemon/daemon.go` (health checks, cleanup, restoration)
+
+---
+
+## Summary
+
+The worker lifecycle has several gaps that can result in:
+- Orphaned resources (worktrees, tmux windows, branches)
+- Lost work (uncommitted changes, unpushed commits)
+- Missing task history records
+- Inconsistent state between daemon and filesystem
+
+---
+
+## Gap 1: No Rollback on Worker Creation Failure
+
+**Location:** `internal/cli/cli.go:1622-1828`
+
+**Issue:** Worker creation is not atomic. Resources are created sequentially:
+1. Worktree created (line 1700/1707)
+2. Tmux window created (line 1746)
+3. Claude started (line 1783)
+4. Worker registered with daemon (line 1796)
+
+If any step after worktree creation fails, earlier resources are orphaned.
+
+**Example scenarios:**
+- Daemon registration fails → orphaned worktree + tmux window
+- Claude startup fails → orphaned worktree + tmux window
+- Tmux window creation fails → orphaned worktree
+
+**Severity:** Medium - orphans accumulate over time, waste disk space
+
+**Suggested fix:** Add rollback logic or deferred cleanup on error path.
+
+---
+
+## Gap 2: Workers Not Cleaned Up After Crash
+
+**Location:** `internal/daemon/daemon.go:300-310`
+
+**Issue:** When a worker's Claude process dies (crash, system restart, etc.),
+the worker is NOT auto-restarted or cleaned up. The comment says workers
+"complete and clean up" but this only happens if the worker calls
+`multiclaude agent complete` before dying.
+
+```go
+// For transient agents (workers, review), don't auto-restart - they complete and clean up
+```
+
+A crashed worker remains in state with:
+- Dead PID
+- Existing tmux window (empty shell)
+- Existing worktree (possibly with uncommitted work)
+
+The health check doesn't mark them as dead because the window still exists.
+
+**Severity:** High - crashed workers become zombies, blocking cleanup
+
+**Suggested fix:** Detect workers with dead PIDs and either:
+- Mark them for cleanup after a grace period, or
+- Notify supervisor that worker crashed with uncommitted work
+
+---
+
+## Gap 3: Branch Name Assumption in Cleanup
+
+**Location:** `internal/daemon/daemon.go:1354-1360`
+
+**Issue:** Cleanup assumes worker branch is `work/<agentName>`:
+```go
+branchName := "work/" + agentName
+```
+
+But workers created with `--push-to` flag use custom branch names
+(cli.go:1694-1702). This causes:
+- Failed branch deletion (branch doesn't exist)
+- Wrong branch deleted (if another branch happens to match)
+
+**Severity:** Low - deletion just fails silently with a warning
+
+**Suggested fix:** Store actual branch name in agent state, use it for cleanup.
+
+---
+
+## Gap 4: Session Restoration Loses Worker State
+
+**Location:** `internal/daemon/daemon.go:1614-1629`
+
+**Issue:** When tmux session is lost (e.g., system restart, tmux server crash),
+`restoreRepoAgents` removes ALL agents from state before recreating the session:
+
+```go
+for agentName := range repo.Agents {
+    d.state.RemoveAgent(repoName, agentName)
+}
+```
+
+Only persistent agents (supervisor, merge-queue, workspace) are recreated.
+Workers are silently lost without:
+- Task history record
+- Notification to user
+- Any recovery attempt
+
+**Severity:** High - all in-progress worker state lost silently
+
+**Suggested fix:**
+- Record task history before removing workers
+- Log warning about lost workers
+- Consider storing worktree paths for recovery
+
+---
+
+## Gap 5: Manual Removal Skips Task History
+
+**Location:** `internal/cli/cli.go:2225-2366`
+
+**Issue:** `multiclaude worker rm` removes workers without recording task
+history. Only `cleanupDeadAgents` calls `recordTaskHistory`.
+
+Workers removed manually have no record of what they were working on.
+
+**Severity:** Low - task history is for auditing, not critical
+
+**Suggested fix:** Call daemon's complete_agent or add history recording to
+removeWorker.
+
+---
+
+## Gap 6: Race Condition in Worker Completion
+
+**Location:** `internal/daemon/daemon.go:984-1046`
+
+**Issue:** `handleCompleteAgent` does three async things:
+1. Marks agent as `ReadyForCleanup`
+2. Sends messages to supervisor/merge-queue (async delivery via `go d.routeMessages()`)
+3. Triggers cleanup check (async via `go d.checkAgentHealth()`)
+
+The worker process might still be running after returning from `complete_agent`.
+If health check runs fast, it could:
+- Kill the tmux window while worker is still outputting
+- Remove worktree while Claude is still writing files
+
+**Severity:** Low - unlikely in practice due to timing
+
+**Suggested fix:** Wait for worker process to exit before cleanup, or add
+brief delay.
+
+---
+
+## Gap 7: PID Detection Timing Issues
+
+**Location:** `internal/daemon/daemon.go:1768`
+
+**Issue:** After starting Claude, code sleeps 500ms then gets PID:
+```go
+time.Sleep(500 * time.Millisecond)
+pid, err := d.tmux.GetPanePID(...)
+```
+
+This is fragile:
+- If Claude takes >500ms to start, might get shell PID instead
+- If Claude starts faster, works but wastes time
+- No verification that PID is actually Claude process
+
+**Severity:** Low - usually works, but PID might be wrong
+
+**Suggested fix:** Poll for Claude process or verify PID is claude binary.
+
+---
+
+## Gap 8: Orphaned State Without Worktree
+
+**Location:** `internal/daemon/daemon.go:1471-1501`
+
+**Issue:** `cleanupOrphanedWorktrees` only removes worktree directories not
+tracked by git. It doesn't handle:
+- Agent state without worktree (worktree manually deleted)
+- Agent state with corrupted worktree (git refs broken)
+
+The repair command (`handleTriggerCleanup`) does check for missing worktrees,
+but this isn't run automatically.
+
+**Severity:** Low - manual repair available
+
+**Suggested fix:** Add worktree existence check to health check loop.
+
+---
+
+## Recommendations
+
+### Immediate (P0)
+
+1. **Add crash detection for workers** - If worker PID is dead and window
+   exists (empty shell), mark as crashed and notify supervisor. Don't silently
+   leave zombie workers.
+
+2. **Record task history on session loss** - Before clearing agents during
+   session restoration, record their task history so we know what was lost.
+
+### Short-term (P1)
+
+3. **Add rollback to worker creation** - Use deferred cleanup to remove
+   worktree/window if later steps fail.
+
+4. **Store actual branch name in state** - Don't assume `work/<name>` for
+   branch cleanup.
+
+### Nice-to-have (P2)
+
+5. **Record task history on manual removal** - Make `worker rm` record history.
+
+6. **Improve PID detection** - Poll or verify instead of fixed sleep.
+
+---
+
+## Testing Scenarios
+
+To verify fixes, test these scenarios:
+
+1. **Creation failure:** Kill daemon mid-worker-creation
+2. **Worker crash:** `kill -9` the Claude process
+3. **Tmux crash:** `tmux kill-server` with workers running
+4. **Manual deletion:** `rm -rf` a worker worktree while it's in state
+5. **Push-to cleanup:** Create worker with `--push-to`, complete it, verify
+   correct branch cleanup

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -431,7 +431,7 @@ func (c *CLI) registerCommands() {
 	agentCmd.Subcommands["complete"] = &Command{
 		Name:        "complete",
 		Description: "Signal worker completion",
-		Usage:       "multiclaude agent complete [--summary <text>] [--failure <reason>]",
+		Usage:       "multiclaude agent complete [--summary <text>] [--failure <reason>] [--pr-url <url>] [--pr-number <num>]",
 		Run:         c.completeWorker,
 	}
 
@@ -3339,6 +3339,20 @@ func (c *CLI) completeWorker(args []string) error {
 	if failureReason, ok := flags["failure"]; ok && failureReason != "" {
 		reqArgs["failure_reason"] = failureReason
 		fmt.Printf("Failure reason: %s\n", failureReason)
+	}
+
+	// Add optional PR URL
+	if prURL, ok := flags["pr-url"]; ok && prURL != "" {
+		reqArgs["pr_url"] = prURL
+		fmt.Printf("PR URL: %s\n", prURL)
+	}
+
+	// Add optional PR number
+	if prNumber, ok := flags["pr-number"]; ok && prNumber != "" {
+		if num, err := strconv.Atoi(prNumber); err == nil && num > 0 {
+			reqArgs["pr_number"] = num
+			fmt.Printf("PR Number: #%d\n", num)
+		}
 	}
 
 	client := socket.NewClient(c.paths.DaemonSock)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -475,6 +475,13 @@ func (c *CLI) registerCommands() {
 		Run:         c.repair,
 	}
 
+	c.rootCmd.Subcommands["refresh"] = &Command{
+		Name:        "refresh",
+		Description: "Sync agent worktrees with main branch",
+		Usage:       "multiclaude refresh",
+		Run:         c.refresh,
+	}
+
 	// Claude restart command - for resuming Claude after exit
 	c.rootCmd.Subcommands["claude"] = &Command{
 		Name:        "claude",
@@ -4777,6 +4784,151 @@ func (c *CLI) localRepair(verbose bool) error {
 		fmt.Println("  No issues found")
 	}
 
+	return nil
+}
+
+// refresh syncs agent worktrees with the main branch
+func (c *CLI) refresh(args []string) error {
+	fmt.Println("Syncing agent worktrees with main branch...")
+
+	// Check if daemon is running
+	client := socket.NewClient(c.paths.DaemonSock)
+	_, err := client.Send(socket.Request{Command: "ping"})
+	if err != nil {
+		// Daemon not running - do local refresh
+		fmt.Println("Daemon is not running. Performing local refresh...")
+		return c.localRefresh()
+	}
+
+	// Trigger worktree refresh via daemon
+	resp, err := client.Send(socket.Request{
+		Command: "refresh_worktrees",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to trigger refresh: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("refresh failed: %s", resp.Error)
+	}
+
+	// Display results
+	if data, ok := resp.Data.(map[string]interface{}); ok {
+		if refreshed, ok := data["refreshed"].([]interface{}); ok && len(refreshed) > 0 {
+			fmt.Printf("✓ Refreshed %d worktree(s):\n", len(refreshed))
+			for _, agent := range refreshed {
+				fmt.Printf("  - %s\n", agent)
+			}
+		}
+		if skipped, ok := data["skipped"].([]interface{}); ok && len(skipped) > 0 {
+			fmt.Printf("⊘ Skipped %d worktree(s):\n", len(skipped))
+			for _, item := range skipped {
+				if m, ok := item.(map[string]interface{}); ok {
+					agent := m["agent"]
+					reason := m["reason"]
+					fmt.Printf("  - %s: %s\n", agent, reason)
+				}
+			}
+		}
+		if errors, ok := data["errors"].([]interface{}); ok && len(errors) > 0 {
+			fmt.Printf("✗ Failed to refresh %d worktree(s):\n", len(errors))
+			for _, item := range errors {
+				if m, ok := item.(map[string]interface{}); ok {
+					agent := m["agent"]
+					errMsg := m["error"]
+					fmt.Printf("  - %s: %s\n", agent, errMsg)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// localRefresh performs worktree refresh without the daemon running
+func (c *CLI) localRefresh() error {
+	// Load state from disk
+	st, err := c.loadState()
+	if err != nil {
+		return err
+	}
+
+	refreshed := 0
+	skipped := 0
+	errCount := 0
+
+	repos := st.GetAllRepos()
+	for repoName, repo := range repos {
+		repoPath := c.paths.RepoDir(repoName)
+
+		// Check if repo path exists
+		if _, err := os.Stat(repoPath); os.IsNotExist(err) {
+			continue
+		}
+
+		wt := worktree.NewManager(repoPath)
+
+		// Get the upstream remote and default branch
+		remote, err := wt.GetUpstreamRemote()
+		if err != nil {
+			continue
+		}
+
+		mainBranch, err := wt.GetDefaultBranch(remote)
+		if err != nil {
+			continue
+		}
+
+		// Fetch from remote
+		if err := wt.FetchRemote(remote); err != nil {
+			continue
+		}
+
+		// Check each worker agent's worktree
+		for agentName, agent := range repo.Agents {
+			// Only refresh worker worktrees
+			if agent.Type != state.AgentTypeWorker {
+				continue
+			}
+
+			// Skip if worktree path is empty or doesn't exist
+			if agent.WorktreePath == "" {
+				continue
+			}
+			if _, err := os.Stat(agent.WorktreePath); os.IsNotExist(err) {
+				continue
+			}
+
+			// Check worktree state
+			wtState, err := worktree.GetWorktreeState(agent.WorktreePath, remote, mainBranch)
+			if err != nil {
+				continue
+			}
+
+			// Skip if can't refresh
+			if !wtState.CanRefresh {
+				fmt.Printf("⊘ Skipping %s/%s: %s\n", repoName, agentName, wtState.RefreshReason)
+				skipped++
+				continue
+			}
+
+			// Refresh the worktree
+			fmt.Printf("Refreshing %s/%s (%d commits behind)...\n", repoName, agentName, wtState.CommitsBehind)
+			result := worktree.RefreshWorktree(agent.WorktreePath, remote, mainBranch)
+
+			if result.Error != nil {
+				fmt.Printf("✗ Failed to refresh %s/%s: %v\n", repoName, agentName, result.Error)
+				errCount++
+			} else if result.Skipped {
+				fmt.Printf("⊘ Skipped %s/%s: %s\n", repoName, agentName, result.SkipReason)
+				skipped++
+			} else {
+				fmt.Printf("✓ Refreshed %s/%s (rebased %d commits)\n", repoName, agentName, result.CommitsRebased)
+				refreshed++
+			}
+		}
+	}
+
+	fmt.Printf("\n✓ Refresh completed: %d refreshed, %d skipped, %d errors\n", refreshed, skipped, errCount)
 	return nil
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -912,7 +912,7 @@ func (c *CLI) initRepo(args []string) error {
 		case "assigned":
 			mqTrackMode = state.TrackModeAssigned
 		default:
-			return fmt.Errorf("invalid --mq-track value: %s (must be 'all', 'author', or 'assigned')", trackMode)
+			return errors.InvalidFlagValue("--mq-track", trackMode, []string{"all", "author", "assigned"})
 		}
 	}
 
@@ -950,7 +950,7 @@ func (c *CLI) initRepo(args []string) error {
 	// Create tmux session
 	tmuxSession := sanitizeTmuxSessionName(repoName)
 	if tmuxSession == "mc-" {
-		return fmt.Errorf("invalid tmux session name: repository name cannot be empty")
+		return errors.InvalidRepoName("cannot be empty")
 	}
 
 	fmt.Printf("Creating tmux session: %s\n", tmuxSession)
@@ -1522,17 +1522,17 @@ func (c *CLI) showRepoConfig(repoName string) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to get repo config: %w (is daemon running?)", err)
+		return errors.DaemonCommunicationFailed("getting repo config", err)
 	}
 
 	if !resp.Success {
-		return fmt.Errorf("failed to get repo config: %s", resp.Error)
+		return errors.Wrap(errors.CategoryRuntime, "failed to get repo config", fmt.Errorf("%s", resp.Error))
 	}
 
 	// Parse response
 	configMap, ok := resp.Data.(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("unexpected response format")
+		return errors.New(errors.CategoryRuntime, "unexpected response format from daemon")
 	}
 
 	fmt.Printf("Configuration for repository: %s\n\n", repoName)
@@ -1576,7 +1576,7 @@ func (c *CLI) updateRepoConfig(repoName string, flags map[string]string) error {
 		case "false":
 			updateArgs["mq_enabled"] = false
 		default:
-			return fmt.Errorf("invalid --mq-enabled value: %s (must be 'true' or 'false')", mqEnabled)
+			return errors.InvalidFlagValue("--mq-enabled", mqEnabled, []string{"true", "false"})
 		}
 	}
 
@@ -1585,7 +1585,7 @@ func (c *CLI) updateRepoConfig(repoName string, flags map[string]string) error {
 		case "all", "author", "assigned":
 			updateArgs["mq_track_mode"] = mqTrack
 		default:
-			return fmt.Errorf("invalid --mq-track value: %s (must be 'all', 'author', or 'assigned')", mqTrack)
+			return errors.InvalidFlagValue("--mq-track", mqTrack, []string{"all", "author", "assigned"})
 		}
 	}
 
@@ -1595,11 +1595,11 @@ func (c *CLI) updateRepoConfig(repoName string, flags map[string]string) error {
 		Args:    updateArgs,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to update repo config: %w (is daemon running?)", err)
+		return errors.DaemonCommunicationFailed("updating repo config", err)
 	}
 
 	if !resp.Success {
-		return fmt.Errorf("failed to update repo config: %s", resp.Error)
+		return errors.Wrap(errors.CategoryRuntime, "failed to update repo config", fmt.Errorf("%s", resp.Error))
 	}
 
 	fmt.Printf("Configuration updated for repository: %s\n", repoName)
@@ -2660,7 +2660,7 @@ func (c *CLI) addWorkspace(args []string) error {
 			agentType, _ := agentMap["type"].(string)
 			name, _ := agentMap["name"].(string)
 			if agentType == "workspace" && name == workspaceName {
-				return fmt.Errorf("workspace '%s' already exists in repo '%s'", workspaceName, repoName)
+				return errors.WorkspaceAlreadyExists(workspaceName, repoName)
 			}
 		}
 	}
@@ -3010,10 +3010,10 @@ func (c *CLI) connectWorkspace(args []string) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to get workspace info: %w (is daemon running?)", err)
+		return errors.DaemonCommunicationFailed("getting workspace info", err)
 	}
 	if !resp.Success {
-		return fmt.Errorf("failed to get workspace info: %s", resp.Error)
+		return errors.Wrap(errors.CategoryRuntime, "failed to get workspace info", fmt.Errorf("%s", resp.Error))
 	}
 
 	agents, _ := resp.Data.([]interface{})
@@ -4076,10 +4076,10 @@ func (c *CLI) attachAgent(args []string) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to get agent info: %w (is daemon running?)", err)
+		return errors.DaemonCommunicationFailed("getting agent info", err)
 	}
 	if !resp.Success {
-		return fmt.Errorf("failed to get agent info: %s", resp.Error)
+		return errors.Wrap(errors.CategoryRuntime, "failed to get agent info", fmt.Errorf("%s", resp.Error))
 	}
 
 	agents, _ := resp.Data.([]interface{})

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1936,6 +1936,8 @@ func (c *CLI) listWorkers(args []string) error {
 			statusCell = format.ColorCell(format.ColoredStatus(format.StatusCompleted), nil)
 		case "stopped":
 			statusCell = format.ColorCell(format.ColoredStatus(format.StatusError), nil)
+		case "crashed":
+			statusCell = format.ColorCell(format.ColoredStatus(format.StatusCrashed), nil)
 		default:
 			statusCell = format.ColorCell(format.ColoredStatus(format.StatusIdle), nil)
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1480,35 +1480,16 @@ func (c *CLI) clearCurrentRepo(args []string) error {
 func (c *CLI) configRepo(args []string) error {
 	flags, posArgs := ParseFlags(args)
 
-	// Determine repository
+	// Determine repository: positional arg takes priority, then resolveRepo fallback
 	var repoName string
 	if len(posArgs) >= 1 {
 		repoName = posArgs[0]
 	} else {
-		// Try to infer from current directory
-		cwd, err := os.Getwd()
+		resolved, err := c.resolveRepo(flags)
 		if err != nil {
-			return fmt.Errorf("failed to get current directory: %w", err)
+			return errors.NotInRepo()
 		}
-
-		// Check if we're in a tracked repo
-		repos := c.getReposList()
-		for _, repo := range repos {
-			repoPath := c.paths.RepoDir(repo)
-			if strings.HasPrefix(cwd, repoPath) {
-				repoName = repo
-				break
-			}
-		}
-
-		if repoName == "" {
-			// If only one repo exists, use it
-			if len(repos) == 1 {
-				repoName = repos[0]
-			} else {
-				return fmt.Errorf("please specify a repository name or run from within a tracked repository")
-			}
-		}
+		repoName = resolved
 	}
 
 	// Check if any config flags are provided
@@ -2431,16 +2412,9 @@ func (c *CLI) addWorkspace(args []string) error {
 	}
 
 	// Determine repository
-	var repoName string
-	if r, ok := flags["repo"]; ok {
-		repoName = r
-	} else {
-		// Try to infer from current directory
-		if inferred, err := c.inferRepoFromCwd(); err == nil {
-			repoName = inferred
-		} else {
-			return errors.MultipleRepos()
-		}
+	repoName, err := c.resolveRepo(flags)
+	if err != nil {
+		return errors.NotInRepo()
 	}
 
 	// Determine branch to start from
@@ -3174,22 +3148,25 @@ func normalizeGitHubURL(url string) string {
 
 // findRepoFromGitRemote looks for a git remote in the current directory
 // and tries to match it against known repositories in state.
+// It checks both "origin" and "upstream" remotes to support fork workflows
+// where origin points to the user's fork and upstream points to the tracked repo.
 func (c *CLI) findRepoFromGitRemote() (string, error) {
-	// Run git remote get-url origin
-	cmd := exec.Command("git", "remote", "get-url", "origin")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to get git remote: %w", err)
+	// Collect remote URLs from origin and upstream (covers fork workflows)
+	var remoteURLs []string
+	for _, remote := range []string{"origin", "upstream"} {
+		cmd := exec.Command("git", "remote", "get-url", remote)
+		output, err := cmd.Output()
+		if err != nil {
+			continue
+		}
+		url := strings.TrimSpace(string(output))
+		if url != "" {
+			remoteURLs = append(remoteURLs, url)
+		}
 	}
 
-	remoteURL := strings.TrimSpace(string(output))
-	if remoteURL == "" {
-		return "", fmt.Errorf("git remote URL is empty")
-	}
-
-	normalizedRemote := normalizeGitHubURL(remoteURL)
-	if normalizedRemote == "" {
-		return "", fmt.Errorf("not a GitHub URL: %s", remoteURL)
+	if len(remoteURLs) == 0 {
+		return "", fmt.Errorf("no git remotes found")
 	}
 
 	// Load state to check against known repositories
@@ -3198,20 +3175,27 @@ func (c *CLI) findRepoFromGitRemote() (string, error) {
 		return "", err
 	}
 
-	// Iterate through repos and find a match
-	for _, repoName := range st.ListRepos() {
-		repo, exists := st.GetRepo(repoName)
-		if !exists {
+	// Check each remote URL against tracked repos
+	for _, remoteURL := range remoteURLs {
+		normalizedRemote := normalizeGitHubURL(remoteURL)
+		if normalizedRemote == "" {
 			continue
 		}
 
-		normalizedStateURL := normalizeGitHubURL(repo.GithubURL)
-		if normalizedStateURL != "" && normalizedStateURL == normalizedRemote {
-			return repoName, nil
+		for _, repoName := range st.ListRepos() {
+			repo, exists := st.GetRepo(repoName)
+			if !exists {
+				continue
+			}
+
+			normalizedStateURL := normalizeGitHubURL(repo.GithubURL)
+			if normalizedStateURL != "" && normalizedStateURL == normalizedRemote {
+				return repoName, nil
+			}
 		}
 	}
 
-	return "", fmt.Errorf("no matching repository found for remote: %s", remoteURL)
+	return "", fmt.Errorf("no matching repository found for remotes: %v", remoteURLs)
 }
 
 // resolveRepo determines the repository to use based on:
@@ -3414,15 +3398,10 @@ func (c *CLI) restartAgentCmd(args []string) error {
 	}
 	agentName := remaining[0]
 
-	// Get repo from flag or infer from cwd
-	repoName := flags["repo"]
-	if repoName == "" {
-		// Try to infer from cwd
-		inferred, err := c.inferRepoFromCwd()
-		if err != nil {
-			return errors.InvalidUsage("could not determine repository - use --repo flag or run from within a multiclaude worktree")
-		}
-		repoName = inferred
+	// Get repo from flag or infer from context
+	repoName, err := c.resolveRepo(flags)
+	if err != nil {
+		return errors.NotInRepo()
 	}
 
 	force := flags["force"] == "true"
@@ -3481,31 +3460,11 @@ func (c *CLI) reviewPR(args []string) error {
 	prNumber := parts[4]
 	fmt.Printf("Reviewing PR #%s\n", prNumber)
 
-	// Determine repository from flag or current directory
+	// Determine repository from flag or current context
 	flags, _ := ParseFlags(args[1:])
-	var repoName string
-	if r, ok := flags["repo"]; ok {
-		repoName = r
-	} else {
-		// Try to infer from current directory
-		cwd, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("failed to get current directory: %w", err)
-		}
-
-		// Check if we're in a tracked repo
-		repos := c.getReposList()
-		for _, repo := range repos {
-			repoPath := c.paths.RepoDir(repo)
-			if strings.HasPrefix(cwd, repoPath) {
-				repoName = repo
-				break
-			}
-		}
-
-		if repoName == "" {
-			return errors.NotInRepo()
-		}
+	repoName, err := c.resolveRepo(flags)
+	if err != nil {
+		return errors.NotInRepo()
 	}
 
 	// Generate review agent name
@@ -3632,19 +3591,9 @@ func (c *CLI) viewLogs(args []string) error {
 	flags, _ := ParseFlags(args[1:])
 
 	// Determine repository
-	var repoName string
-	if r, ok := flags["repo"]; ok {
-		repoName = r
-	} else {
-		repos := c.getReposList()
-		if len(repos) == 0 {
-			return errors.NoRepositoriesFound()
-		}
-		if len(repos) == 1 {
-			repoName = repos[0]
-		} else {
-			return errors.MultipleRepos()
-		}
+	repoName, err := c.resolveRepo(flags)
+	if err != nil {
+		return errors.NotInRepo()
 	}
 
 	// Determine if it's a worker or system agent by checking if it exists in workers dir

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -393,6 +393,14 @@ func (c *CLI) registerCommands() {
 		Run:         c.showHistory,
 	}
 
+	// Stats command
+	c.rootCmd.Subcommands["stats"] = &Command{
+		Name:        "stats",
+		Description: "Show agent activity statistics",
+		Usage:       "multiclaude stats [--repo <repo>]",
+		Run:         c.showStats,
+	}
+
 	// Agent commands (run from within Claude)
 	agentCmd := &Command{
 		Name:        "agent",
@@ -2184,6 +2192,209 @@ func (c *CLI) showHistory(args []string) error {
 	}
 
 	return nil
+}
+
+// showStats displays agent activity statistics
+func (c *CLI) showStats(args []string) error {
+	flags, _ := ParseFlags(args)
+
+	// Determine repository
+	repoName, err := c.resolveRepo(flags)
+	if err != nil {
+		return errors.NotInRepo()
+	}
+
+	// Get all task history from daemon (use high limit to get all)
+	client := socket.NewClient(c.paths.DaemonSock)
+	historyResp, err := client.Send(socket.Request{
+		Command: "task_history",
+		Args: map[string]interface{}{
+			"repo":  repoName,
+			"limit": float64(1000), // Fetch all history
+		},
+	})
+	if err != nil {
+		return errors.DaemonCommunicationFailed("getting task history", err)
+	}
+
+	if !historyResp.Success {
+		return fmt.Errorf("failed to get task history: %s", historyResp.Error)
+	}
+
+	// Get daemon status for active agent count
+	statusResp, err := client.Send(socket.Request{
+		Command: "list_workers",
+		Args: map[string]interface{}{
+			"repo": repoName,
+		},
+	})
+
+	// Parse task history
+	entries, ok := historyResp.Data.([]interface{})
+	if !ok {
+		entries = []interface{}{}
+	}
+
+	// Calculate statistics
+	totalTasks := len(entries)
+	statusCounts := map[string]int{
+		"merged": 0,
+		"open":   0,
+		"closed": 0,
+		"failed": 0,
+		"no-pr":  0,
+	}
+
+	var totalDuration time.Duration
+	tasksWithDuration := 0
+	repoPath := c.paths.RepoDir(repoName)
+
+	for _, e := range entries {
+		entry, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		branch, _ := entry["branch"].(string)
+		prURL, _ := entry["pr_url"].(string)
+		storedStatus, _ := entry["status"].(string)
+
+		// Get PR status
+		prStatus, _ := c.getPRStatusForBranch(repoPath, branch, prURL)
+
+		// Use stored status if it indicates failure
+		if storedStatus == "failed" {
+			prStatus = "failed"
+		}
+		if prStatus == "" {
+			prStatus = "no-pr"
+		}
+
+		statusCounts[prStatus]++
+
+		// Calculate duration if both times exist
+		createdAtStr, _ := entry["created_at"].(string)
+		completedAtStr, _ := entry["completed_at"].(string)
+
+		if createdAtStr != "" && completedAtStr != "" {
+			createdAt, err1 := time.Parse(time.RFC3339, createdAtStr)
+			completedAt, err2 := time.Parse(time.RFC3339, completedAtStr)
+			if err1 == nil && err2 == nil && !completedAt.IsZero() {
+				duration := completedAt.Sub(createdAt)
+				if duration > 0 {
+					totalDuration += duration
+					tasksWithDuration++
+				}
+			}
+		}
+	}
+
+	// Count active agents
+	activeAgents := 0
+	if statusResp.Success {
+		if workers, ok := statusResp.Data.([]interface{}); ok {
+			for _, w := range workers {
+				if worker, ok := w.(map[string]interface{}); ok {
+					if status, _ := worker["status"].(string); status == "running" {
+						activeAgents++
+					}
+				}
+			}
+		}
+	}
+
+	// Calculate average duration
+	var avgDuration time.Duration
+	if tasksWithDuration > 0 {
+		avgDuration = totalDuration / time.Duration(tasksWithDuration)
+	}
+
+	// Display statistics
+	format.Header("Agent Statistics for '%s'", repoName)
+	fmt.Println()
+
+	// Summary section
+	fmt.Println("Summary:")
+	fmt.Printf("  Total tasks completed: %d\n", totalTasks)
+	fmt.Printf("  Active agents:         %d\n", activeAgents)
+	fmt.Println()
+
+	// PR status breakdown
+	fmt.Println("PR Status:")
+	table := format.NewColoredTable("Status", "Count", "Percentage")
+
+	prsCreated := statusCounts["merged"] + statusCounts["open"] + statusCounts["closed"]
+	addStatusRow := func(name string, count int) {
+		pct := 0.0
+		if totalTasks > 0 {
+			pct = float64(count) / float64(totalTasks) * 100
+		}
+		// Determine color based on status
+		var statusCell format.ColoredCell
+		switch name {
+		case "merged":
+			statusCell = format.ColorCell(name, format.Green)
+		case "open":
+			statusCell = format.ColorCell(name, format.Yellow)
+		case "closed", "failed":
+			statusCell = format.ColorCell(name, format.Red)
+		default:
+			statusCell = format.ColorCell(name, format.Dim)
+		}
+		table.AddRow(
+			statusCell,
+			format.Cell(fmt.Sprintf("%d", count)),
+			format.Cell(fmt.Sprintf("%.0f%%", pct)),
+		)
+	}
+
+	addStatusRow("merged", statusCounts["merged"])
+	addStatusRow("open", statusCounts["open"])
+	addStatusRow("closed", statusCounts["closed"])
+	addStatusRow("failed", statusCounts["failed"])
+	addStatusRow("no-pr", statusCounts["no-pr"])
+	table.Print()
+
+	// Time stats
+	if tasksWithDuration > 0 {
+		fmt.Println()
+		fmt.Println("Time Statistics:")
+		fmt.Printf("  Average task duration: %s\n", formatDuration(avgDuration))
+		fmt.Printf("  Total time spent:      %s\n", formatDuration(totalDuration))
+	}
+
+	// Success rate
+	if totalTasks > 0 {
+		fmt.Println()
+		fmt.Println("Success Metrics:")
+		prRate := float64(prsCreated) / float64(totalTasks) * 100
+		mergeRate := 0.0
+		if prsCreated > 0 {
+			mergeRate = float64(statusCounts["merged"]) / float64(prsCreated) * 100
+		}
+		fmt.Printf("  PR creation rate:      %.0f%% (%d/%d tasks)\n", prRate, prsCreated, totalTasks)
+		fmt.Printf("  PR merge rate:         %.0f%% (%d/%d PRs)\n", mergeRate, statusCounts["merged"], prsCreated)
+	}
+
+	return nil
+}
+
+// formatDuration formats a duration in a human-readable way
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	hours := int(d.Hours())
+	mins := int(d.Minutes()) % 60
+	if hours < 24 {
+		return fmt.Sprintf("%dh %dm", hours, mins)
+	}
+	days := hours / 24
+	hours = hours % 24
+	return fmt.Sprintf("%dd %dh", days, hours)
 }
 
 // getPRStatusForBranch queries GitHub for the PR status of a branch

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2531,6 +2531,108 @@ func TestFindRepoFromGitRemote(t *testing.T) {
 			t.Errorf("findRepoFromGitRemote() = %q, want %q", repoName, "repo-b")
 		}
 	})
+
+	t.Run("matches upstream remote for fork workflow", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		stateFile := filepath.Join(tmpDir, "state.json")
+
+		// Create state tracking the upstream repo URL
+		st := state.New(stateFile)
+		st.AddRepo("upstream-repo", &state.Repository{
+			GithubURL:   "https://github.com/upstream-org/upstream-repo",
+			TmuxSession: "mc-upstream-repo",
+			Agents:      make(map[string]state.Agent),
+		})
+
+		// Create a git repo simulating a fork:
+		// origin -> user's fork (doesn't match tracked repo)
+		// upstream -> original repo (matches tracked repo)
+		gitDir := filepath.Join(tmpDir, "git-test")
+		if err := os.MkdirAll(gitDir, 0755); err != nil {
+			t.Fatalf("failed to create git dir: %v", err)
+		}
+		if err := os.Chdir(gitDir); err != nil {
+			t.Fatalf("failed to chdir: %v", err)
+		}
+
+		if err := exec.Command("git", "init").Run(); err != nil {
+			t.Fatalf("failed to init git: %v", err)
+		}
+		// origin points to user's fork (no match)
+		if err := exec.Command("git", "remote", "add", "origin", "git@github.com:myuser/upstream-repo.git").Run(); err != nil {
+			t.Fatalf("failed to add origin remote: %v", err)
+		}
+		// upstream points to tracked repo (should match)
+		if err := exec.Command("git", "remote", "add", "upstream", "git@github.com:upstream-org/upstream-repo.git").Run(); err != nil {
+			t.Fatalf("failed to add upstream remote: %v", err)
+		}
+
+		cli := &CLI{
+			paths: &config.Paths{
+				StateFile: stateFile,
+			},
+		}
+
+		repoName, err := cli.findRepoFromGitRemote()
+		if err != nil {
+			t.Fatalf("findRepoFromGitRemote() error: %v", err)
+		}
+		if repoName != "upstream-repo" {
+			t.Errorf("findRepoFromGitRemote() = %q, want %q", repoName, "upstream-repo")
+		}
+	})
+
+	t.Run("origin takes priority over upstream", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		stateFile := filepath.Join(tmpDir, "state.json")
+
+		// Create state with two repos
+		st := state.New(stateFile)
+		st.AddRepo("origin-repo", &state.Repository{
+			GithubURL:   "https://github.com/user/origin-repo",
+			TmuxSession: "mc-origin-repo",
+			Agents:      make(map[string]state.Agent),
+		})
+		st.AddRepo("upstream-repo", &state.Repository{
+			GithubURL:   "https://github.com/org/upstream-repo",
+			TmuxSession: "mc-upstream-repo",
+			Agents:      make(map[string]state.Agent),
+		})
+
+		// Create a git repo where both remotes match different tracked repos
+		gitDir := filepath.Join(tmpDir, "git-test")
+		if err := os.MkdirAll(gitDir, 0755); err != nil {
+			t.Fatalf("failed to create git dir: %v", err)
+		}
+		if err := os.Chdir(gitDir); err != nil {
+			t.Fatalf("failed to chdir: %v", err)
+		}
+
+		if err := exec.Command("git", "init").Run(); err != nil {
+			t.Fatalf("failed to init git: %v", err)
+		}
+		if err := exec.Command("git", "remote", "add", "origin", "git@github.com:user/origin-repo.git").Run(); err != nil {
+			t.Fatalf("failed to add origin remote: %v", err)
+		}
+		if err := exec.Command("git", "remote", "add", "upstream", "git@github.com:org/upstream-repo.git").Run(); err != nil {
+			t.Fatalf("failed to add upstream remote: %v", err)
+		}
+
+		cli := &CLI{
+			paths: &config.Paths{
+				StateFile: stateFile,
+			},
+		}
+
+		repoName, err := cli.findRepoFromGitRemote()
+		if err != nil {
+			t.Fatalf("findRepoFromGitRemote() error: %v", err)
+		}
+		// origin should be checked first and win
+		if repoName != "origin-repo" {
+			t.Errorf("findRepoFromGitRemote() = %q, want %q (origin should take priority)", repoName, "origin-repo")
+		}
+	})
 }
 
 func TestCreateWorkerRollbackOnFailure(t *testing.T) {

--- a/internal/cli/selector.go
+++ b/internal/cli/selector.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dlorenc/multiclaude/internal/errors"
 	"github.com/dlorenc/multiclaude/internal/format"
 )
 
@@ -21,7 +22,7 @@ type SelectableItem struct {
 // If there's only one item, it's auto-selected without prompting.
 func SelectFromList(prompt string, items []SelectableItem) (string, error) {
 	if len(items) == 0 {
-		return "", fmt.Errorf("no items available")
+		return "", errors.NoItemsAvailable("")
 	}
 
 	// Auto-select if only one item
@@ -63,7 +64,7 @@ func SelectFromList(prompt string, items []SelectableItem) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
 	input, err := reader.ReadString('\n')
 	if err != nil {
-		return "", fmt.Errorf("failed to read input: %w", err)
+		return "", errors.FailedToReadInput(err)
 	}
 
 	input = strings.TrimSpace(input)
@@ -76,12 +77,12 @@ func SelectFromList(prompt string, items []SelectableItem) (string, error) {
 	// Parse number
 	num, err := strconv.Atoi(input)
 	if err != nil {
-		return "", fmt.Errorf("invalid selection: %q is not a number", input)
+		return "", errors.InvalidSelection(input, len(items))
 	}
 
 	// Validate range
 	if num < 1 || num > len(items) {
-		return "", fmt.Errorf("invalid selection: %d is out of range (1-%d)", num, len(items))
+		return "", errors.SelectionOutOfRange(num, len(items))
 	}
 
 	return items[num-1].Name, nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -683,6 +683,9 @@ func (d *Daemon) handleRequest(req socket.Request) socket.Response {
 		go d.routeMessages()
 		return socket.Response{Success: true, Data: "Message routing triggered"}
 
+	case "refresh_worktrees":
+		return d.handleRefreshWorktrees(req)
+
 	case "task_history":
 		return d.handleTaskHistory(req)
 
@@ -1527,6 +1530,137 @@ func (d *Daemon) handleTaskHistory(req socket.Request) socket.Response {
 	}
 
 	return socket.Response{Success: true, Data: result}
+}
+
+// handleRefreshWorktrees triggers immediate worktree refresh for all repos
+func (d *Daemon) handleRefreshWorktrees(req socket.Request) socket.Response {
+	d.logger.Info("Manual worktree refresh triggered")
+
+	// Run refresh synchronously so we can report results
+	results := d.refreshWorktreesWithResults()
+
+	return socket.Response{
+		Success: true,
+		Data:    results,
+	}
+}
+
+// refreshWorktreesWithResults syncs worker worktrees and returns results
+func (d *Daemon) refreshWorktreesWithResults() map[string]interface{} {
+	results := map[string]interface{}{
+		"refreshed": []string{},
+		"skipped":   []map[string]string{},
+		"errors":    []map[string]string{},
+	}
+
+	refreshed := []string{}
+	skipped := []map[string]string{}
+	errors := []map[string]string{}
+
+	repos := d.state.GetAllRepos()
+	for repoName, repo := range repos {
+		repoPath := d.paths.RepoDir(repoName)
+
+		// Check if repo path exists
+		if _, err := os.Stat(repoPath); os.IsNotExist(err) {
+			continue
+		}
+
+		wt := worktree.NewManager(repoPath)
+
+		// Get the upstream remote and default branch
+		remote, err := wt.GetUpstreamRemote()
+		if err != nil {
+			d.logger.Debug("Could not get remote for %s: %v", repoName, err)
+			continue
+		}
+
+		mainBranch, err := wt.GetDefaultBranch(remote)
+		if err != nil {
+			d.logger.Debug("Could not get default branch for %s: %v", repoName, err)
+			continue
+		}
+
+		// Fetch from remote to have latest state
+		if err := wt.FetchRemote(remote); err != nil {
+			d.logger.Debug("Could not fetch from remote for %s: %v", repoName, err)
+			continue
+		}
+
+		// Check each worker agent's worktree
+		for agentName, agent := range repo.Agents {
+			// Only refresh worker worktrees
+			if agent.Type != state.AgentTypeWorker {
+				continue
+			}
+
+			// Skip if worktree path is empty
+			if agent.WorktreePath == "" {
+				continue
+			}
+
+			// Check if worktree exists
+			if _, err := os.Stat(agent.WorktreePath); os.IsNotExist(err) {
+				continue
+			}
+
+			// Check worktree state
+			wtState, err := worktree.GetWorktreeState(agent.WorktreePath, remote, mainBranch)
+			if err != nil {
+				d.logger.Debug("Could not get worktree state for %s/%s: %v", repoName, agentName, err)
+				continue
+			}
+
+			// Skip if can't refresh
+			if !wtState.CanRefresh {
+				skipped = append(skipped, map[string]string{
+					"agent":  agentName,
+					"repo":   repoName,
+					"reason": wtState.RefreshReason,
+				})
+				continue
+			}
+
+			// Refresh the worktree
+			d.logger.Info("Refreshing worktree for %s/%s (%d commits behind)", repoName, agentName, wtState.CommitsBehind)
+			result := worktree.RefreshWorktree(agent.WorktreePath, remote, mainBranch)
+
+			if result.Error != nil {
+				errors = append(errors, map[string]string{
+					"agent": agentName,
+					"repo":  repoName,
+					"error": result.Error.Error(),
+				})
+				if result.HasConflicts {
+					d.logger.Warn("Worktree refresh for %s/%s has conflicts in: %v", repoName, agentName, result.ConflictFiles)
+				} else {
+					d.logger.Error("Failed to refresh worktree for %s/%s: %v", repoName, agentName, result.Error)
+				}
+			} else if result.Skipped {
+				skipped = append(skipped, map[string]string{
+					"agent":  agentName,
+					"repo":   repoName,
+					"reason": result.SkipReason,
+				})
+			} else {
+				refreshed = append(refreshed, fmt.Sprintf("%s/%s", repoName, agentName))
+				d.logger.Info("Refreshed worktree for %s/%s: rebased %d commits", repoName, agentName, result.CommitsRebased)
+
+				// Notify the agent that their worktree was refreshed
+				msgMgr := d.getMessageManager()
+				msg := fmt.Sprintf("Your worktree has been synced with main (rebased %d commits). Run 'git log --oneline -5' to see recent changes.", result.CommitsRebased)
+				if _, err := msgMgr.Send(repoName, "daemon", agentName, msg); err != nil {
+					d.logger.Debug("Could not send refresh notification to %s/%s: %v", repoName, agentName, err)
+				}
+			}
+		}
+	}
+
+	results["refreshed"] = refreshed
+	results["skipped"] = skipped
+	results["errors"] = errors
+
+	return results
 }
 
 // cleanupOrphanedWorktrees removes worktree directories without git tracking

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -442,11 +442,12 @@ func (d *Daemon) wakeLoop() {
 	}
 }
 
-// wakeAgents sends periodic nudges to agents
+// wakeAgents sends periodic nudges to agents, but only when they have work to do
 func (d *Daemon) wakeAgents() {
-	d.logger.Debug("Waking agents")
+	d.logger.Debug("Waking agents (selective)")
 
 	now := time.Now()
+	msgMgr := d.getMessageManager()
 
 	// Get a snapshot of repos to avoid concurrent map access
 	repos := d.state.GetAllRepos()
@@ -459,6 +460,13 @@ func (d *Daemon) wakeAgents() {
 
 			// Skip if nudged recently (within last 2 minutes)
 			if !agent.LastNudge.IsZero() && now.Sub(agent.LastNudge) < 2*time.Minute {
+				continue
+			}
+
+			// Selective wakeup: only wake agents that have work to do
+			reason := d.agentHasWork(repoName, agentName, agent, repo, msgMgr)
+			if reason == "" {
+				d.logger.Debug("Skipping wake for %s/%s: no work detected", repoName, agentName)
 				continue
 			}
 
@@ -487,9 +495,56 @@ func (d *Daemon) wakeAgents() {
 				d.logger.Error("Failed to update agent %s last nudge: %v", agentName, err)
 			}
 
-			d.logger.Debug("Woke agent %s in repo %s", agentName, repoName)
+			d.logger.Debug("Woke agent %s in repo %s (reason: %s)", agentName, repoName, reason)
 		}
 	}
+}
+
+// agentHasWork checks whether an agent has work that warrants a wake nudge.
+// Returns a reason string if there's work, or empty string if no work detected.
+func (d *Daemon) agentHasWork(repoName, agentName string, agent state.Agent, repo *state.Repository, msgMgr *messages.Manager) string {
+	// Any agent with pending messages has work
+	if msgMgr.HasPending(repoName, agentName) {
+		return "pending messages"
+	}
+
+	switch agent.Type {
+	case state.AgentTypeSupervisor:
+		// Supervisor has work when there are active workers to monitor
+		for _, a := range repo.Agents {
+			if a.Type == state.AgentTypeWorker && !a.ReadyForCleanup {
+				return "active workers"
+			}
+		}
+
+	case state.AgentTypeMergeQueue:
+		// Merge queue has work when there are workers with open PRs
+		for _, a := range repo.Agents {
+			if a.Type == state.AgentTypeWorker && a.PRURL != "" && !a.ReadyForCleanup {
+				return "open worker PRs"
+			}
+		}
+		// Also check task history for recent open PRs
+		history, err := d.state.GetTaskHistory(repoName, 10)
+		if err == nil {
+			for _, entry := range history {
+				if entry.Status == state.TaskStatusOpen && entry.PRURL != "" {
+					return "open PRs in history"
+				}
+			}
+		}
+
+	case state.AgentTypeWorker:
+		// Workers drive their own work - only wake for pending messages (checked above).
+		// No periodic nudge needed since workers are actively executing tasks.
+		return ""
+
+	case state.AgentTypeReview:
+		// Review agents drive their own work - only wake for pending messages (checked above).
+		return ""
+	}
+
+	return ""
 }
 
 // worktreeRefreshLoop periodically syncs worker worktrees with main branch

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -429,3 +429,77 @@ func InvalidDuration(value string) *CLIError {
 		Suggestion: "use format like '7d', '24h', or '30m' (days, hours, minutes)",
 	}
 }
+
+// InvalidFlagValue creates an error for invalid flag values with allowed options
+func InvalidFlagValue(flag, value string, allowed []string) *CLIError {
+	return &CLIError{
+		Category:   CategoryUsage,
+		Message:    fmt.Sprintf("invalid value '%s' for %s", value, flag),
+		Suggestion: fmt.Sprintf("allowed values: %s", strings.Join(allowed, ", ")),
+	}
+}
+
+// InvalidSelection creates an error for invalid user selection input
+func InvalidSelection(input string, maxNum int) *CLIError {
+	if maxNum > 0 {
+		return &CLIError{
+			Category:   CategoryUsage,
+			Message:    fmt.Sprintf("invalid selection: '%s'", input),
+			Suggestion: fmt.Sprintf("enter a number between 1 and %d, or press Enter to cancel", maxNum),
+		}
+	}
+	return &CLIError{
+		Category:   CategoryUsage,
+		Message:    fmt.Sprintf("invalid selection: '%s'", input),
+		Suggestion: "enter a valid number from the list",
+	}
+}
+
+// SelectionOutOfRange creates an error for selection numbers outside valid range
+func SelectionOutOfRange(num, maxNum int) *CLIError {
+	return &CLIError{
+		Category:   CategoryUsage,
+		Message:    fmt.Sprintf("selection %d is out of range", num),
+		Suggestion: fmt.Sprintf("enter a number between 1 and %d", maxNum),
+	}
+}
+
+// NoItemsAvailable creates an error when a selection list is empty
+func NoItemsAvailable(itemType string) *CLIError {
+	msg := "no items available for selection"
+	if itemType != "" {
+		msg = fmt.Sprintf("no %s available", itemType)
+	}
+	return &CLIError{
+		Category: CategoryNotFound,
+		Message:  msg,
+	}
+}
+
+// WorkspaceAlreadyExists creates an error when a workspace name is already taken
+func WorkspaceAlreadyExists(name, repo string) *CLIError {
+	return &CLIError{
+		Category:   CategoryRuntime,
+		Message:    fmt.Sprintf("workspace '%s' already exists in repo '%s'", name, repo),
+		Suggestion: fmt.Sprintf("choose a different name, or remove existing workspace:\n  multiclaude workspace rm %s --repo %s", name, repo),
+	}
+}
+
+// InvalidRepoName creates an error for invalid or empty repository names
+func InvalidRepoName(reason string) *CLIError {
+	return &CLIError{
+		Category:   CategoryUsage,
+		Message:    fmt.Sprintf("invalid repository name: %s", reason),
+		Suggestion: "repository names must be non-empty and follow GitHub naming rules",
+	}
+}
+
+// FailedToReadInput creates an error for input reading failures
+func FailedToReadInput(cause error) *CLIError {
+	return &CLIError{
+		Category:   CategoryRuntime,
+		Message:    "failed to read input",
+		Cause:      cause,
+		Suggestion: "check terminal is interactive and try again",
+	}
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -307,16 +307,18 @@ func MissingArgument(argName, expectedType string) *CLIError {
 		msg = fmt.Sprintf("missing required argument: %s (%s)", argName, expectedType)
 	}
 	return &CLIError{
-		Category: CategoryUsage,
-		Message:  msg,
+		Category:   CategoryUsage,
+		Message:    msg,
+		Suggestion: "multiclaude --help",
 	}
 }
 
 // InvalidArgument creates an error for invalid argument values
 func InvalidArgument(argName, value, expected string) *CLIError {
 	return &CLIError{
-		Category: CategoryUsage,
-		Message:  fmt.Sprintf("invalid value for '%s': got '%s', expected %s", argName, value, expected),
+		Category:   CategoryUsage,
+		Message:    fmt.Sprintf("invalid value for '%s': got '%s', expected %s", argName, value, expected),
+		Suggestion: "multiclaude --help",
 	}
 }
 
@@ -380,5 +382,50 @@ func WorkspaceNotFound(name, repo string) *CLIError {
 		Category:   CategoryNotFound,
 		Message:    fmt.Sprintf("workspace '%s' not found in repo '%s'", name, repo),
 		Suggestion: fmt.Sprintf("multiclaude workspace list --repo %s", repo),
+	}
+}
+
+// InvalidWorkspaceName creates an error for invalid workspace names
+func InvalidWorkspaceName(reason string) *CLIError {
+	return &CLIError{
+		Category:   CategoryUsage,
+		Message:    fmt.Sprintf("invalid workspace name: %s", reason),
+		Suggestion: "workspace names follow git branch naming rules (no spaces, '..' or special characters)",
+	}
+}
+
+// LogFileNotFound creates an error for when an agent's log file cannot be found
+func LogFileNotFound(agent, repo string) *CLIError {
+	return &CLIError{
+		Category:   CategoryNotFound,
+		Message:    fmt.Sprintf("no log file found for agent '%s' in repo '%s'", agent, repo),
+		Suggestion: fmt.Sprintf("check agent exists: multiclaude worker list --repo %s", repo),
+	}
+}
+
+// AgentNotInState creates an error for when an agent is not found in state
+func AgentNotInState(agent, repo string) *CLIError {
+	return &CLIError{
+		Category:   CategoryNotFound,
+		Message:    fmt.Sprintf("agent '%s' not found in state for repo '%s'", agent, repo),
+		Suggestion: "the agent may have been removed; try recreating it",
+	}
+}
+
+// NoSessionID creates an error for when an agent has no session ID
+func NoSessionID(agent string) *CLIError {
+	return &CLIError{
+		Category:   CategoryConfig,
+		Message:    fmt.Sprintf("agent '%s' has no session ID", agent),
+		Suggestion: "try removing and recreating the agent",
+	}
+}
+
+// InvalidDuration creates an error for invalid duration strings
+func InvalidDuration(value string) *CLIError {
+	return &CLIError{
+		Category:   CategoryUsage,
+		Message:    fmt.Sprintf("invalid duration: %s", value),
+		Suggestion: "use format like '7d', '24h', or '30m' (days, hours, minutes)",
 	}
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -577,3 +577,135 @@ func TestWorkspaceNotFound(t *testing.T) {
 		t.Errorf("expected workspace list suggestion, got: %s", formatted)
 	}
 }
+
+func TestInvalidWorkspaceName(t *testing.T) {
+	err := InvalidWorkspaceName("cannot contain spaces")
+
+	if err.Category != CategoryUsage {
+		t.Errorf("expected CategoryUsage, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "invalid workspace name") {
+		t.Errorf("expected 'invalid workspace name' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "cannot contain spaces") {
+		t.Errorf("expected reason in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "branch naming") {
+		t.Errorf("expected branch naming hint in suggestion, got: %s", formatted)
+	}
+}
+
+func TestLogFileNotFound(t *testing.T) {
+	err := LogFileNotFound("worker-1", "my-repo")
+
+	if err.Category != CategoryNotFound {
+		t.Errorf("expected CategoryNotFound, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "worker-1") {
+		t.Errorf("expected agent name in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "my-repo") {
+		t.Errorf("expected repo name in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "multiclaude worker list") {
+		t.Errorf("expected worker list suggestion, got: %s", formatted)
+	}
+}
+
+func TestAgentNotInState(t *testing.T) {
+	err := AgentNotInState("worker-1", "my-repo")
+
+	if err.Category != CategoryNotFound {
+		t.Errorf("expected CategoryNotFound, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "worker-1") {
+		t.Errorf("expected agent name in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "my-repo") {
+		t.Errorf("expected repo name in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "recreating") {
+		t.Errorf("expected recreating hint in suggestion, got: %s", formatted)
+	}
+}
+
+func TestNoSessionID(t *testing.T) {
+	err := NoSessionID("worker-1")
+
+	if err.Category != CategoryConfig {
+		t.Errorf("expected CategoryConfig, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "worker-1") {
+		t.Errorf("expected agent name in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "session ID") {
+		t.Errorf("expected 'session ID' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "recreating") {
+		t.Errorf("expected recreating hint in suggestion, got: %s", formatted)
+	}
+}
+
+func TestInvalidDuration(t *testing.T) {
+	err := InvalidDuration("abc")
+
+	if err.Category != CategoryUsage {
+		t.Errorf("expected CategoryUsage, got %v", err.Category)
+	}
+	if err.Suggestion == "" {
+		t.Error("should have a suggestion")
+	}
+
+	formatted := Format(err)
+	if !strings.Contains(formatted, "invalid duration") {
+		t.Errorf("expected 'invalid duration' in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "abc") {
+		t.Errorf("expected value in message, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "7d") {
+		t.Errorf("expected example format in suggestion, got: %s", formatted)
+	}
+}
+
+func TestMissingArgumentHasSuggestion(t *testing.T) {
+	err := MissingArgument("filename", "string")
+
+	if err.Suggestion == "" {
+		t.Error("MissingArgument should have a suggestion")
+	}
+	if !strings.Contains(err.Suggestion, "--help") {
+		t.Errorf("expected --help in suggestion, got: %s", err.Suggestion)
+	}
+}
+
+func TestInvalidArgumentHasSuggestion(t *testing.T) {
+	err := InvalidArgument("count", "abc", "integer")
+
+	if err.Suggestion == "" {
+		t.Error("InvalidArgument should have a suggestion")
+	}
+	if !strings.Contains(err.Suggestion, "--help") {
+		t.Errorf("expected --help in suggestion, got: %s", err.Suggestion)
+	}
+}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -20,6 +20,7 @@ const (
 	StatusWarning   Status = "warning"
 	StatusError     Status = "error"
 	StatusPending   Status = "pending"
+	StatusCrashed   Status = "crashed"
 )
 
 // Colors for different statuses
@@ -39,7 +40,7 @@ func StatusColor(status Status) *color.Color {
 		return Green
 	case StatusWarning, StatusIdle, StatusPending:
 		return Yellow
-	case StatusError:
+	case StatusError, StatusCrashed:
 		return Red
 	default:
 		return color.New()
@@ -59,6 +60,8 @@ func StatusIcon(status Status) string {
 		return "⚠"
 	case StatusError:
 		return "✗"
+	case StatusCrashed:
+		return "!"
 	case StatusPending:
 		return "◦"
 	default:

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -18,6 +18,7 @@ func TestStatusColor(t *testing.T) {
 		{StatusIdle, false},
 		{StatusPending, false},
 		{StatusError, false},
+		{StatusCrashed, false},
 		{Status("unknown"), false},
 	}
 
@@ -45,6 +46,7 @@ func TestStatusIcon(t *testing.T) {
 		{StatusIdle, "○"},
 		{StatusWarning, "⚠"},
 		{StatusError, "✗"},
+		{StatusCrashed, "!"},
 		{StatusPending, "◦"},
 		{Status("unknown"), "-"},
 	}

--- a/internal/prompts/commands/refresh.md
+++ b/internal/prompts/commands/refresh.md
@@ -4,34 +4,51 @@ Sync your worktree with the latest changes from the main branch.
 
 ## Instructions
 
-1. First, fetch the latest changes:
+1. First, determine the correct remote to use. Check if an upstream remote exists (indicates a fork):
    ```bash
+   git remote | grep -q upstream && echo "upstream" || echo "origin"
+   ```
+   Use `upstream` if it exists (fork mode), otherwise use `origin`.
+
+2. Fetch the latest changes from the appropriate remote:
+   ```bash
+   # For forks (upstream remote exists):
+   git fetch upstream main
+
+   # For non-forks (origin only):
    git fetch origin main
    ```
 
-2. Check if there are any uncommitted changes:
+3. Check if there are any uncommitted changes:
    ```bash
    git status --porcelain
    ```
 
-3. If there are uncommitted changes, stash them first:
+4. If there are uncommitted changes, stash them first:
    ```bash
    git stash push -m "refresh-stash-$(date +%s)"
    ```
 
-4. Rebase your current branch onto main:
+5. Rebase your current branch onto main from the correct remote:
    ```bash
+   # For forks (upstream remote exists):
+   git rebase upstream/main
+
+   # For non-forks (origin only):
    git rebase origin/main
    ```
 
-5. If you stashed changes, pop them:
+6. If you stashed changes, pop them:
    ```bash
    git stash pop
    ```
 
-6. Report the result to the user, including:
+7. Report the result to the user, including:
+   - Which remote was used (upstream or origin)
    - How many commits were rebased
    - Whether there were any conflicts
    - Current status after refresh
 
 If there are rebase conflicts, stop and let the user know which files have conflicts.
+
+**Note for forks:** When working in a fork, always rebase onto `upstream/main` (the original repo) to keep your work up to date with the latest upstream changes.

--- a/internal/prompts/merge-queue.md
+++ b/internal/prompts/merge-queue.md
@@ -292,18 +292,27 @@ Every merge you make locks in progress. Every passing PR you process is a ratche
 
 ## Keeping Local Refs in Sync
 
-After successfully merging a PR, always update the local main branch to stay in sync with origin:
+After successfully merging a PR, always update local refs AND sync other agent worktrees:
 
 ```bash
+# Update local main branch
 git fetch origin main:main
+
+# Sync all worker worktrees with main branch
+multiclaude refresh
 ```
 
 This is important because:
 - Workers branch off the local `main` ref when created
 - If local main is stale, new workers will start from old code
 - Stale refs cause unnecessary merge conflicts in future PRs
+- Other workers may be working on stale code and need to be rebased
 
-**Always run this command immediately after each successful merge.** This ensures the next worker created will start from the latest code.
+**Always run both commands immediately after each successful merge.** The `multiclaude refresh` command:
+- Fetches the latest main branch
+- Rebases all worker worktrees that are behind main
+- Sends notifications to affected agents
+- Handles conflicts gracefully (aborts rebase and notifies if conflicts occur)
 
 ## PR Rejection Handling
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -89,6 +89,8 @@ type Agent struct {
 	Task            string    `json:"task,omitempty"`             // Only for workers
 	Summary         string    `json:"summary,omitempty"`          // Brief summary of work done (workers only)
 	FailureReason   string    `json:"failure_reason,omitempty"`   // Why the task failed (workers only)
+	PRURL           string    `json:"pr_url,omitempty"`           // Pull request URL if created (workers only)
+	PRNumber        int       `json:"pr_number,omitempty"`        // PR number for quick lookup (workers only)
 	CreatedAt       time.Time `json:"created_at"`
 	LastNudge       time.Time `json:"last_nudge,omitempty"`
 	ReadyForCleanup bool      `json:"ready_for_cleanup,omitempty"` // Only for workers


### PR DESCRIPTION
## Summary
- Gemini + Claude deep analysis of the full `pr-triage-b2` diff (16 files, +2153/-127 lines)
- Identified 12 findings: 2 critical bugs, 3 high-severity redundancies, 7 medium/low improvements
- Report at `docs/PR_TRIAGE_B2_REVIEW.md` and `/tmp/swarm-b2-opportunities.md`

## Key Findings

**Critical:**
1. **Display bug**: Token warning `format.Dimmed(...)` returns string but never prints it
2. **Phantom skill**: Worker template references `sc:index-repo` which doesn't exist in multiclaude

**High:**
3. `ensureCoreAgents` duplicated across CLI (142 lines) and daemon (68 lines)
4. `ensureDefaultWorkspace` duplicated across CLI (107 lines) and daemon (141 lines)
5. Inconsistent prompt file writing patterns between layers

**Medium:**
6. Dead code remnants in systemStatus
7. Stale `CLI_RESTRUCTURE_PROPOSAL.md` (323 lines, already partially implemented)
8. `verify-docs.yml` references Go 1.25 (doesn't exist)

## Opportunities Not Implemented
- Extract shared `WorkspaceCreator` to eliminate CLI/daemon duplication
- `registerHiddenAlias()` helper to reduce boilerplate
- Daemon repair unit tests (currently only CLI-side tests exist)

## Test plan
- [x] Report reviewed for accuracy against actual diff
- [x] Bug findings verified by examining specific diff lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)