### PR TITLE
fix: replace --append-system-prompt-file with --append-system-prompt

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5551,7 +5551,10 @@ func (c *CLI) restartClaude(args []string) error {
 	// Add common flags
 	cmdArgs = append(cmdArgs, "--dangerously-skip-permissions")
 	if _, err := os.Stat(promptFile); err == nil {
-		cmdArgs = append(cmdArgs, "--append-system-prompt-file", promptFile)
+		promptContent, readErr := os.ReadFile(promptFile)
+		if readErr == nil {
+			cmdArgs = append(cmdArgs, "--append-system-prompt", string(promptContent))
+		}
 	}
 
 	// Exec claude
@@ -5874,7 +5877,7 @@ func (c *CLI) startClaudeInTmux(binaryPath, tmuxSession, tmuxWindow, workDir, se
 
 	// Add prompt file if provided
 	if promptFile != "" {
-		claudeCmd += fmt.Sprintf(" --append-system-prompt-file %s", promptFile)
+		claudeCmd += fmt.Sprintf(` --append-system-prompt "$(cat '%s')"`, promptFile)
 	}
 
 	// Send command to tmux window

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2060,7 +2060,7 @@ func (d *Daemon) startAgentWithConfig(repoName string, repo *state.Repository, c
 		}
 
 		// Build CLI command
-		claudeCmd := fmt.Sprintf("%s --session-id %s --dangerously-skip-permissions --append-system-prompt-file %s",
+		claudeCmd := fmt.Sprintf(`%s --session-id %s --dangerously-skip-permissions --append-system-prompt "$(cat '%s')"`,
 			binaryPath, sessionID, cfg.promptFile)
 
 		// Send command to tmux window

--- a/pkg/claude/README.md
+++ b/pkg/claude/README.md
@@ -205,7 +205,7 @@ The runner constructs Claude commands with these flags:
 | `--session-id <uuid>` | Unique session identifier |
 | `--resume <uuid>` | Resume existing session |
 | `--dangerously-skip-permissions` | Skip interactive permission prompts |
-| `--append-system-prompt-file <path>` | Path to system prompt file |
+| `--append-system-prompt <text>` | System prompt content (read from file via shell expansion) |
 
 ## Prompt Building
 

--- a/pkg/claude/doc.go
+++ b/pkg/claude/doc.go
@@ -3,7 +3,7 @@
 // This package abstracts the details of launching and interacting with Claude Code
 // instances running in terminal emulators. It handles:
 //
-//   - CLI flag construction (--session-id, --dangerously-skip-permissions, --append-system-prompt-file)
+//   - CLI flag construction (--session-id, --dangerously-skip-permissions, --append-system-prompt)
 //   - Session ID generation (UUID v4)
 //   - Startup timing quirks
 //   - Terminal integration via the [TerminalRunner] interface

--- a/pkg/claude/runner.go
+++ b/pkg/claude/runner.go
@@ -188,7 +188,7 @@ type Config struct {
 	WorkDir string
 
 	// SystemPromptFile is the path to a file containing the system prompt.
-	// This is passed via --append-system-prompt-file.
+	// The file contents are read and passed inline via --append-system-prompt.
 	SystemPromptFile string
 
 	// InitialMessage is an optional message to send to Claude after startup.
@@ -315,9 +315,9 @@ func (r *Runner) buildCommand(sessionID string, cfg Config) string {
 		cmd += " --dangerously-skip-permissions"
 	}
 
-	// Add system prompt file
+	// Add system prompt (read file contents via shell expansion)
 	if cfg.SystemPromptFile != "" {
-		cmd += fmt.Sprintf(" --append-system-prompt-file %s", cfg.SystemPromptFile)
+		cmd += fmt.Sprintf(` --append-system-prompt "$(cat '%s')"`, cfg.SystemPromptFile)
 	}
 
 	return cmd

--- a/pkg/claude/runner_test.go
+++ b/pkg/claude/runner_test.go
@@ -173,8 +173,8 @@ func TestStart(t *testing.T) {
 	if !strings.Contains(call.text, "--dangerously-skip-permissions") {
 		t.Errorf("expected command to contain --dangerously-skip-permissions, got %q", call.text)
 	}
-	if !strings.Contains(call.text, "--append-system-prompt-file /path/to/prompt.md") {
-		t.Errorf("expected command to contain prompt file, got %q", call.text)
+	if !strings.Contains(call.text, `--append-system-prompt "$(cat '/path/to/prompt.md')"`) {
+		t.Errorf("expected command to contain prompt via cat, got %q", call.text)
 	}
 }
 
@@ -491,7 +491,7 @@ func TestBuildCommand(t *testing.T) {
 				SystemPromptFile: "/path/to/prompt.md",
 			},
 			contains: []string{
-				"--append-system-prompt-file /path/to/prompt.md",
+				`--append-system-prompt "$(cat '/path/to/prompt.md')"`,
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

- **P0 FIX**: Claude CLI v2.1.63 does not support `--append-system-prompt-file`. All agent spawning was blocked.
- Changed all command construction sites to use `--append-system-prompt` with inline content instead.
- For tmux-based launches (runner.go, daemon.go, cli.go `startClaudeInTmux`): uses `$(cat 'file')` shell expansion so the prompt file is read at execution time.
- For `exec.Command`-based launch (cli.go `restartClaude`): reads the file in Go via `os.ReadFile` and passes content directly as an argument.
- Updated tests, doc.go, and README.md references.

## Files Changed

| File | Change |
|------|--------|
| `pkg/claude/runner.go` | `buildCommand()` uses `--append-system-prompt "$(cat '...')"` |
| `pkg/claude/runner_test.go` | Updated test expectations |
| `pkg/claude/doc.go` | Updated flag reference |
| `pkg/claude/README.md` | Updated CLI flags table |
| `internal/daemon/daemon.go` | Fixed direct command construction |
| `internal/cli/cli.go` | Fixed both `restartClaude` (exec.Command) and `startClaudeInTmux` |

## Opportunities (not implemented)

- `docs/AGENTS.md`, `docs/CRASH_RECOVERY.md`, `SPEC.md`, `ARCHITECTURE.md` still reference the old flag name in documentation/examples — these are doc-only, non-blocking.

## Test plan

- [x] `go test ./pkg/claude/...` — all 20 tests pass
- [x] `go test ./internal/...` — all internal tests pass
- [x] `go build ./...` — full build succeeds
- [x] No Go source files reference `--append-system-prompt-file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)